### PR TITLE
SD-JWT: Parse EUDIW issued credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Release 5.1.0:
  - Replace `relyingPartyUrl` with `clientIdScheme` on `OidcSiopVerifier`s constructor, to clarify use of `client_id` in requests
  - Rename objects in `OpenIdConstants.ProofType`, `OpenIdConstants.CliendIdScheme` and `OpenIdConstants.ResponseMode`
  - In all OpenID data classes, serialize strings only, and parse them to crypto data classes (from signum) in a separate property (this increases interop, as we can deserialize unsupported algorithms too)
+ - Add `publicKeyLookup` function to `DefaultVerifierJwsService` to provide valid keys for JWS objects out-of-band (e.g. when they're not included in the header of the JWS)
  - OID4VCI:
    - `WalletService` supports building multiple authorization details to request a token for more than one credential
    - Remove `buildAuthorizationDetails(RequestOptions)` for `WalletService`, please migrate to `buildScope(RequestOptions)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Release 5.1.0:
    - Remove `buildAuthorizationDetails(RequestOptions)` for `WalletService`, please migrate to `buildScope(RequestOptions)`
    - Note that multiple `scope` values may be joined with a whitespace ` `
  - SD-JWT:
+   - Add implementation of JWT VC issuer metadata, see `JwtVcIssuerMetadata`
    - Pass around decoded data with `SdJwtSigned` in several result classes like `VerifyPresentationResult.SuccessSdJwt`
    - Rename `disclosures` to `reconstructedJsonObject` in several result classes like `AuthnResponseResult.SuccessSdJwt`
    - Correctly implement confirmation claim in `VerifiableCredentialSdJwt`, migrating from `JsonWebKey` to `ConfirmationClaim`

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/JwtVcIssuerMetadata.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/JwtVcIssuerMetadata.kt
@@ -1,0 +1,44 @@
+package at.asitplus.openid
+
+import at.asitplus.KmmResult
+import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.signum.indispensable.josef.JsonWebKeySet
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+
+/**
+ * Metadata about the credential issuer in
+ * [SD-JWT VC](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-05.html)
+ *
+ * To be serialized into JSON and made available at `/.well-known/jwt-vc-issuer` at the credential issuer.
+ */
+@Serializable
+data class JwtVcIssuerMetadata(
+    /**
+     * REQUIRED. The Issuer identifier, which MUST be identical to the `iss` value in the JWT.
+     */
+    @SerialName("issuer")
+    val issuer: String,
+
+    /**
+     * OPTIONAL. Issuer's JSON Web Key Set (RFC7517) document value, which contains the Issuer's public keys.
+     * The value of this field MUST be a JSON object containing a valid JWK Set.
+     */
+    @SerialName("jwks")
+    val jsonWebKeySet: JsonWebKeySet? = null,
+
+    /**
+     * OPTIONAL. URL string referencing the Issuer's JSON Web Key (JWK) Set (RFC7517) document which contains the
+     * Issuer's public keys. The value of this field MUST point to a valid JWK Set document.
+     */
+    @SerialName("jwks_uri")
+    val jsonWebKeySetUrl: String? = null,
+) {
+    fun serialize() = jsonSerializer.encodeToString(this)
+
+    companion object {
+        fun deserialize(input: String): KmmResult<JwtVcIssuerMetadata> =
+            runCatching { jsonSerializer.decodeFromString<JwtVcIssuerMetadata>(input) }.wrap()
+    }
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
@@ -37,6 +37,8 @@ object OpenIdConstants {
 
     const val PATH_WELL_KNOWN_OPENID_CONFIGURATION = "/.well-known/openid-configuration"
 
+    const val PATH_WELL_KNOWN_JWT_VC_ISSUER_METADATA = "/.well-known/jwt-vc-issuer"
+
     const val SCOPE_OPENID = "openid"
 
     const val SCOPE_PROFILE = "profile"

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialIssuer.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialIssuer.kt
@@ -11,6 +11,7 @@ import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.cosef.CborWebToken
 import at.asitplus.signum.indispensable.cosef.CoseSigned
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import at.asitplus.signum.indispensable.josef.JsonWebKeySet
 import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.signum.indispensable.pki.X509Certificate
@@ -59,6 +60,7 @@ class CredentialIssuer(
 ) {
     /**
      * Serve this result JSON-serialized under `/.well-known/openid-credential-issuer`
+     * (see [OpenIdConstants.PATH_WELL_KNOWN_CREDENTIAL_ISSUER])
      */
     val metadata: IssuerMetadata by lazy {
         IssuerMetadata(
@@ -70,6 +72,17 @@ class CredentialIssuer(
                 .flatMap { it.toSupportedCredentialFormat(issuer.cryptoAlgorithms).entries }
                 .associate { it.key to it.value },
             batchCredentialIssuance = BatchCredentialIssuanceMetadata(1)
+        )
+    }
+
+    /**
+     * Serve this result JSON-serialized under `/.well-known/jwt-vc-issuer`
+     * (see [OpenIdConstants.PATH_WELL_KNOWN_JWT_VC_ISSUER_METADATA])
+     */
+    val jwtVcMetadata: JwtVcIssuerMetadata by lazy {
+        JwtVcIssuerMetadata(
+            issuer = publicContext,
+            jsonWebKeySet = JsonWebKeySet(setOf(issuer.keyMaterial.jsonWebKey))
         )
     }
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtInteropTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtInteropTest.kt
@@ -1,0 +1,132 @@
+package at.asitplus.wallet.lib.agent
+
+import at.asitplus.signum.indispensable.josef.toJsonWebKey
+import at.asitplus.signum.indispensable.pki.X509Certificate
+import at.asitplus.wallet.eupid.EuPidScheme
+import at.asitplus.wallet.lib.data.vckJsonSerializer
+import at.asitplus.wallet.lib.jws.DefaultVerifierJwsService
+import at.asitplus.wallet.lib.jws.SdJwtSigned
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.matthewnelson.encoding.base64.Base64
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
+
+class AgentSdJwtInteropTest : FreeSpec({
+
+    lateinit var holder: Holder
+    lateinit var holderCredentialStore: SubjectCredentialStore
+    lateinit var holderKeyMaterial: KeyMaterial
+
+    beforeEach {
+        holderCredentialStore = InMemorySubjectCredentialStore()
+        holderKeyMaterial = EphemeralKeyWithSelfSignedCert()
+        val certificate = """
+            MIIBhTCCASugAwIBAgIUC2Xrc41w9o2CY+4lhyLQWueaKGAwCgYIKoZIzj0EAwIw
+            GDEWMBQGA1UEAwwNcGlkLXV0LWlzc3VlcjAeFw0yNDEwMjQxMTUxNDhaFw0yNDEx
+            MjMxMTUxNDhaMBgxFjAUBgNVBAMMDXBpZC11dC1pc3N1ZXIwWTATBgcqhkjOPQIB
+            BggqhkjOPQMBBwNCAARrAGINez4vmjXMRDiN1fBzlZy/VvSADnAoVeMrUpR6aNj9
+            ehraMttTPfGPb3uHPvTPJfigZ6lyFaybWhTreMxjo1MwUTAdBgNVHQ4EFgQUbZ3T
+            spfdJbLHnIeZOf7ECGjhR1swHwYDVR0jBBgwFoAUbZ3TspfdJbLHnIeZOf7ECGjh
+            R1swDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiAPjQ+C2gKZhxCS
+            rwFVp5Mm8Dv+L0n4c+X/iUH1HYuayQIhALynPbzWFaLZ5C/L085DdcdKwm2VVh79
+            vFasslXfxmLJ
+            """.trimIndent().replace("\n", "")
+        val publicKey = X509Certificate.decodeFromByteArray(certificate.decodeToByteArray(Base64()))!!.publicKey
+        holder = HolderAgent(
+            holderKeyMaterial,
+            holderCredentialStore,
+            validator = Validator(
+                verifierJwsService = DefaultVerifierJwsService(
+                    publicKeyLookup = { setOf(publicKey.toJsonWebKey()) }
+                ),
+            )
+        )
+    }
+
+    "accepts credential from EUDIW issuer" {
+        val input = """
+            eyJhbGciOiAiRVMyNTYiLCAidHlwIjogImV4YW1wbGUrc2Qtand0In0
+            .eyJpc3MiOiAiaHR0cHM6Ly8xOTIuMTY4LjkwLjE3Nzo1MDAwIiwgImp0aSI6ICIxYWEyNTczYy0yNWZiLTQzODctYmRiZC1iN2JhODQ4MzI
+            4ZTUiLCAiaWF0IjogMTczMDA3MDAwMCwgImV4cCI6IDE3Mzc4NDYwMDAsICJ2Y3QiOiAiZXUuZXVyb3BhLmVjLmV1ZGkucGlkLjEiLCAidmV
+            yaWZpZWRfY2xhaW1zIjogeyJ2ZXJpZmljYXRpb24iOiB7Il9zZCI6IFsiU1BKeDFvWGo4Nm8yTjd3RDhGdllGUHdia3A1UC0zYmFHcHIxWnh
+            uMmNpOCJdLCAidHJ1c3RfZnJhbWV3b3JrIjogImVpZGFzIiwgImFzc3VyYW5jZV9sZXZlbCI6ICJoaWdoIn0sICJjbGFpbXMiOiB7ImV1LmV
+            1cm9wYS5lYy5ldWRpLnBpZC4xIjogeyJfc2QiOiBbIjNLY2kxX09leVptdmkxY1RnS0I2OTdVYWpDVDFwRlNGRzQzdUt2WVktNGMiLCAiQWJ
+            iZkZwR0xfdHJob2tUaEx0UE41M0tvQTcwVDNpTE1OMVpmYk9pQV9YTSIsICJFNWNMNlRWMExfN1FZa25FYzQ0UVZnWkVDTnY1VTZCYThmcXc
+            wZTNIY1owIiwgIkdJTGg5YVhQZHBXQ2FJcjdsU0haVTB0bEFPVVF3RmdCOWllWlZrTHlOMjQiLCAiTUNMZndVdWxnaFpFOU42ZFVXdFg3dlh
+            NbWtZby1rSks1YmExODZ2el9LSSIsICJOejQySW9KXzh6VGJ4dTRpdE52cHlIU3hsOHV5eUxyaXpQMlNuQ3hKZXFBIiwgIlNLM0JWNWlDaXQ
+            2aVAtNjRiVS1Ib3VFQlV4Y0o1VkZjZ1hiS1luWlBla28iLCAiWktDSzJTT0NQSDF3ZGtzWktZckJudEZhTl8yZUVzUE82Tld5dFhDVXlWcyJ
+            dfX19LCAiX3NkX2FsZyI6ICJzaGEtMjU2IiwgImNuZiI6IHsiandrIjogeyJrdHkiOiAiRUMiLCAiY3J2IjogIlAtMjU2IiwgIngiOiAiVzJ
+            fWjRyRS1zT1ZvZkNab0tCdWk0QXQwcEsySGo3aVJKZk5JbkY5dVMtMCIsICJ5IjogInRjaHpodEJldi01djRkcDY4MU1Pam1XYWNCVlBrY1d
+            VMFBsVDBYWkRENTAifX19
+            .8RfeOFDzoe0RvlCrNWcJr5yJOQhaGJc6edtwOhRR3nN3OwMI5dWTQQFlT3RPfzxbUz14y4RQv48BtrFDtPN0dg
+            ~WyJ2TGdMZ19zUjZYb0d6M2swSkJ0cUNRIiwgImV2aWRlbmNlIiwgeyJ0eXBlIjogImV1LmV1cm9wYS5lYy5ldWRpLnBpZC4xIiwgInNvdXJ
+            jZSI6IHsib3JnYW5pemF0aW9uX25hbWUiOiAiVGVzdCBQSUQgaXNzdWVyIiwgIm9yZ2FuaXphdGlvbl9pZCI6ICJFVURJIFdhbGxldCBSZWZ
+            lcmVuY2UgSW1wbGVtZW50YXRpb24iLCAiY291bnRyeV9jb2RlIjogIkZDIn19XQ
+            ~WyJhUWxaN2I2bHJZVnA3Wk9INHUzY2VBIiwgImZhbWlseV9uYW1lIiwgImZhbWlseSJd
+            ~WyJBX2VjM1Y3Ym5WNjR1aU0zaE5VbU93IiwgImdpdmVuX25hbWUiLCAiR2l2ZW4iXQ
+            ~WyJRbXpmTjRidkl0ZUFFakFOWTdYeGRBIiwgImJpcnRoX2RhdGUiLCAiMjAyNC0xMC0wNCJd
+            ~WyJycnlUdV82WmduajRDcVVETEZ5U1J3IiwgImFnZV9vdmVyXzE4IiwgZmFsc2Vd
+            ~WyJaNi1weFRDR1I2ZEZ3QXVzMTBXeE1BIiwgImlzc3VhbmNlX2RhdGUiLCAiMjAyNC0xMC0yOCJd
+            ~WyJXOWl6eGJmZXVsZnFNb3NyRUo3VDFnIiwgImV4cGlyeV9kYXRlIiwgIjIwMjUtMDEtMjYiXQ
+            ~WyJPRDRZNXZQM05YMGI2VUV4ZEdpNDdRIiwgImlzc3VpbmdfYXV0aG9yaXR5IiwgIlRlc3QgUElEIGlzc3VlciJd
+            ~WyJZdHR0Z2lFb2dzXzlEaDFHZWtjNnVnIiwgImlzc3VpbmdfY291bnRyeSIsICJGQyJd
+            ~
+        """.trimIndent().replace("\n", "")
+
+        val stored = holder.storeCredential(
+            Holder.StoreCredentialInput.SdJwt(input, EuPidScheme)
+        ).getOrThrow()
+
+        stored.status shouldBe Validator.RevocationStatus.UNKNOWN
+        val entry = stored.storeEntry
+        entry.shouldBeInstanceOf<SubjectCredentialStore.StoreEntry.SdJwt>()
+        entry.disclosures.size shouldBe 9
+
+        val expectedJson = """
+            {
+                "iss": "https://192.168.90.177:5000",
+                "jti": "1aa2573c-25fb-4387-bdbd-b7ba848328e5",
+                "iat": 1730070000,
+                "exp": 1737846000,
+                "vct": "eu.europa.ec.eudi.pid.1",
+                "verified_claims": {
+                    "verification": {
+                        "evidence": {
+                            "type": "eu.europa.ec.eudi.pid.1",
+                            "source": {
+                                "organization_name": "Test PID issuer",
+                                "organization_id": "EUDI Wallet Reference Implementation",
+                                "country_code": "FC"
+                            }
+                        },
+                        "trust_framework": "eidas",
+                        "assurance_level": "high"
+                    },
+                    "claims": {
+                        "eu.europa.ec.eudi.pid.1": {
+                            "expiry_date": "2025-01-26",
+                            "family_name": "family",
+                            "age_over_18": false,
+                            "issuing_authority": "Test PID issuer",
+                            "issuance_date": "2024-10-28",
+                            "given_name": "Given",
+                            "birth_date": "2024-10-04",
+                            "issuing_country": "FC"
+                        }
+                    }
+                },
+                "cnf": {
+                    "jwk": {
+                        "kty": "EC",
+                        "crv": "P-256",
+                        "x": "W2_Z4rE-sOVofCZoKBui4At0pK2Hj7iRJfNInF9uS-0",
+                        "y": "tchzhtBev-5v4dp681MOjmWacBVPkcWU0PlT0XZDD50"
+                    }
+                }
+            }
+        """.trimIndent().let { vckJsonSerializer.parseToJsonElement(it) }
+        SdJwtValidator(SdJwtSigned.parse(entry.vcSerialized)!!).reconstructedJsonObject shouldBe expectedJson
+    }
+
+})

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopCombinedProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopCombinedProtocolTest.kt
@@ -12,7 +12,6 @@ import com.benasher44.uuid.uuid4
 import io.kotest.assertions.fail
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
-import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -137,7 +136,7 @@ class OidcSiopCombinedProtocolTest : FreeSpec({
 
                 val result = verifierSiop.validateAuthnResponse(authnResponse.url)
                     .shouldBeInstanceOf<OidcSiopVerifier.AuthnResponseResult.SuccessSdJwt>()
-                result.verifiableCredentialSdJwt.type?.shouldContain(ConstantIndex.AtomicAttribute2023.vcType)
+                result.verifiableCredentialSdJwt.verifiableCredentialType shouldBe ConstantIndex.AtomicAttribute2023.sdJwtType
             }
         }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -29,19 +29,17 @@ class HolderAgent(
     private val jwsService: JwsService,
     private val coseService: CoseService,
     override val keyPair: KeyMaterial,
-    private val verifiablePresentationFactory: VerifiablePresentationFactory = VerifiablePresentationFactory(
-        jwsService = jwsService,
-        coseService = coseService,
-        identifier = keyPair.identifier,
-    ),
+    private val verifiablePresentationFactory: VerifiablePresentationFactory =
+        VerifiablePresentationFactory(jwsService, coseService, keyPair.identifier),
     private val difInputEvaluator: InputEvaluator = InputEvaluator(),
 ) : Holder {
 
     constructor(
         keyMaterial: KeyMaterial,
-        subjectCredentialStore: SubjectCredentialStore = InMemorySubjectCredentialStore()
+        subjectCredentialStore: SubjectCredentialStore = InMemorySubjectCredentialStore(),
+        validator: Validator = Validator(),
     ) : this(
-        validator = Validator(),
+        validator = validator,
         subjectCredentialStore = subjectCredentialStore,
         jwsService = DefaultJwsService(DefaultCryptoService(keyMaterial)),
         coseService = DefaultCoseService(DefaultCryptoService(keyMaterial)),

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
@@ -52,6 +52,7 @@ class IssuerAgent(
     constructor(
         keyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
         issuerCredentialStore: IssuerCredentialStore = InMemoryIssuerCredentialStore(),
+        validator: Validator = Validator(),
     ) : this(
         validator = Validator(),
         issuerCredentialStore = issuerCredentialStore,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifierAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifierAgent.kt
@@ -20,12 +20,15 @@ class VerifierAgent private constructor(
     override val keyMaterial: KeyMaterial,
 ) : Verifier {
 
-    constructor(keyPairAdapter: KeyMaterial) : this(
-        validator = Validator(),
+    constructor(
+        keyPairAdapter: KeyMaterial,
+        validator: Validator = Validator()
+    ) : this(
+        validator = validator,
         keyMaterial = keyPairAdapter,
     )
 
-    constructor(): this(
+    constructor() : this(
         validator = Validator(),
         keyMaterial = EphemeralKeyWithoutCert(),
     )

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialSdJwt.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialSdJwt.kt
@@ -61,9 +61,6 @@ data class VerifiableCredentialSdJwt(
     @SerialName("_sd")
     val disclosureDigests: Collection<String>? = null,
 
-    @SerialName("type")
-    val type: Collection<String>? = null,
-
     /**
      * REQUIRED. This specification defines the JWT claim `vct` (for verifiable credential type).
      * The vct value MUST be a case-sensitive StringOrURI (see RFC7519) value serving as an identifier for the type

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialSdJwt.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialSdJwt.kt
@@ -12,7 +12,10 @@ import kotlinx.serialization.json.decodeFromJsonElement
 
 /**
  * SD-JWT representation of a [VerifiableCredential].
- * According to "SD-JWT-based Verifiable Credentials (SD-JWT VC), Draft 03"
+ * According to
+ * [SD-JWT-based Verifiable Credentials (SD-JWT VC), Draft 05](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-05.html)
+ * and
+ * [Selective Disclosure for JWTs (SD-JWT), Draft 13](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-13.html)
  */
 @Serializable
 data class VerifiableCredentialSdJwt(
@@ -77,6 +80,12 @@ data class VerifiableCredentialSdJwt(
     // TODO Implement correct draft: draft-ietf-oauth-status-list-05
     val credentialStatus: CredentialStatus? = null,
 
+    /**
+     * The claim `_sd_alg` indicates the hash algorithm used by the Issuer to generate the digests as described in
+     * Section 4.2. When used, this claim MUST appear at the top level of the SD-JWT payload. It MUST NOT be used in
+     * any object nested within the payload. If the `_sd_alg` claim is not present at the top level, a default value of
+     * `sha-256` MUST be used.
+     */
     @SerialName("_sd_alg")
     val selectiveDisclosureAlgorithm: String? = null,
 


### PR DESCRIPTION
Final part in a series of PR to improve SD-JWT interoperability.

Parse EUDIW issued credential and add option to verify the JWS when public key is not provided in the header.