### PR TITLE
SD-JWT: Create complex disclosures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Release 5.1.0:
    - Correctly implement confirmation claim in `VerifiableCredentialSdJwt`, migrating from `JsonWebKey` to `ConfirmationClaim`
    - Change type of `claimValue` in `SelectiveDisclosureItem` from `JsonPrimitive` to `JsonElement` to be able to process nested disclosures
    - Implement deserialization of complex objects, including array claims
+   - Add option to issue nested disclosures, by using `ClaimToBeIssued` recursively, see documentation there
 
 Release 5.0.1:
  - Update JsonPath4K to 2.4.0

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/LibraryInitializer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/LibraryInitializer.kt
@@ -101,11 +101,10 @@ object LibraryInitializer {
  * ```
  * when (it) {
  *     is DrivingPrivilege -> vckJsonSerializer.encodeToJsonElement(it)
- *     is LocalDate -> vckJsonSerializer.encodeToJsonElement(it)
- *     is UInt -> vckJsonSerializer.encodeToJsonElement(it)
  *     else -> null
  * }
  * ```
+ * Credential libraries need to implement only for custom types, as platform types are covered by this library.
  */
 typealias JsonValueEncoder
         = (value: Any) -> JsonElement?

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CredentialToBeIssued.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CredentialToBeIssued.kt
@@ -29,4 +29,5 @@ sealed class CredentialToBeIssued {
     ) : CredentialToBeIssued()
 }
 
+// TODO Add option to NOT make it selective disclosable?
 data class ClaimToBeIssued(val name: String, val value: Any)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CredentialToBeIssued.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CredentialToBeIssued.kt
@@ -29,5 +29,9 @@ sealed class CredentialToBeIssued {
     ) : CredentialToBeIssued()
 }
 
-// TODO Add option to NOT make it selective disclosable?
-data class ClaimToBeIssued(val name: String, val value: Any)
+/**
+ * Represents a claim that shall be issued to the holder,
+ * i.e. serialized into the appropriate credential format.
+ * To issue nested structures in SD-JWT, pass a Collection of [ClaimToBeIssued] in [value].
+ */
+data class ClaimToBeIssued(val name: String, val value: Any, val selectivelyDisclosable: Boolean = true)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CredentialToBeIssued.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CredentialToBeIssued.kt
@@ -33,5 +33,6 @@ sealed class CredentialToBeIssued {
  * Represents a claim that shall be issued to the holder,
  * i.e. serialized into the appropriate credential format.
  * To issue nested structures in SD-JWT, pass a Collection of [ClaimToBeIssued] in [value].
+ * For each claim, one can select if the claim shall be selectively disclosable, or otherwise included plain.
  */
 data class ClaimToBeIssued(val name: String, val value: Any, val selectivelyDisclosable: Boolean = true)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
@@ -5,7 +5,6 @@ import at.asitplus.catching
 import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.cosef.toCoseKey
 import at.asitplus.signum.indispensable.io.Base64Strict
-import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.io.BitSet
 import at.asitplus.signum.indispensable.josef.ConfirmationClaim
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
@@ -15,6 +14,7 @@ import at.asitplus.wallet.lib.ZlibService
 import at.asitplus.wallet.lib.cbor.CoseService
 import at.asitplus.wallet.lib.cbor.DefaultCoseService
 import at.asitplus.wallet.lib.data.*
+import at.asitplus.wallet.lib.data.CredentialToJsonConverter.toJsonElement
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem.Companion.hashDisclosure
 import at.asitplus.wallet.lib.data.VcDataModelConstants.REVOCATION_LIST_MIN_SIZE
 import at.asitplus.wallet.lib.iso.*
@@ -26,7 +26,6 @@ import io.github.aakira.napier.Napier
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import kotlinx.datetime.LocalDate
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.*
 import kotlin.random.Random
@@ -238,22 +237,6 @@ class IssuerAgent(
                 }
             } to disclosures
         }
