### PR TITLE
Release/4.1.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,5 @@
 	path = conventions-vclib/gradle-conventions-plugin
 	url = https://github.com/a-sit-plus/gradle-conventions-plugin.git	
 [submodule "kmp-crypto"]
-	path = kmp-crypto
-	url = https://github.com/a-sit-plus/kmp-crypto.git
+	path = signum
+	url = https://github.com/a-sit-plus/signum.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release 4.1.1 (Bugfix Release):
 * correctly configure and name JSON serializer:
   * `jsonSerializer` -> `vckJsonSerializer`
   * revert to explicit serializer configuration
+* rename kmp-crypto submodule to signum an update all references
+  * this changes the identifier in the version catalog!
 
 Release 4.1.0:
  * Rebrand

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Release 4.1.1 (Bugfix Release):
 * correctly configure and name JSON serializer:
   * `jsonSerializer` -> `vckJsonSerializer`
   * revert to explicit serializer configuration
+  * Introduce `jsonSerializer` and `cborSerilaizer` with deprecation annotation for easier migration in projects consuming VC-K
 * rename kmp-crypto submodule to signum an update all references
   * this changes the identifier in the version catalog!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+Release 4.1.1 (Bugfix Release):
+* correctly configure and name JSON serializer:
+  * `jsonSerializer` -> `vckJsonSerializer`
+  * revert to explicit serializer configuration
+
 Release 4.1.0:
  * Rebrand
    * Project name: _KMM VC Library_ -> VC-K

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Notable features for multiplatform are:
 
 Some parts for increased multiplatform support have been extracted into separate repositories:
  - Reimplementation of Kotlin's [Result](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/) called [KmmResult](https://github.com/a-sit-plus/kmmresult) for easy use from Swift code (since inline classes are [not supported](https://kotlinlang.org/docs/native-objc-interop.html#unsupported)).
