### PR TITLE
Add InputDescriptor.toRequestOptions

### DIFF
--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestOptions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestOptions.kt
@@ -121,6 +121,12 @@ data class RequestOptions(
 /**
  * Miscellaneous helper functions regarding [ConstraintField]
  */
+private fun Collection<ConstraintField>.toRequestedAttributes(): List<String> {
+    val regex = "[a-zA-Z0-9_-]+".toRegex()
+    val rawAttributes = this.map { constraint -> constraint.path.last().split("[").last() }
+    return rawAttributes.map { regex.find(it)?.value ?: "" }
+}
+
 private fun Collection<String>.createConstraints(
     credentialRepresentation: CredentialRepresentation,
     credentialScheme: ConstantIndex.CredentialScheme?,
@@ -233,4 +239,35 @@ private fun CredentialRepresentation.toFormat() = when (this) {
     PLAIN_JWT -> CredentialFormatEnum.JWT_VC
     SD_JWT -> CredentialFormatEnum.VC_SD_JWT
     ISO_MDOC -> CredentialFormatEnum.MSO_MDOC
+}
+
+/**
+ * Inverse operation of [RequestOptions.toInputDescriptor]
+ */
+
+fun InputDescriptor.toRequestOptions(): RequestOptions? {
+    val representationConstraints = mapOf(
+        "type" to PLAIN_JWT, "vct" to SD_JWT
+    )
+
+    val credentialScheme = AttributeIndex.resolveSchemaUri(this.schema.first().uri)
+    val requestedAttributes =
+        (this.constraints?.fields?.toRequestedAttributes() ?: emptyList()).toMutableSet()
+
+    val requestedScheme = representationConstraints.filterKeys { it in requestedAttributes }.values.toSet().apply {
+        if (this.size > 1) throw Exception("Invalid requirement in InputDescriptor: Cannot be two schemes at the same time")
+    }.firstOrNull() ?: ISO_MDOC // this assumes that ISO-MDOC is the only scheme which does not add a specific constraint
+
+    requestedAttributes.removeAll(representationConstraints.keys)
+
+    val isViableTypeConstraint = this.format?.toSetOfRepresentation()?.contains(requestedScheme)
+        ?: true //assume that if not specified everything is supported
+
+    return if (isViableTypeConstraint) {
+        RequestOptions(
+            credentialScheme = credentialScheme,
+            representation = requestedScheme,
+            requestedAttributes = requestedAttributes.toList()
+        )
+    } else null
 }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RequestOptionUnitTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RequestOptionUnitTest.kt
@@ -1,0 +1,38 @@
+package at.asitplus.wallet.lib.openid
+
+import at.asitplus.wallet.lib.data.ConstantIndex
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import kotlin.random.Random
+
+class RequestOptionUnitTest : FreeSpec({
+    val scheme = ConstantIndex.AtomicAttribute2023
+    val representations = listOf(
+        ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+        ConstantIndex.CredentialRepresentation.SD_JWT,
+        ConstantIndex.CredentialRepresentation.ISO_MDOC
+    )
+
+
+    representations.forEach { representation ->
+        "${representation.name}: RequestOptions -> InputDescriptor -> RequestOptions quasi equality" {
+            repeat(3) {
+                val reqOptions = RequestOptions(
+                    credentialScheme = scheme,
+                    representation = representation,
+                    requestedAttributes = scheme.claimNames.randomSubList()
+                )
+                val inputDescriptor = reqOptions.toInputDescriptor()
+                val reqOptionNew =
+                    inputDescriptor.toRequestOptions()
+                        ?: throw Exception("Couldn't create RequestOption inputDescriptor")
+                reqOptionNew.requestedAttributes shouldBe reqOptions.requestedAttributes
+                reqOptionNew.representation shouldBe reqOptions.representation
+                reqOptionNew.credentialScheme shouldBe reqOptions.credentialScheme
+            }
+        }
+    }
+})
+
+private fun <E> Collection<E>.randomSubList(): List<E> =
+    this.shuffled().subList(0, Random.Default.nextInt(0, this.size))

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/dif/FormatHolder.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/dif/FormatHolder.kt
@@ -31,4 +31,14 @@ data class FormatHolder(
     val ldpVc: FormatContainerLdp? = null,
     @SerialName("mso_mdoc")
     val msoMdoc: FormatContainerJwt? = null,
-)
+) {
+    /**
+     * Inverse operation to `ConstantIndex.CredentialRepresentation.toFormatHolder()`
+     */
+    fun toSetOfRepresentation(): Set<ConstantIndex.CredentialRepresentation> =
+        mutableSetOf<ConstantIndex.CredentialRepresentation>().apply {
+            if (jwt != null) add(ConstantIndex.CredentialRepresentation.PLAIN_JWT)
+            if (jwtSd != null) add(ConstantIndex.CredentialRepresentation.SD_JWT)
+            if (msoMdoc != null) add(ConstantIndex.CredentialRepresentation.ISO_MDOC)
+        }.toSet()
+}


### PR DESCRIPTION
Adds inverse operations to get back RequestOptions which were used to generate InputDescriptor.
This is useful if an incoming request needs to be manipulated.