-
-    // TODO Merge with function in [CredentialToJsonConverter] or [SelectiveDisclosureItem]?
-    private fun Any.toJsonElement(): JsonElement = when (this) {
-        is Boolean -> JsonPrimitive(this)
-        is Number -> JsonPrimitive(this)
-        is String -> JsonPrimitive(this)
-        is ByteArray -> JsonPrimitive(encodeToString(Base64UrlStrict))
-        is LocalDate -> JsonPrimitive(this.toString())
-        is UByte -> JsonPrimitive(this)
-        is UShort -> JsonPrimitive(this)
-        is UInt -> JsonPrimitive(this)
-        is ULong -> JsonPrimitive(this)
-        is Collection<*> -> JsonArray(mapNotNull { it?.toJsonElement() }.toList())
-        is JsonElement -> this
-        else -> JsonPrimitive(toString())
-    }
 
     private fun ClaimToBeIssued.toSdItem(claimValue: JsonObject) =
         SelectiveDisclosureItem(Random.nextBytes(32), name, claimValue)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SdJwtCreator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SdJwtCreator.kt
@@ -1,0 +1,67 @@
+package at.asitplus.wallet.lib.agent
+
+import at.asitplus.wallet.lib.data.CredentialToJsonConverter.toJsonElement
+import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
+import at.asitplus.wallet.lib.data.SelectiveDisclosureItem.Companion.hashDisclosure
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.addAll
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.putJsonArray
+import kotlin.random.Random
+
+/**
+ * See [Selective Disclosure for JWTs (SD-JWT)](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-13.html#name-simple-structured-sd-jwt)
+ */
+object SdJwtCreator {
+
+    /**
+     * Creates a JSON object to contain only digests for the selectively disclosable claims, and the plain values for
+     * other claims that are not selectively disclosable (see [ClaimToBeIssued.selectivelyDisclosable])
+     *
+     * @return The encoded JSON object and the disclosure strings
+     */
+    fun Collection<ClaimToBeIssued>.toSdJsonObject(): Pair<JsonObject, Collection<String>> =
+        mutableListOf<String>().let { disclosures ->
+            buildJsonObject {
+                with(partition { it.value is Collection<*> && it.value.first() is ClaimToBeIssued }) {
+                    val objectClaimDigests = first.mapNotNull { claim ->
+                        claim.value as Collection<*>
+                        (claim.value.filterIsInstance<ClaimToBeIssued>()).toSdJsonObject().let {
+                            if (claim.selectivelyDisclosable) {
+                                disclosures.addAll(it.second)
+                                put(claim.name, it.first)
+                                claim.toSdItem(it.first).toDisclosure()
+                                    .also { disclosures.add(it) }
+                                    .hashDisclosure()
+                            } else {
+                                disclosures.addAll(it.second)
+                                put(claim.name, it.first)
+                                null
+                            }
+                        }
+                    }
+                    val singleClaimsDigests = second.mapNotNull { claim ->
+                        if (claim.selectivelyDisclosable) {
+                            claim.toSdItem().toDisclosure()
+                                .also { disclosures.add(it) }
+                                .hashDisclosure()
+                        } else {
+                            put(claim.name, claim.value.toJsonElement())
+                            null
+                        }
+                    }
+                    (objectClaimDigests + singleClaimsDigests).let { digests ->
+                        if (digests.isNotEmpty())
+                            putJsonArray("_sd") { addAll(digests) }
+                    }
+                }
+            } to disclosures
+        }
+
+    private fun ClaimToBeIssued.toSdItem(claimValue: JsonObject) =
+        SelectiveDisclosureItem(Random.nextBytes(32), name, claimValue)
+
+    private fun ClaimToBeIssued.toSdItem() =
+        SelectiveDisclosureItem(Random.nextBytes(32), name, value)
+
+}

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -128,8 +128,6 @@ class VerifiablePresentationFactory(
         validSdJwtCredential: SubjectCredentialStore.StoreEntry.SdJwt,
         requestedClaims: Collection<NormalizedJsonPath>,
     ): Holder.CreatePresentationResult.SdJwt {
-        // TODO That's not entirely correct, as we would need to verify the nested digests too!
-        // e.g. "address.region" -> "address" needs to contain hash of "region" in the "_sd" array in claimValue
         val filteredDisclosures = requestedClaims
             .flatMap { it.segments }
             .filterIsInstance<NormalizedJsonPathSegment.NameSegment>()

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/CredentialToJsonConverter.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/CredentialToJsonConverter.kt
@@ -1,6 +1,6 @@
 package at.asitplus.wallet.lib.data
 
-import at.asitplus.signum.indispensable.io.Base64Strict
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.wallet.lib.agent.SdJwtValidator
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
 import at.asitplus.wallet.lib.jws.SdJwtSigned
@@ -61,13 +61,23 @@ object CredentialToJsonConverter {
         }
     }
 
