### PR TITLE
Fix XCF export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 Release 5.1.0:
- - tbd
+ - Update JsonPath4K to 2.4.0
+ - Fix XCF export with transitive dependencies
 
 Release 5.0.0:
  - Remove `OidcSiopWallet.newDefaultInstance()` and replace it with a constructor

--- a/conventions-vclib/src/main/resources/vcLibVersions.properties
+++ b/conventions-vclib/src/main/resources/vcLibVersions.properties
@@ -1,7 +1,7 @@
 signum=3.9.0
 supreme=0.4.0
 uuid=0.8.1
-jsonpath=2.3.0
+jsonpath=2.4.0
 jvm.json=20230618
 jvm.cbor=1.18
 eupid=2.2.0

--- a/dif-data-classes/build.gradle.kts
+++ b/dif-data-classes/build.gradle.kts
@@ -32,7 +32,12 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(project.napier())
-                implementation(project.ktor("http"))
+                implementation(project.ktor("http")) {
+                    //will be upgraded anyways, just to remove it from XCF dependencies
+                    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+                }
+                //and here, we manually add it with the correct version
+                implementation(coroutines())
                 api("com.benasher44:uuid:${VcLibVersions.uuid}")
                 api("at.asitplus.signum:indispensable-cosef:${VcLibVersions.signum}")
                 api("at.asitplus.signum:indispensable-josef:${VcLibVersions.signum}")

--- a/openid-data-classes/build.gradle.kts
+++ b/openid-data-classes/build.gradle.kts
@@ -33,18 +33,10 @@ kotlin {
             dependencies {
                 api(project(":dif-data-classes"))
                 implementation(project.napier())
-                api(serialization("json"))
-                api(serialization("cbor"))
-                api(datetime())
-                api("com.ionspin.kotlin:bignum:${signumVersionCatalog.findVersion("bignum").get()}")
-                api(kmmresult())
                 api("at.asitplus.signum:indispensable:${VcLibVersions.signum}")
                 api("at.asitplus.signum:indispensable-cosef:${VcLibVersions.signum}")
                 api("at.asitplus.signum:indispensable-josef:${VcLibVersions.signum}")
                 api("at.asitplus:jsonpath4k:${VcLibVersions.jsonpath}")
-                api("io.matthewnelson.encoding:core:${AspVersions.versions["encoding"]}")
-                api("io.matthewnelson.encoding:base16:${AspVersions.versions["encoding"]}")
-                api("io.matthewnelson.encoding:base64:${AspVersions.versions["encoding"]}")
             }
         }
 

--- a/vck-aries/build.gradle.kts
+++ b/vck-aries/build.gradle.kts
@@ -56,7 +56,7 @@ kotlin {
 
 exportIosFramework(
     "VckAriesKmm",
-    transitiveExports = false,
+    transitiveExports = true,
     project(":vck")
 )
 

--- a/vck-openid/build.gradle.kts
+++ b/vck-openid/build.gradle.kts
@@ -65,7 +65,7 @@ kotlin {
 
 exportIosFramework(
     "VckOpenIdKmm",
-    transitiveExports = false,
+    transitiveExports = true,
     project(":vck")
 )
 

--- a/vck/build.gradle.kts
+++ b/vck/build.gradle.kts
@@ -70,9 +70,8 @@ setupAndroid()
 
 exportIosFramework(
     name = "VckKmm",
-    transitiveExports = false,
-    project(":dif-data-classes"),
-    "at.asitplus.signum:supreme:${VcLibVersions.supreme}"
+    transitiveExports = true,
+    project(":dif-data-classes")
 )
 
 val javadocJar = setupDokka(


### PR DESCRIPTION
Update to JsonPath4K 2.4.0 to be able to auto-export all transitive dependencies to an XCF that actually works.

Bottom line: bloats the XFC but cleans dependency declaration