### PR TITLE
SD-JWT: Refactor interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Release 5.1.0:
  - SD-JWT:
    - Pass around decoded data with `SdJwtSigned` in several result classes like `VerifyPresentationResult.SuccessSdJwt`
    - Rename `disclosures` to `reconstructed` in several result classes like `AuthnResponseResult.SuccessSdJwt`
+   - Correctly implement confirmation claim in `VerifiableCredentialSdJwt`, migrating from `JsonWebKey` to `ConfirmationClaim`
 
 Release 5.0.1:
  - Update JsonPath4K to 2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Release 5.1.0:
    - `WalletService` supports building multiple authorization details to request a token for more than one credential
    - Remove `buildAuthorizationDetails(RequestOptions)` for `WalletService`, please migrate to `buildScope(RequestOptions)`
    - Note that multiple `scope` values may be joined with a whitespace ` `
+ - SD-JWT:
+   - Pass around decoded data with `SdJwtSigned` in several result classes like `VerifyPresentationResult.SuccessSdJwt`
+   - Rename `disclosures` to `validatedItems` in several result classes like `AuthnResponseResult.SuccessSdJwt`
 
 Release 5.0.1:
  - Update JsonPath4K to 2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Release 5.1.0:
    - Note that multiple `scope` values may be joined with a whitespace ` `
  - SD-JWT:
    - Pass around decoded data with `SdJwtSigned` in several result classes like `VerifyPresentationResult.SuccessSdJwt`
-   - Rename `disclosures` to `validatedItems` in several result classes like `AuthnResponseResult.SuccessSdJwt`
+   - Rename `disclosures` to `reconstructed` in several result classes like `AuthnResponseResult.SuccessSdJwt`
 
 Release 5.0.1:
  - Update JsonPath4K to 2.4.0

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopVerifier.kt
@@ -504,6 +504,7 @@ class OidcSiopVerifier private constructor(
             val verifiableCredentialSdJwt: VerifiableCredentialSdJwt,
             @Deprecated("Renamed to verifiableCredentialSdJwt", replaceWith = ReplaceWith("verifiableCredentialSdJwt"))
             val sdJwt: VerifiableCredentialSdJwt,
+            val reconstructed: ReconstructedSdJwtClaims,
             val disclosures: Collection<SelectiveDisclosureItem>,
             val state: String?,
         ) : AuthnResponseResult()
@@ -694,6 +695,7 @@ class OidcSiopVerifier private constructor(
                 sdJwtSigned,
                 verifiableCredentialSdJwt,
                 sdJwt,
+                reconstructed,
                 disclosures,
                 state
             ).also { Napier.i("VP success: $this") }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopCombinedProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopCombinedProtocolTest.kt