-    // TODO Merge with that one function in [SelectiveDisclosureItem]?
-    private fun Any.toJsonElement(): JsonElement = when (this) {
+    /**
+     * Converts any value to a [JsonElement], to be used when serializing values into JSON structures.
+     */
+    fun Any.toJsonElement(): JsonElement = when (this) {
         is Boolean -> JsonPrimitive(this)
+        is Number -> JsonPrimitive(this)
         is String -> JsonPrimitive(this)
-        is ByteArray -> JsonPrimitive(encodeToString(Base64Strict))
+        is ByteArray -> JsonPrimitive(encodeToString(Base64UrlStrict))
         is LocalDate -> JsonPrimitive(this.toString())
-        is Array<*> -> buildJsonArray { filterNotNull().forEach { add(it.toJsonElement()) } }
-        else -> JsonCredentialSerializer.encode(this) ?: JsonNull
+        is UByte -> JsonPrimitive(this)
+        is UShort -> JsonPrimitive(this)
+        is UInt -> JsonPrimitive(this)
+        is ULong -> JsonPrimitive(this)
+        is Collection<*> -> JsonArray(mapNotNull { it?.toJsonElement() }.toList())
+        is Array<*> -> JsonArray(mapNotNull { it?.toJsonElement() }.toList())
+        is JsonElement -> this
+        else -> JsonCredentialSerializer.encode(this) ?: JsonPrimitive(toString())
     }
 }
+

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/CredentialToJsonConverter.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/CredentialToJsonConverter.kt
@@ -8,57 +8,55 @@ import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.json.*
 