- - Several crypto datatypes including an ASN.1 parser and encoder called [kmp-crypto](https://github.com/a-sit-plus/kmp-crypto).
+ - Several crypto datatypes including an ASN.1 parser and encoder called [Signum](https://github.com/a-sit-plus/signum).
 
 The main entry point for applications is an instance of `HolderAgent`, `VerifierAgent` or `IssuerAgent`, according to the nomenclature from the [W3C VC Data Model](https://w3c.github.io/vc-data-model/).
 

--- a/conventions-vclib/src/main/kotlin/VcLibConventions.kt
+++ b/conventions-vclib/src/main/kotlin/VcLibConventions.kt
@@ -11,16 +11,15 @@ import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-import org.jetbrains.kotlin.gradle.utils.named
 
 
-val Project.kmpCryptoVersionCatalog: VersionCatalog
-    get() = extensions.getByType<VersionCatalogsExtension>().named("kmpCrypto")
+val Project.signumVersionCatalog: VersionCatalog
+    get() = extensions.getByType<VersionCatalogsExtension>().named("signum")
 
 inline fun Project.commonApiDependencies(): List<String> {
-    project.AspVersions.versions["kmpcrypto"] = VcLibVersions.kmpcrypto
+    project.AspVersions.versions["signum"] = VcLibVersions.signum
     project.AspVersions.versions["jsonpath"] = VcLibVersions.jsonpath
-    project.AspVersions.versions["okio"] = kmpCryptoVersionCatalog.findVersion("okio").get().toString()
+    project.AspVersions.versions["okio"] = signumVersionCatalog.findVersion("okio").get().toString()
     project.AspVersions.versions["encoding"] = "2.2.1"
 
 
@@ -28,9 +27,9 @@ inline fun Project.commonApiDependencies(): List<String> {
         coroutines(),
         serialization("json"),
         serialization("cbor"),
-        addDependency("at.asitplus.signum:indispensable", "kmpcrypto"), //for iOS Export
-        addDependency("at.asitplus.signum:indispensable-cosef", "kmpcrypto"),
-        addDependency("at.asitplus.signum:indispensable-josef", "kmpcrypto"),
+        addDependency("at.asitplus.signum:indispensable", "signum"), //for iOS Export
+        addDependency("at.asitplus.signum:indispensable-cosef", "signum"),
+        addDependency("at.asitplus.signum:indispensable-josef", "signum"),
         addDependency("at.asitplus:jsonpath4k", "jsonpath"),
         datetime(),
         addDependency("com.squareup.okio:okio", "okio"),
@@ -56,11 +55,11 @@ inline fun KotlinDependencyHandler.commonImplementationDependencies() {
 
 fun Project.commonIosExports() = arrayOf(
     datetime(),
-    "com.ionspin.kotlin:bignum:${kmpCryptoVersionCatalog.findVersion("bignum").get()}",
+    "com.ionspin.kotlin:bignum:${signumVersionCatalog.findVersion("bignum").get()}",
     kmmresult(),
-    "at.asitplus.signum:indispensable:${VcLibVersions.kmpcrypto}",
-    "at.asitplus.signum:indispensable-cosef:${VcLibVersions.kmpcrypto}",
-    "at.asitplus.signum:indispensable-josef:${VcLibVersions.kmpcrypto}",
+    "at.asitplus.signum:indispensable:${VcLibVersions.signum}",
+    "at.asitplus.signum:indispensable-cosef:${VcLibVersions.signum}",
+    "at.asitplus.signum:indispensable-josef:${VcLibVersions.signum}",
     "at.asitplus:jsonpath4k:${VcLibVersions.jsonpath}",
     "io.matthewnelson.encoding:core:${AspVersions.versions["encoding"]}",
     "io.matthewnelson.encoding:base16:${AspVersions.versions["encoding"]}",

--- a/conventions-vclib/src/main/kotlin/VcLibVersions.kt
+++ b/conventions-vclib/src/main/kotlin/VcLibVersions.kt
@@ -9,7 +9,7 @@ object VcLibVersions {
     private fun versionOf(dependency: String) = versions[dependency] as String
 
     val uuid get() = versionOf("uuid")
-    val kmpcrypto get() = versionOf("kmpCrypto")
+    val signum get() = versionOf("signum")
     val jsonpath get() = versionOf("jsonpath")
     val eupidcredential get() = versionOf("eupid")
     val mdl get() = versionOf("mdl")

--- a/conventions-vclib/src/main/resources/vcLibVersions.properties
+++ b/conventions-vclib/src/main/resources/vcLibVersions.properties
@@ -1,4 +1,4 @@
-kmpCrypto=3.6.0
+signum=3.6.0
 uuid=0.8.1
 jsonpath=2.2.0
 jvm.json=20230618

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
-artifactVersion = 4.1.0
+artifactVersion = 4.1.1
 jdk.version=17
 
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,14 +12,14 @@ pluginManagement {
 }
 
 if (System.getProperty("publishing.excludeIncludedBuilds") != "true") {
-    includeBuild("kmp-crypto") {
+    includeBuild("signum") {
         dependencySubstitution {
             substitute(module("at.asitplus.signum:indispensable")).using(project(":indispensable"))
             substitute(module("at.asitplus.signum:indispensable-josef")).using(project(":indispensable-josef"))
             substitute(module("at.asitplus.signum:indispensable-cosef")).using(project(":indispensable-cosef"))
         }
     }
-} else logger.lifecycle("Excluding KMP Crypto from this build")
+} else logger.lifecycle("Excluding Signum from this build")
 
 rootProject.name = "vc-k"
 include(":vck")
@@ -40,8 +40,8 @@ dependencyResolutionManagement {
 
         fun versionOf(dependency: String) = versions[dependency] as String
 
-        create("kmpCrypto") {
-            from("at.asitplus.signum:indispensable-versionCatalog:${versionOf("kmpCrypto")}")
+        create("signum") {
+            from("at.asitplus.signum:indispensable-versionCatalog:${versionOf("signum")}")
         }
     }
 }

--- a/vck-aries/build.gradle.kts
+++ b/vck-aries/build.gradle.kts
@@ -34,12 +34,12 @@ kotlin {
 
         jvmMain {
             dependencies {
-                implementation(kmpCrypto.bcpkix.jdk18on)
+                implementation(signum.bcpkix.jdk18on)
             }
         }
         jvmTest {
             dependencies {
-                implementation(kmpCrypto.jose)
+                implementation(signum.jose)
                 implementation("org.json:json:${VcLibVersions.Jvm.json}")
             }
         }

--- a/vck-openid/build.gradle.kts
+++ b/vck-openid/build.gradle.kts
@@ -41,13 +41,13 @@ kotlin {
 
         jvmMain {
             dependencies {
-                implementation(kmpCrypto.bcpkix.jdk18on)
+                implementation(signum.bcpkix.jdk18on)
             }
         }
 
         jvmTest {
             dependencies {
-                implementation(kmpCrypto.jose)
+                implementation(signum.jose)
                 implementation("org.json:json:${VcLibVersions.Jvm.json}")
             }
         }

--- a/vck/build.gradle.kts
+++ b/vck/build.gradle.kts
@@ -34,12 +34,12 @@ kotlin {
 
         jvmMain {
             dependencies {
-                implementation(kmpCrypto.bcpkix.jdk18on)
+                implementation(signum.bcpkix.jdk18on)
             }
         }
         jvmTest {
             dependencies {
-                implementation(kmpCrypto.jose)
+                implementation(signum.jose)
                 implementation("org.json:json:${VcLibVersions.Jvm.json}")
                 implementation("com.authlete:cbor:${VcLibVersions.Jvm.`authlete-cbor`}")
             }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/CredentialToJsonConverter.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/CredentialToJsonConverter.kt
@@ -19,13 +19,13 @@ object CredentialToJsonConverter {
             is SubjectCredentialStore.StoreEntry.Vc -> {
                 buildJsonObject {
                     put("type", JsonPrimitive(credential.scheme.vcType))
-                    jsonSerializer.encodeToJsonElement(credential.vc.vc.credentialSubject).jsonObject.entries.forEach {
+                    vckJsonSerializer.encodeToJsonElement(credential.vc.vc.credentialSubject).jsonObject.entries.forEach {
                         put(it.key, it.value)
                     }
                     // TODO: Remove the rest here when there is a clear specification on how to encode vc credentials
                     //  This may actually depend on the presentation context, so more information may be required
                     put("vc", buildJsonArray {
-                        add(jsonSerializer.encodeToJsonElement(credential.vc.vc.credentialSubject))
+                        add(vckJsonSerializer.encodeToJsonElement(credential.vc.vc.credentialSubject))
                     })
                 }
             }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/Json.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/Json.kt
@@ -26,8 +26,12 @@ internal object JsonCredentialSerializer {
 
 }
 
-val jsonSerializer by lazy {
-    Json(from = at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer) {
+val vckJsonSerializer by lazy {
+    Json {
+        prettyPrint = false
+        encodeDefaults = false
+        classDiscriminator = "type"
+        ignoreUnknownKeys = true
         serializersModule = SerializersModule {
             polymorphic(CredentialSubject::class) {
                 subclass(AtomicAttribute2023::class)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/Json.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/Json.kt
@@ -26,6 +26,9 @@ internal object JsonCredentialSerializer {
 
 }
 
+@Deprecated("use vckJsonSerializer", replaceWith = ReplaceWith("vckJsonSerializer"))
+val jsonSerializer get() = vckJsonSerializer
+
 val vckJsonSerializer by lazy {
     Json {
         prettyPrint = false

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/KeyBindingJws.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/KeyBindingJws.kt
@@ -24,7 +24,7 @@ data class KeyBindingJws(
     val sdHash: ByteArray,
 ) {
 
-    fun serialize() = jsonSerializer.encodeToString(this)
+    fun serialize() = vckJsonSerializer.encodeToString(this)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -50,7 +50,7 @@ data class KeyBindingJws(
 
     companion object {
         fun deserialize(it: String) = kotlin.runCatching {
-            jsonSerializer.decodeFromString<KeyBindingJws>(it)
+            vckJsonSerializer.decodeFromString<KeyBindingJws>(it)
         }.wrap()
     }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/SelectiveDisclosureItem.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/SelectiveDisclosureItem.kt
@@ -21,7 +21,7 @@ data class SelectiveDisclosureItem(
     val claimValue: Any,
 ) {
 
-    fun serialize() = jsonSerializer.encodeToString(this)
+    fun serialize() = vckJsonSerializer.encodeToString(this)
 
     /**
      * Creates a disclosure, as described in section 5.2 of
@@ -60,7 +60,7 @@ data class SelectiveDisclosureItem(
 
     companion object {
         fun deserialize(it: String) = kotlin.runCatching {
-            jsonSerializer.decodeFromString<SelectiveDisclosureItem>(it)
+            vckJsonSerializer.decodeFromString<SelectiveDisclosureItem>(it)
         }.wrap()
 
         /**

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialJws.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialJws.kt
@@ -27,11 +27,11 @@ data class VerifiableCredentialJws(
     val jwtId: String
 ) {
 
-    fun serialize() = jsonSerializer.encodeToString(this)
+    fun serialize() = vckJsonSerializer.encodeToString(this)
 
     companion object {
         fun deserialize(it: String) = kotlin.runCatching {
-            jsonSerializer.decodeFromString<VerifiableCredentialJws>(it)
+            vckJsonSerializer.decodeFromString<VerifiableCredentialJws>(it)
         }.wrap()
     }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialSdJwt.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialSdJwt.kt
@@ -91,11 +91,11 @@ data class VerifiableCredentialSdJwt(
     val confirmationKey: JsonWebKey? = null,
 ) {
 
-    fun serialize() = jsonSerializer.encodeToString(this)
+    fun serialize() = vckJsonSerializer.encodeToString(this)
 
     companion object {
         fun deserialize(it: String) = kotlin.runCatching {
-            jsonSerializer.decodeFromString<VerifiableCredentialSdJwt>(it)
+            vckJsonSerializer.decodeFromString<VerifiableCredentialSdJwt>(it)
         }.wrap()
     }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiablePresentationJws.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiablePresentationJws.kt
@@ -22,11 +22,11 @@ data class VerifiablePresentationJws(
     val jwtId: String
 ) {
 
-    fun serialize() = jsonSerializer.encodeToString(this)
+    fun serialize() = vckJsonSerializer.encodeToString(this)
 
     companion object {
         fun deserialize(it: String) = kotlin.runCatching {
-            jsonSerializer.decodeFromString<VerifiablePresentationJws>(it)
+            vckJsonSerializer.decodeFromString<VerifiablePresentationJws>(it)
         }.wrap()
     }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/dif/PresentationDefinition.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/dif/PresentationDefinition.kt
@@ -1,7 +1,7 @@
 package at.asitplus.wallet.lib.data.dif
 
 import at.asitplus.KmmResult.Companion.wrap
-import at.asitplus.wallet.lib.data.jsonSerializer
+import at.asitplus.wallet.lib.data.vckJsonSerializer
 import com.benasher44.uuid.uuid4
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -31,11 +31,11 @@ data class PresentationDefinition(
         formats: FormatHolder
     ) : this(id = uuid4().toString(), inputDescriptors = inputDescriptors, formats = formats)
 
-    fun serialize() = jsonSerializer.encodeToString(this)
+    fun serialize() = vckJsonSerializer.encodeToString(this)
 
     companion object {
         fun deserialize(it: String) = kotlin.runCatching {
-            jsonSerializer.decodeFromString<PresentationDefinition>(it)
+            vckJsonSerializer.decodeFromString<PresentationDefinition>(it)
         }.wrap()
     }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/ServerRequest.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/ServerRequest.kt
@@ -1,7 +1,7 @@
 package at.asitplus.wallet.lib.iso
 
 import at.asitplus.KmmResult.Companion.wrap
-import at.asitplus.wallet.lib.data.jsonSerializer
+import at.asitplus.wallet.lib.data.vckJsonSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -19,7 +19,7 @@ data class ServerRequest(
     val docRequests: Array<ServerItemsRequest>,
 ) {
 
-    fun serialize() = jsonSerializer.encodeToString(this)
+    fun serialize() = vckJsonSerializer.encodeToString(this)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -39,7 +39,7 @@ data class ServerRequest(
 
     companion object {
         fun deserialize(it: String) = kotlin.runCatching {
-            jsonSerializer.decodeFromString<ServerRequest>(it)
+            vckJsonSerializer.decodeFromString<ServerRequest>(it)
         }.wrap()
     }
 }
@@ -72,7 +72,7 @@ data class ServerResponse(
     @SerialName("documentErrors")
     val documentErrors: Map<String, Int>? = null,
 ) {
-    fun serialize() = jsonSerializer.encodeToString(this)
+    fun serialize() = vckJsonSerializer.encodeToString(this)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -94,7 +94,7 @@ data class ServerResponse(
 
     companion object {
         fun deserialize(it: String) = kotlin.runCatching {
-            jsonSerializer.decodeFromString<ServerResponse>(it)
+            vckJsonSerializer.decodeFromString<ServerResponse>(it)
         }.wrap()
     }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/cborSerializer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/cborSerializer.kt
@@ -42,6 +42,9 @@ internal object CborCredentialSerializer {
         }
 }
 
+@Deprecated("use vckCborSerializer instead", replaceWith = ReplaceWith("vckCborSerializer"))
+val cborSerializer get() = vckCborSerializer
+
 @OptIn(ExperimentalSerializationApi::class)
 val vckCborSerializer by lazy {
     Cbor(from = at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer) {

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceTest.kt
@@ -11,7 +11,7 @@ import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.wallet.lib.agent.CryptoService
 import at.asitplus.wallet.lib.agent.DefaultCryptoService
 import at.asitplus.wallet.lib.agent.RandomKeyPairAdapter
-import at.asitplus.wallet.lib.data.jsonSerializer
+import at.asitplus.wallet.lib.data.vckJsonSerializer
 import com.benasher44.uuid.uuid4
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -57,7 +57,7 @@ class JwsServiceTest : FreeSpec({
     }
 
     "signed object can be verified" {
-        val stringPayload = jsonSerializer.encodeToString(randomPayload)
+        val stringPayload = vckJsonSerializer.encodeToString(randomPayload)
         val signed =
             jwsService.createSignedJwt(JwsContentTypeConstants.JWT, stringPayload.encodeToByteArray()).getOrThrow()
         signed.shouldNotBeNull()
@@ -107,7 +107,7 @@ class JwsServiceTest : FreeSpec({
     }
 
     "encrypted object can be decrypted" {
-        val stringPayload = jsonSerializer.encodeToString(randomPayload)
+        val stringPayload = vckJsonSerializer.encodeToString(randomPayload)
         val encrypted = jwsService.encryptJweObject(
             JwsContentTypeConstants.DIDCOMM_ENCRYPTED_JSON,
             stringPayload.encodeToByteArray(),

--- a/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceJvmTest.kt
+++ b/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceJvmTest.kt
@@ -7,7 +7,7 @@ import at.asitplus.signum.indispensable.josef.JweEncrypted
 import at.asitplus.signum.indispensable.josef.JweEncryption
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.wallet.lib.agent.DefaultCryptoService
-import at.asitplus.wallet.lib.data.jsonSerializer
+import at.asitplus.wallet.lib.data.vckJsonSerializer
 import com.benasher44.uuid.uuid4
 import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.JOSEObjectType
@@ -116,7 +116,7 @@ class JwsServiceJvmTest : FreeSpec({
             "$testIdentifier:" - {
 
                 "Signed object from int. library can be verified with int. library" {
-                    val stringPayload = jsonSerializer.encodeToString(randomPayload)
+                    val stringPayload = vckJsonSerializer.encodeToString(randomPayload)
                     val signed =
                         jwsService.createSignedJwt(JwsContentTypeConstants.JWT, stringPayload.encodeToByteArray())
                             .getOrThrow()
@@ -128,7 +128,7 @@ class JwsServiceJvmTest : FreeSpec({
                 }
 
                 "Signed object from ext. library can be verified with int. library" {
-                    val stringPayload = jsonSerializer.encodeToString(randomPayload)
+                    val stringPayload = vckJsonSerializer.encodeToString(randomPayload)
                     val libHeader = JWSHeader.Builder(JWSAlgorithm(algo.name))
                         .type(JOSEObjectType("JWT"))
                         .jwk(JWK.parse(cryptoService.keyPairAdapter.jsonWebKey.serialize()))
@@ -161,7 +161,7 @@ class JwsServiceJvmTest : FreeSpec({
                 }
 
                 "Signed object from int. library can be verified with ext. library" {
-                    val stringPayload = jsonSerializer.encodeToString(randomPayload)
+                    val stringPayload = vckJsonSerializer.encodeToString(randomPayload)
                     val signed =
                         jwsService.createSignedJwt(JwsContentTypeConstants.JWT, stringPayload.encodeToByteArray())
                             .getOrThrow()
@@ -180,7 +180,7 @@ class JwsServiceJvmTest : FreeSpec({
                  */
                 if (thisConfiguration.first == "EC") {
                     "Encrypted object from ext. library can be decrypted with int. library" {
-                        val stringPayload = jsonSerializer.encodeToString(randomPayload)
+                        val stringPayload = vckJsonSerializer.encodeToString(randomPayload)
                         val libJweHeader =
                             JWEHeader.Builder(JWEAlgorithm(jweAlgorithm.identifier), EncryptionMethod.A256GCM)
                                 .type(JOSEObjectType(JwsContentTypeConstants.DIDCOMM_ENCRYPTED_JSON))
@@ -200,7 +200,7 @@ class JwsServiceJvmTest : FreeSpec({
                     }
 
                     "Encrypted object from int. library can be decrypted with ext. library" {
-                        val stringPayload = jsonSerializer.encodeToString(randomPayload)
+                        val stringPayload = vckJsonSerializer.encodeToString(randomPayload)
                         val encrypted = jwsService.encryptJweObject(
                             JwsContentTypeConstants.DIDCOMM_ENCRYPTED_JSON,
                             stringPayload.encodeToByteArray(),


### PR DESCRIPTION
Release 4.1.1 (Bugfix Release):
* correctly configure and name JSON serializer:
  * `jsonSerializer` -> `vckJsonSerializer`
  * revert to explicit serializer configuration
  * Introduce `jsonSerializer` and `cborSerilaizer` with deprecation annotation for easier migration in projects consuming VC-K
* rename kmp-crypto submodule to signum an update all references
  * this changes the identifier in the version catalog!