@@ -242,17 +242,17 @@ class OidcSiopCombinedProtocolTest : FreeSpec({
         groupedResult.validationResults.size shouldBe 2
         groupedResult.validationResults.forEach { result ->
             result.shouldBeInstanceOf<OidcSiopVerifier.AuthnResponseResult.SuccessSdJwt>()
-            result.validatedItems.shouldNotBeEmpty()
+            result.reconstructed.claims.shouldNotBeEmpty()
             when (result.verifiableCredentialSdJwt.verifiableCredentialType) {
                 EuPidScheme.sdJwtType -> {
-                    result.validatedItems.firstOrNull { it.claimName == EuPidScheme.Attributes.FAMILY_NAME }
+                    result.reconstructed.claims.firstOrNull { it.claimName == EuPidScheme.Attributes.FAMILY_NAME }
                         .shouldNotBeNull()
-                    result.validatedItems.firstOrNull { it.claimName == EuPidScheme.Attributes.GIVEN_NAME }
+                    result.reconstructed.claims.firstOrNull { it.claimName == EuPidScheme.Attributes.GIVEN_NAME }
                         .shouldNotBeNull()
                 }
 
                 ConstantIndex.AtomicAttribute2023.sdJwtType -> {
-                    result.validatedItems.firstOrNull { it.claimName == CLAIM_DATE_OF_BIRTH }.shouldNotBeNull()
+                    result.reconstructed.claims.firstOrNull { it.claimName == CLAIM_DATE_OF_BIRTH }.shouldNotBeNull()
                 }
 
                 else -> {

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopCombinedProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopCombinedProtocolTest.kt
@@ -137,7 +137,7 @@ class OidcSiopCombinedProtocolTest : FreeSpec({
 
                 val result = verifierSiop.validateAuthnResponse(authnResponse.url)
                     .shouldBeInstanceOf<OidcSiopVerifier.AuthnResponseResult.SuccessSdJwt>()
-                result.sdJwt.type?.shouldContain(ConstantIndex.AtomicAttribute2023.vcType)
+                result.verifiableCredentialSdJwt.type?.shouldContain(ConstantIndex.AtomicAttribute2023.vcType)
             }
         }
 
@@ -242,21 +242,21 @@ class OidcSiopCombinedProtocolTest : FreeSpec({
         groupedResult.validationResults.size shouldBe 2
         groupedResult.validationResults.forEach { result ->
             result.shouldBeInstanceOf<OidcSiopVerifier.AuthnResponseResult.SuccessSdJwt>()
-            result.disclosures.shouldNotBeEmpty()
-            when (result.sdJwt.verifiableCredentialType) {
+            result.validatedItems.shouldNotBeEmpty()
+            when (result.verifiableCredentialSdJwt.verifiableCredentialType) {
                 EuPidScheme.sdJwtType -> {
-                    result.disclosures.firstOrNull { it.claimName == EuPidScheme.Attributes.FAMILY_NAME }
+                    result.validatedItems.firstOrNull { it.claimName == EuPidScheme.Attributes.FAMILY_NAME }
                         .shouldNotBeNull()
-                    result.disclosures.firstOrNull { it.claimName == EuPidScheme.Attributes.GIVEN_NAME }
+                    result.validatedItems.firstOrNull { it.claimName == EuPidScheme.Attributes.GIVEN_NAME }
                         .shouldNotBeNull()
                 }
 
                 ConstantIndex.AtomicAttribute2023.sdJwtType -> {
-                    result.disclosures.firstOrNull() { it.claimName == CLAIM_DATE_OF_BIRTH }.shouldNotBeNull()
+                    result.validatedItems.firstOrNull { it.claimName == CLAIM_DATE_OF_BIRTH }.shouldNotBeNull()
                 }
 
                 else -> {
-                    fail("Unexpected SD-JWT type: ${result.sdJwt.verifiableCredentialType}")
+                    fail("Unexpected SD-JWT type: ${result.verifiableCredentialSdJwt.verifiableCredentialType}")
                 }
             }
         }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopIsoProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopIsoProtocolTest.kt
@@ -7,6 +7,7 @@ import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN
 import at.asitplus.wallet.lib.data.IsoDocumentParsed
 import at.asitplus.wallet.lib.oidvci.formUrlEncode
 import at.asitplus.wallet.mdl.MobileDrivingLicenceDataElements
+import at.asitplus.wallet.mdl.MobileDrivingLicenceDataElements.FAMILY_NAME
 import at.asitplus.wallet.mdl.MobileDrivingLicenceScheme
 import com.benasher44.uuid.uuid4
 import io.kotest.core.spec.style.FreeSpec
@@ -112,7 +113,7 @@ class OidcSiopIsoProtocolTest : FreeSpec({
     }
 
     "Selective Disclosure with mDL" {
-        val requestedClaim = MobileDrivingLicenceDataElements.FAMILY_NAME
+        val requestedClaim = FAMILY_NAME
         verifierSiop = OidcSiopVerifier(
             keyMaterial = verifierKeyMaterial,
             clientIdScheme = OidcSiopVerifier.ClientIdScheme.RedirectUri(clientId),
@@ -132,14 +133,13 @@ class OidcSiopIsoProtocolTest : FreeSpec({
             holderSiop,
         )
 
-        document.validItems.shouldNotBeEmpty()
         document.validItems.shouldBeSingleton()
         document.validItems.shouldHaveSingleElement { it.elementIdentifier == requestedClaim }
         document.invalidItems.shouldBeEmpty()
     }
 
     "Selective Disclosure with mDL and encryption" {
-        val requestedClaim = MobileDrivingLicenceDataElements.FAMILY_NAME
+        val requestedClaim = FAMILY_NAME
         verifierSiop = OidcSiopVerifier(
             keyMaterial = verifierKeyMaterial,
             clientIdScheme = OidcSiopVerifier.ClientIdScheme.RedirectUri(clientId),
@@ -167,7 +167,6 @@ class OidcSiopIsoProtocolTest : FreeSpec({
 
         val document = result.documents.first()
 
-        document.validItems.shouldNotBeEmpty()
         document.validItems.shouldBeSingleton()
         document.validItems.shouldHaveSingleElement { it.elementIdentifier == requestedClaim }
         document.invalidItems.shouldBeEmpty()
@@ -186,16 +185,15 @@ class OidcSiopIsoProtocolTest : FreeSpec({
                     OidcSiopVerifier.RequestOptionsCredential(
                         MobileDrivingLicenceScheme,
                         ConstantIndex.CredentialRepresentation.ISO_MDOC,
-                        listOf(MobileDrivingLicenceDataElements.FAMILY_NAME)
+                        listOf(FAMILY_NAME)
                     )
                 )
             ),
             holderSiop,
         )
 
-        document.validItems.shouldNotBeEmpty()
         document.validItems.shouldBeSingleton()
-        document.validItems.shouldHaveSingleElement { it.elementIdentifier == MobileDrivingLicenceDataElements.FAMILY_NAME }
+        document.validItems.shouldHaveSingleElement { it.elementIdentifier == FAMILY_NAME }
         document.invalidItems.shouldBeEmpty()
     }
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopSdJwtProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopSdJwtProtocolTest.kt
@@ -79,10 +79,10 @@ class OidcSiopSdJwtProtocolTest : FreeSpec({
 
         val result = verifierSiop.validateAuthnResponse(authnResponse.url)
         result.shouldBeInstanceOf<OidcSiopVerifier.AuthnResponseResult.SuccessSdJwt>()
-        result.sdJwt.shouldNotBeNull()
-        result.disclosures.shouldNotBeEmpty()
-        result.disclosures.shouldBeSingleton()
-        result.disclosures.shouldHaveSingleElement { it.claimName == requestedClaim }
+        result.verifiableCredentialSdJwt.shouldNotBeNull()
+        result.validatedItems.shouldNotBeEmpty()
+        result.validatedItems.shouldBeSingleton()
+        result.validatedItems.shouldHaveSingleElement { it.claimName == requestedClaim }
     }
 
 })

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopSdJwtProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopSdJwtProtocolTest.kt
@@ -6,9 +6,7 @@ import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN
 import at.asitplus.wallet.lib.oidc.OidcSiopVerifier.RequestOptions
 import com.benasher44.uuid.uuid4
 import io.kotest.core.spec.style.FreeSpec
-import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.collections.shouldHaveSingleElement
-import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -80,9 +78,7 @@ class OidcSiopSdJwtProtocolTest : FreeSpec({
         val result = verifierSiop.validateAuthnResponse(authnResponse.url)
         result.shouldBeInstanceOf<OidcSiopVerifier.AuthnResponseResult.SuccessSdJwt>()
         result.verifiableCredentialSdJwt.shouldNotBeNull()
-        result.validatedItems.shouldNotBeEmpty()
-        result.validatedItems.shouldBeSingleton()
-        result.validatedItems.shouldHaveSingleElement { it.claimName == requestedClaim }
+        result.reconstructed.claims.shouldHaveSingleElement { it.claimName == requestedClaim }
     }
 
 })

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopX509SanDnsTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopX509SanDnsTest.kt
@@ -14,7 +14,7 @@ import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN
 import at.asitplus.wallet.lib.oidc.OidcSiopVerifier.RequestOptions
 import at.asitplus.wallet.lib.oidvci.formUrlEncode
 import io.kotest.core.spec.style.FreeSpec
-import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 class OidcSiopX509SanDnsTest : FreeSpec({
@@ -86,7 +86,7 @@ class OidcSiopX509SanDnsTest : FreeSpec({
 
         val result = verifierSiop.validateAuthnResponseFromPost(authnResponse.params.formUrlEncode())
         result.shouldBeInstanceOf<OidcSiopVerifier.AuthnResponseResult.SuccessSdJwt>()
-        result.validatedItems.shouldNotBeEmpty()
+        result.reconstructed.claims.shouldHaveSingleElement { it.claimName == CLAIM_GIVEN_NAME }
 
     }
 })

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopX509SanDnsTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopX509SanDnsTest.kt
@@ -86,7 +86,7 @@ class OidcSiopX509SanDnsTest : FreeSpec({
 
         val result = verifierSiop.validateAuthnResponseFromPost(authnResponse.params.formUrlEncode())
         result.shouldBeInstanceOf<OidcSiopVerifier.AuthnResponseResult.SuccessSdJwt>()
-        result.disclosures.shouldNotBeEmpty()
+        result.validatedItems.shouldNotBeEmpty()
 
     }
 })

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -85,7 +85,7 @@ class HolderAgent(
                 subjectCredentialStore.storeCredential(
                     sdJwt.verifiableCredentialSdJwt,
                     credential.vcSdJwt,
-                    sdJwt.sdJwtSigned.disclosures,
+                    sdJwt.disclosures,
                     credential.scheme,
                 ).toStoredCredential()
             }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -83,9 +83,9 @@ class HolderAgent(
                     throw VerificationError(sdJwt.toString())
                 }
                 subjectCredentialStore.storeCredential(
-                    sdJwt.sdJwt,
+                    sdJwt.verifiableCredentialSdJwt,
                     credential.vcSdJwt,
-                    sdJwt.disclosures,
+                    sdJwt.sdJwtSigned.disclosures,
                     credential.scheme,
                 ).toStoredCredential()
             }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
@@ -1,11 +1,7 @@
 package at.asitplus.wallet.lib.agent
 
 import at.asitplus.KmmResult
-import at.asitplus.wallet.lib.data.ConstantIndex
-import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
-import at.asitplus.wallet.lib.data.VerifiableCredential
-import at.asitplus.wallet.lib.data.VerifiableCredentialJws
-import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
+import at.asitplus.wallet.lib.data.*
 import at.asitplus.wallet.lib.iso.IssuerSigned
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -33,7 +29,7 @@ interface SubjectCredentialStore {
      * Passed credentials have been validated before.
      *
      * @param vc Instance of [VerifiableCredentialSdJwt]
-     * @param vcSerialized Serialized form of [VerifiableCredential]
+     * @param vcSerialized Serialized form of [at.asitplus.wallet.lib.jws.SdJwtSigned]
      */
     suspend fun storeCredential(
         vc: VerifiableCredentialSdJwt,
@@ -80,9 +76,7 @@ interface SubjectCredentialStore {
             val vcSerialized: String,
             @SerialName("sd-jwt")
             val sdJwt: VerifiableCredentialSdJwt,
-            /**
-             * Map of original serialized disclosure item to parsed item
-             */
+            /** Map of serialized disclosure item (as [String]) to parsed item (as [SelectiveDisclosureItem]) */
             @SerialName("disclosures")
             val disclosures: Map<String, SelectiveDisclosureItem?>,
             @SerialName("scheme")

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -142,8 +142,7 @@ class VerifiablePresentationFactory(
                 it.discloseItem(requestedRootAttributes)
             }.keys
         }
-        val issuerJwtPlusDisclosures =
-            SdJwtSigned.sdHashInput(validSdJwtCredential, filteredDisclosures)
+        val issuerJwtPlusDisclosures = SdJwtSigned.sdHashInput(validSdJwtCredential, filteredDisclosures)
         val keyBinding = createKeyBindingJws(audienceId, challenge, issuerJwtPlusDisclosures)
         val jwsFromIssuer = JwsSigned.deserialize(validSdJwtCredential.vcSerialized.substringBefore("~")).getOrElse {
             Napier.w("Could not re-create JWS from stored SD-JWT", it)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
@@ -5,6 +5,7 @@ import at.asitplus.signum.indispensable.josef.jwkId
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.wallet.lib.data.*
 import at.asitplus.wallet.lib.iso.IssuerSigned
+import at.asitplus.wallet.lib.jws.ReconstructedSdJwtClaims
 import at.asitplus.wallet.lib.jws.SdJwtSigned
 
 
@@ -47,6 +48,7 @@ interface Verifier {
             val verifiableCredentialSdJwt: VerifiableCredentialSdJwt,
             @Deprecated("Renamed to verifiableCredentialSdJwt", replaceWith = ReplaceWith("verifiableCredentialSdJwt"))
             val sdJwt: VerifiableCredentialSdJwt,
+            val reconstructed: ReconstructedSdJwtClaims,
             val disclosures: Collection<SelectiveDisclosureItem>,
             val isRevoked: Boolean
         ) : VerifyPresentationResult()
@@ -63,6 +65,7 @@ interface Verifier {
             val verifiableCredentialSdJwt: VerifiableCredentialSdJwt,
             @Deprecated("Renamed to verifiableCredentialSdJwt", replaceWith = ReplaceWith("verifiableCredentialSdJwt"))
             val sdJwt: VerifiableCredentialSdJwt,
+            val reconstructed: ReconstructedSdJwtClaims,
             /** Map of serialized disclosure item (as [String]) to parsed item (as [SelectiveDisclosureItem]) */
             val disclosures: Map<String, SelectiveDisclosureItem>,
             val isRevoked: Boolean,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
@@ -1,11 +1,11 @@
 package at.asitplus.wallet.lib.agent
 
 import at.asitplus.signum.indispensable.CryptoPublicKey
-import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.signum.indispensable.josef.jwkId
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.wallet.lib.data.*
 import at.asitplus.wallet.lib.iso.IssuerSigned
+import at.asitplus.wallet.lib.jws.SdJwtSigned
 
 
 /**
@@ -43,9 +43,11 @@ interface Verifier {
     sealed class VerifyPresentationResult {
         data class Success(val vp: VerifiablePresentationParsed) : VerifyPresentationResult()
         data class SuccessSdJwt(
-            val jwsSigned: JwsSigned,
+            val sdJwtSigned: SdJwtSigned,
+            val verifiableCredentialSdJwt: VerifiableCredentialSdJwt,
+            @Deprecated("Renamed to verifiableCredentialSdJwt", replaceWith = ReplaceWith("verifiableCredentialSdJwt"))
             val sdJwt: VerifiableCredentialSdJwt,
-            val disclosures: List<SelectiveDisclosureItem>,
+            val disclosures: Collection<SelectiveDisclosureItem>,
             val isRevoked: Boolean
         ) : VerifyPresentationResult()
 
@@ -57,16 +59,12 @@ interface Verifier {
     sealed class VerifyCredentialResult {
         data class SuccessJwt(val jws: VerifiableCredentialJws) : VerifyCredentialResult()
         data class SuccessSdJwt(
-            /**
-             * Extracted JWS from the input (containing also the disclosures)
-             */
-            val jwsSigned: JwsSigned,
+            val sdJwtSigned: SdJwtSigned,
+            val verifiableCredentialSdJwt: VerifiableCredentialSdJwt,
+            @Deprecated("Renamed to verifiableCredentialSdJwt", replaceWith = ReplaceWith("verifiableCredentialSdJwt"))
             val sdJwt: VerifiableCredentialSdJwt,
-            val keyBindingJws: JwsSigned?,
-            /**
-             * Map of original serialized disclosure item to parsed item
-             */
-            val disclosures: Map<String, SelectiveDisclosureItem?>,
+            /** Map of serialized disclosure item (as [String]) to parsed item (as [SelectiveDisclosureItem]) */
+            val disclosures: Map<String, SelectiveDisclosureItem>,
             val isRevoked: Boolean,
         ) : VerifyCredentialResult()
 
@@ -94,4 +92,4 @@ fun CryptoPublicKey.matchesIdentifier(input: String): Boolean {
     return false
 }
 
-class VerificationError(message: String?): Throwable(message)
+class VerificationError(message: String?) : Throwable(message)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/ReconstructedSdJwtClaims.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/ReconstructedSdJwtClaims.kt
@@ -1,0 +1,10 @@
+package at.asitplus.wallet.lib.jws
+
+import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
+
+/**
+ * Contains all claims that have been successfully reconstructed from an [SdJwtSigned]
+ */
+data class ReconstructedSdJwtClaims(
+    val claims: Collection<SelectiveDisclosureItem>
+)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/SdJwtSigned.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/SdJwtSigned.kt
@@ -1,17 +1,19 @@
 package at.asitplus.wallet.lib.jws
 
+import at.asitplus.KmmResult
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
 import at.asitplus.wallet.lib.data.KeyBindingJws
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
+import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import io.github.aakira.napier.Napier
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 
 /**
- * Representation of a signed SD-JWT (payload of [jws] is [at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt]),
- * as issued by an [at.asitplus.wallet.lib.agent.Issuer] or an [at.asitplus.wallet.lib.agent.Holder],
- * i.e. consisting of an JWS (with header, payload and signature)
+ * Representation of a signed SD-JWT,
+ * as issued by an [at.asitplus.wallet.lib.agent.Issuer] or presented by an [at.asitplus.wallet.lib.agent.Holder], i.e.
+ * consisting of an JWS (with header, payload is [at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt] and signature)
  * and several disclosures ([SelectiveDisclosureItem]) separated by a `~`,
  * possibly ending with a [keyBindingJws], that is a JWS with payload [KeyBindingJws].
  */
@@ -44,6 +46,8 @@ data class SdJwtSigned(
         return result
     }
 
+    fun getPayloadAsVerifiableCredentialSdJwt(): KmmResult<VerifiableCredentialSdJwt> =
+        VerifiableCredentialSdJwt.deserialize(jws.payload.decodeToString())
 
     companion object {
         fun parse(input: String): SdJwtSigned? {

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/SdJwtSigned.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/SdJwtSigned.kt
@@ -1,14 +1,12 @@
 package at.asitplus.wallet.lib.jws
 
 import at.asitplus.KmmResult
-import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
 import at.asitplus.wallet.lib.data.KeyBindingJws
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
 import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import io.github.aakira.napier.Napier
-import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 
 /**
  * Representation of a signed SD-JWT,
@@ -19,9 +17,8 @@ import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
  */
 data class SdJwtSigned(
     val jws: JwsSigned,
-    val disclosures: Map<String, SelectiveDisclosureItem>,
-    val keyBindingJws: JwsSigned? = null,
     val rawDisclosures: List<String>,
+    val keyBindingJws: JwsSigned? = null,
 ) {
 
     override fun equals(other: Any?): Boolean {
@@ -31,18 +28,16 @@ data class SdJwtSigned(
         other as SdJwtSigned
 
         if (jws != other.jws) return false
-        if (disclosures != other.disclosures) return false
-        if (keyBindingJws != other.keyBindingJws) return false
         if (rawDisclosures != other.rawDisclosures) return false
+        if (keyBindingJws != other.keyBindingJws) return false
 
         return true
     }
 
     override fun hashCode(): Int {
         var result = jws.hashCode()
-        result = 31 * result + disclosures.hashCode()
-        result = 31 * result + (keyBindingJws?.hashCode() ?: 0)
         result = 31 * result + rawDisclosures.hashCode()
+        result = 31 * result + (keyBindingJws?.hashCode() ?: 0)
         return result
     }
 
@@ -62,17 +57,9 @@ data class SdJwtSigned(
             val rawDisclosures = stringListWithoutJws
                 .filterNot { it.contains(".") }
                 .filterNot { it.isEmpty() }
-            val disclosures = stringListWithoutJws.take(rawDisclosures.count())
-                .associateWith {
-                    val decoded = it.decodeToByteArray(Base64UrlStrict).decodeToString()
-                    SelectiveDisclosureItem.deserialize(decoded).getOrElse { ex ->
-                        Napier.w("Could not parse SD Item: $it", ex)
-                        return null
-                    }
-                }
             val keyBindingString = stringList.drop(1 + rawDisclosures.size).firstOrNull()
             val keyBindingJws = keyBindingString?.let { JwsSigned.deserialize(it).getOrNull() }
-            return SdJwtSigned(jws, disclosures, keyBindingJws, rawDisclosures)
+            return SdJwtSigned(jws, rawDisclosures, keyBindingJws)
         }
 
         fun serializePresentation(

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
@@ -18,7 +18,8 @@ import at.asitplus.wallet.lib.jws.SdJwtSigned
 import com.benasher44.uuid.uuid4
 import io.github.aakira.napier.Napier
 import io.kotest.core.spec.style.FreeSpec
-import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -65,10 +66,12 @@ class AgentSdJwtTest : FreeSpec({
 
         val verified = verifier.verifyPresentation(vp.sdJwt, challenge)
             .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
-        verified.validatedItems shouldHaveSize 2
+        verified.reconstructed.claims shouldHaveSize 2
 
-        verified.validatedItems.first { it.claimName == CLAIM_GIVEN_NAME }.claimValue.content shouldBe "Susanne"
-        verified.validatedItems.first { it.claimName == CLAIM_DATE_OF_BIRTH }.claimValue.content shouldBe "1990-01-01"
+        verified.reconstructed.claims.first { it.claimName == CLAIM_GIVEN_NAME }
+            .claimValue.content shouldBe "Susanne"
+        verified.reconstructed.claims.first { it.claimName == CLAIM_DATE_OF_BIRTH }
+            .claimValue.content shouldBe "1990-01-01"
         verified.isRevoked shouldBe false
     }
 
@@ -84,8 +87,8 @@ class AgentSdJwtTest : FreeSpec({
         ).sdJwt
         val verified = verifier.verifyPresentation(sdJwt, challenge)
             .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
-        verified.validatedItems shouldHaveSize 1
-        verified.validatedItems.forAll { it.claimName shouldBe CLAIM_GIVEN_NAME }
+        verified.reconstructed.claims.shouldBeSingleton()
+        verified.reconstructed.claims.shouldHaveSingleElement { it.claimName == CLAIM_GIVEN_NAME }
         verified.isRevoked shouldBe false
     }
 

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
@@ -65,10 +65,10 @@ class AgentSdJwtTest : FreeSpec({
 
         val verified = verifier.verifyPresentation(vp.sdJwt, challenge)
             .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
-        verified.disclosures shouldHaveSize 2
+        verified.validatedItems shouldHaveSize 2
 
-        verified.disclosures.first { it.claimName == CLAIM_GIVEN_NAME }.claimValue.content shouldBe "Susanne"
-        verified.disclosures.first { it.claimName == CLAIM_DATE_OF_BIRTH }.claimValue.content shouldBe "1990-01-01"
+        verified.validatedItems.first { it.claimName == CLAIM_GIVEN_NAME }.claimValue.content shouldBe "Susanne"
+        verified.validatedItems.first { it.claimName == CLAIM_DATE_OF_BIRTH }.claimValue.content shouldBe "1990-01-01"
         verified.isRevoked shouldBe false
     }
 
@@ -84,8 +84,8 @@ class AgentSdJwtTest : FreeSpec({
         ).sdJwt
         val verified = verifier.verifyPresentation(sdJwt, challenge)
             .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
-        verified.disclosures shouldHaveSize 1
-        verified.disclosures.forAll { it.claimName shouldBe CLAIM_GIVEN_NAME }
+        verified.validatedItems shouldHaveSize 1
+        verified.validatedItems.forAll { it.claimName shouldBe CLAIM_GIVEN_NAME }
         verified.isRevoked shouldBe false
     }
 


### PR DESCRIPTION
Part 1 of a series of MR to handle complex SD-JWT, as discussed in #20, but without `kotlinx.serialization`.

This PR prepares the public API of this library to be able to handle complex SD-JWT structures.