+/**
+ * In OpenID4VP, the claims to be presented are described using a JSONPath, so compiling this to a JsonElement seems
+ * reasonable.
+ */
 object CredentialToJsonConverter {
-    // in openid4vp, the claims to be presented are described using a JSONPath, so compiling this to a JsonElement seems reasonable
-    fun toJsonElement(credential: SubjectCredentialStore.StoreEntry): JsonElement {
-        return when (credential) {
-            is SubjectCredentialStore.StoreEntry.Vc -> {
-                buildJsonObject {
-                    put("type", JsonPrimitive(credential.scheme.vcType))
-                    vckJsonSerializer.encodeToJsonElement(credential.vc.vc.credentialSubject).jsonObject.entries.forEach {
-                        put(it.key, it.value)
-                    }
-                    // TODO: Remove the rest here when there is a clear specification on how to encode vc credentials
-                    //  This may actually depend on the presentation context, so more information may be required
-                    put("vc", buildJsonArray {
-                        add(vckJsonSerializer.encodeToJsonElement(credential.vc.vc.credentialSubject))
-                    })
+
+    /**
+     * The result is used in [at.asitplus.wallet.lib.data.dif.InputEvaluator.evaluateConstraintFieldMatches]
+     */
+    fun toJsonElement(credential: SubjectCredentialStore.StoreEntry): JsonElement = when (credential) {
+        is SubjectCredentialStore.StoreEntry.Vc -> buildJsonObject {
+            put("type", JsonPrimitive(credential.scheme.vcType))
+            val vcAsJsonElement = vckJsonSerializer.encodeToJsonElement(credential.vc.vc.credentialSubject)
+            vcAsJsonElement.jsonObject.entries.forEach {
+                put(it.key, it.value)
+            }
+            // TODO: Remove the rest here when there is a clear specification on how to encode vc credentials
+            //  This may actually depend on the presentation context, so more information may be required
+            put("vc", buildJsonArray {
+                add(vcAsJsonElement)
+            })
+        }
+
+        is SubjectCredentialStore.StoreEntry.SdJwt -> {
+            val sdJwtSigned = SdJwtSigned.parse(credential.vcSerialized)
+            val payloadVc = sdJwtSigned?.getPayloadAsJsonObject()?.getOrNull()
+            val reconstructed = sdJwtSigned?.let { SdJwtValidator(it).reconstructedJsonObject }
+            val simpleDisclosureMap = credential.disclosures.map { entry ->
+                entry.value?.let { it.claimName to it.claimValue }
+            }.filterNotNull().toMap()
+
+            buildJsonObject {
+                put("vct", JsonPrimitive(credential.scheme.sdJwtType ?: credential.scheme.vcType))
+                payloadVc?.forEach { put(it.key, it.value) }
+                reconstructed?.forEach {
+                    put(it.key, it.value)
+                } ?: simpleDisclosureMap.forEach { pair ->
+                    pair.key?.let { put(it, pair.value) }
                 }
             }
+        }
 
-            is SubjectCredentialStore.StoreEntry.SdJwt -> {
-                val sdJwtSigned = SdJwtSigned.parse(credential.vcSerialized)
-                val payloadVc = sdJwtSigned?.getPayloadAsJsonObject()?.getOrNull()
-                val reconstructed = sdJwtSigned?.let { SdJwtValidator(it).reconstructedJsonObject }
-                val simpleDisclosureMap = credential.disclosures.map { entry ->
-                    entry.value?.let { it.claimName to it.claimValue }
-                }.filterNotNull().toMap()
-
-
-                buildJsonObject {
-                    put("vct", JsonPrimitive(credential.scheme.sdJwtType ?: credential.scheme.vcType))
-                    payloadVc?.forEach { put(it.key, it.value) }
-                    reconstructed?.forEach {
-                        put(it.key, it.value)
-                    } ?: simpleDisclosureMap.forEach { pair ->
-                        pair.key?.let { put(it, pair.value) }
+        is SubjectCredentialStore.StoreEntry.Iso -> buildJsonObject {
+            credential.issuerSigned.namespaces?.forEach {
+                put(it.key, buildJsonObject {
+                    it.value.entries.map { it.value }.forEach { value ->
+                        put(value.elementIdentifier, value.elementValue.toJsonElement())
                     }
-                }
-            }
-
-            is SubjectCredentialStore.StoreEntry.Iso -> {
-                buildJsonObject {
-                    credential.issuerSigned.namespaces?.forEach {
-                        put(it.key, buildJsonObject {
-                            it.value.entries.forEach { signedItem ->
-                                put(
-                                    signedItem.value.elementIdentifier,
-                                    signedItem.value.elementValue.toJsonElement()
-                                )
-                            }
-                        })
-                    }
-                }
+                })
             }
         }
     }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/SelectiveDisclosureItem.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/SelectiveDisclosureItem.kt
@@ -76,6 +76,7 @@ data class SelectiveDisclosureItem(
 
 }
 
+// TODO Merge with that one function in [CredentialToJsonConverter]?
 private fun Any.toJsonElement(): JsonElement = when (this) {
     is Boolean -> JsonPrimitive(this)
     is Number -> JsonPrimitive(this)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/SelectiveDisclosureItem.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/SelectiveDisclosureItem.kt
@@ -2,16 +2,14 @@ package at.asitplus.wallet.lib.data
 
 import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import at.asitplus.wallet.lib.data.CredentialToJsonConverter.toJsonElement
 import at.asitplus.wallet.lib.iso.sha256
 import at.asitplus.wallet.lib.jws.SelectiveDisclosureItemSerializer
 import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * Selective Disclosure item in SD-JWT format
@@ -74,20 +72,4 @@ data class SelectiveDisclosureItem(
         fun String.hashDisclosure() = encodeToByteArray().sha256().encodeToString(Base64UrlStrict)
     }
 
-}
-
-// TODO Merge with that one function in [CredentialToJsonConverter]?
-private fun Any.toJsonElement(): JsonElement = when (this) {
-    is Boolean -> JsonPrimitive(this)
-    is Number -> JsonPrimitive(this)
-    is String -> JsonPrimitive(this)
-    is ByteArray -> JsonPrimitive(encodeToString(Base64UrlStrict))
-    is LocalDate -> JsonPrimitive(this.toString())
-    is UByte -> JsonPrimitive(this)
-    is UShort -> JsonPrimitive(this)
-    is UInt -> JsonPrimitive(this)
-    is ULong -> JsonPrimitive(this)
-    is Collection<*> -> JsonArray(mapNotNull { it?.toJsonElement() }.toList())
-    is JsonElement -> this
-    else -> JsonPrimitive(toString())
 }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentComplexSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentComplexSdJwtTest.kt
@@ -1,0 +1,118 @@
+package at.asitplus.wallet.lib.agent
+
+import at.asitplus.KmmResult
+import at.asitplus.catching
+import at.asitplus.dif.Constraint
+import at.asitplus.dif.ConstraintField
+import at.asitplus.dif.DifInputDescriptor
+import at.asitplus.dif.PresentationDefinition
+import at.asitplus.signum.indispensable.CryptoPublicKey
+import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_FAMILY_NAME
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
+import com.benasher44.uuid.uuid4
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.datetime.Clock
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.time.Duration.Companion.minutes
+
+class AgentComplexSdJwtTest : FreeSpec({
+
+    lateinit var issuer: Issuer
+    lateinit var holder: Holder
+    lateinit var verifier: Verifier
+    lateinit var issuerCredentialStore: IssuerCredentialStore
+    lateinit var holderCredentialStore: SubjectCredentialStore
+    lateinit var holderKeyMaterial: KeyMaterial
+    lateinit var challenge: String
+
+    beforeEach {
+        issuerCredentialStore = InMemoryIssuerCredentialStore()
+        holderCredentialStore = InMemorySubjectCredentialStore()
+        issuer = IssuerAgent(EphemeralKeyWithoutCert(), issuerCredentialStore)
+        holderKeyMaterial = EphemeralKeyWithSelfSignedCert()
+        holder = HolderAgent(holderKeyMaterial, holderCredentialStore)
+        verifier = VerifierAgent()
+        challenge = uuid4().toString()
+    }
+
+    "simple walk-through success" {
+        holder.storeCredential(
+            issuer.issueCredential(
+                getCredential(holderKeyMaterial.publicKey, AtomicAttribute2023, SD_JWT).getOrThrow()
+            ).getOrThrow().toStoreCredentialInput()
+        )
+
+        val presentationParameters = holder.createPresentation(
+            challenge = challenge,
+            audienceId = verifier.keyMaterial.identifier,
+            presentationDefinition = buildPresentationDefinition(
+                "$['$CLAIM_GIVEN_NAME']",
+                "$['$CLAIM_FAMILY_NAME']",
+                "$['address']['region']",
+                "$.address.country",
+            )
+        ).getOrThrow()
+
+        val vp = presentationParameters.presentationResults.firstOrNull()
+            .shouldBeInstanceOf<Holder.CreatePresentationResult.SdJwt>()
+
+        val verified = verifier.verifyPresentation(vp.sdJwt, challenge)
+            .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
+
+        verified.reconstructedJsonObject[CLAIM_GIVEN_NAME]
+            ?.jsonPrimitive?.content shouldBe "Susanne"
+        verified.reconstructedJsonObject[CLAIM_FAMILY_NAME]
+            ?.jsonPrimitive?.content shouldBe "Meier"
+        verified.reconstructedJsonObject["address"]?.jsonObject?.get("region")
+            ?.jsonPrimitive?.content shouldBe "Vienna"
+        verified.reconstructedJsonObject["address"]?.jsonObject?.get("country")
+            ?.jsonPrimitive?.content shouldBe "AT"
+        verified.isRevoked shouldBe false
+    }
+
+})
+
+private fun getCredential(
+    subjectPublicKey: CryptoPublicKey,
+    credentialScheme: ConstantIndex.CredentialScheme,
+    representation: ConstantIndex.CredentialRepresentation,
+): KmmResult<CredentialToBeIssued> = catching {
+    val claims = listOf(
+        ClaimToBeIssued(CLAIM_GIVEN_NAME, "Susanne"),
+        ClaimToBeIssued(CLAIM_FAMILY_NAME, "Meier"),
+        ClaimToBeIssued(
+            "address", listOf(
+                ClaimToBeIssued("region", "Vienna"),
+                ClaimToBeIssued("country", "AT")
+            )
+        )
+    )
+    when (representation) {
+        ConstantIndex.CredentialRepresentation.SD_JWT -> CredentialToBeIssued.VcSd(
+            claims = claims,
+            expiration = Clock.System.now() + 1.minutes,
+            scheme = credentialScheme,
+            subjectPublicKey = subjectPublicKey,
+        )
+
+        else -> throw IllegalArgumentException(representation.toString())
+    }
+}
+
+private fun buildPresentationDefinition(vararg attributeName: String) = PresentationDefinition(
+    id = uuid4().toString(),
+    inputDescriptors = listOf(
+        DifInputDescriptor(
+            id = uuid4().toString(),
+            constraints = Constraint(
+                fields = attributeName.map { ConstraintField(path = listOf(it)) }
+            )
+        )
+    )
+)


### PR DESCRIPTION
Part 3 of a series of MR to handle complex SD-JWT structures.

This PR implements creating SD-JWT credentials with nested disclosures, although that's not needed by our current credential implementations.