### PR TITLE
COSE Signed API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Release 5.2.0:
  - SD-JWT: Validate confirmation claims correctly
- - Adapt to changes in `signum`, i.e. the classes `JwsSigned`, `JweDecrypted`, `CoseSigned` are now typed to their payload
+ - Adapt to changes in `signum`, i.e. the classes `JwsSigned`, `JweDecrypted`, `CoseSigned` are now typed to their payload, leading to changes in `CoseService` and `JwsService` to add overloads for typed payloads, as well as members in data classes containing e.g. `JwsSigned<*>`
  - ISO credentials: Serialize and deserialize device signed items correctly (i.e. considering the namespace of the element)
 
 Release 5.1.0:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Release 5.2.0:
  - SD-JWT: Validate confirmation claims correctly
- - Adapt to changes in `signum`, i.e. the classes `JwsSigned` and `JweDecrypted` are now typed to their payload
+ - Adapt to changes in `signum`, i.e. the classes `JwsSigned`, `JweDecrypted`, `CoseSigned` are now typed to their payload
  - ISO credentials: Serialize and deserialize device signed items correctly (i.e. considering the namespace of the element)
 
 Release 5.1.0:

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
@@ -4,8 +4,6 @@ import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.asn1.BitSet
-import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
-import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapperSerializer
 import at.asitplus.signum.indispensable.cosef.toCoseKey
 import at.asitplus.signum.indispensable.io.Base64Strict
 import at.asitplus.signum.indispensable.josef.ConfirmationClaim
@@ -114,8 +112,7 @@ class IssuerAgent(
         val issuerSigned = IssuerSigned.fromIssuerSignedItems(
             namespacedItems = mapOf(credential.scheme.isoNamespace!! to credential.issuerSignedItems),
             issuerAuth = coseService.createSignedCose(
-                payload = ByteStringWrapper(mso),
-                serializationStrategy = ByteStringWrapperSerializer(MobileSecurityObject.serializer()),
+                payload = mso,
                 addKeyId = false,
                 addCertificate = true,
             ).getOrThrow(),

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
@@ -4,6 +4,8 @@ import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.asn1.BitSet
+import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
+import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapperSerializer
 import at.asitplus.signum.indispensable.cosef.toCoseKey
 import at.asitplus.signum.indispensable.io.Base64Strict
 import at.asitplus.signum.indispensable.josef.ConfirmationClaim
@@ -112,7 +114,8 @@ class IssuerAgent(
         val issuerSigned = IssuerSigned.fromIssuerSignedItems(
             namespacedItems = mapOf(credential.scheme.isoNamespace!! to credential.issuerSignedItems),
             issuerAuth = coseService.createSignedCose(
-                payload = mso.serializeForIssuerAuth(),
+                payload = ByteStringWrapper(mso),
+                serializationStrategy = ByteStringWrapperSerializer(MobileSecurityObject.serializer()),
                 addKeyId = false,
                 addCertificate = true,
             ).getOrThrow(),

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Validator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Validator.kt
@@ -5,7 +5,6 @@ import at.asitplus.signum.indispensable.asn1.BitSet
 import at.asitplus.signum.indispensable.asn1.toBitSet
 import at.asitplus.signum.indispensable.cosef.CoseKey
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
-import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapperSerializer
 import at.asitplus.signum.indispensable.cosef.toCoseKey
 import at.asitplus.signum.indispensable.equalsCryptographically
 import at.asitplus.signum.indispensable.io.Base64Strict
@@ -294,12 +293,10 @@ class Validator(
                 .also { Napier.w("IssuerAuth not verified: $issuerAuth") }
         }
 
-        val mso: MobileSecurityObject? =
-            issuerSigned.issuerAuth.getTypedPayload(ByteStringWrapperSerializer(MobileSecurityObject.serializer()))
-                .onFailure {
-                    throw IllegalArgumentException("mso", it)
-                    Napier.w("MSO could not be decoded", it)
-                }.getOrNull()?.value
+        val mso: MobileSecurityObject? = issuerSigned.issuerAuth.getTypedPayload(MobileSecurityObject.serializer()).onFailure {
+                throw IllegalArgumentException("mso", it)
+                Napier.w("MSO could not be decoded", it)
+            }.getOrNull()?.value
         if (mso == null) {
             Napier.w("MSO is null: ${issuerAuth.payload?.encodeToString(Base16(strict = true))}")
             throw IllegalArgumentException("mso")

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -56,7 +56,8 @@ class VerifiablePresentationFactory(
         requestedClaims: Collection<NormalizedJsonPath>
     ): Holder.CreatePresentationResult.DeviceResponse {
         val deviceSignature = coseService.createSignedCose(
-            payload = challenge.encodeToByteArray(), addKeyId = false
+            payload = challenge.encodeToByteArray(),
+            addKeyId = false
         ).getOrElse {
             Napier.w("Could not create DeviceAuth for presentation", it)
             throw PresentationException(it)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/cbor/CoseService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/cbor/CoseService.kt
@@ -36,12 +36,12 @@ interface CoseService {
         payload: ByteArray? = null,
         addKeyId: Boolean = true,
         addCertificate: Boolean = false,
-    ): KmmResult<CoseSigned>
+    ): KmmResult<CoseSigned<ByteArray>>
 }
 
 interface VerifierCoseService {
 
-    fun verifyCose(coseSigned: CoseSigned, signer: CoseKey): KmmResult<Verifier.Success>
+    fun verifyCose(coseSigned: CoseSigned<ByteArray>, signer: CoseKey): KmmResult<Verifier.Success>
 
 }
 
@@ -55,7 +55,7 @@ class DefaultCoseService(private val cryptoService: CryptoService) : CoseService
         payload: ByteArray?,
         addKeyId: Boolean,
         addCertificate: Boolean,
-    ): KmmResult<CoseSigned> = catching {
+    ): KmmResult<CoseSigned<ByteArray>> = catching {
         var copyProtectedHeader = protectedHeader?.copy(algorithm = algorithm)
             ?: CoseHeader(algorithm = algorithm)
         if (addKeyId) {
@@ -94,7 +94,7 @@ class DefaultVerifierCoseService(
     /**
      * Verifiers the signature of [coseSigned] by using [signer].
      */
-    override fun verifyCose(coseSigned: CoseSigned, signer: CoseKey) = catching {
+    override fun verifyCose(coseSigned: CoseSigned<ByteArray>, signer: CoseKey) = catching {
         val signatureInput = CoseSigned.prepareCoseSignatureInput(coseSigned.protectedHeader.value, coseSigned.payload)
 
         val algorithm = coseSigned.protectedHeader.value.algorithm

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/cbor/CoseService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/cbor/CoseService.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.cbor
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
+import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.cosef.*
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
@@ -132,7 +133,7 @@ class DefaultCoseService(private val cryptoService: CryptoService) : CoseService
         }
         val signatureInput = CoseSigned.prepareCoseSignatureInput(copyProtectedHeader, rawPayload)
 
-        val signature = cryptoService.sign(signatureInput).asKmmResult().getOrElse {
+        val signature: CryptoSignature.RawByteEncodable = cryptoService.sign(signatureInput).asKmmResult().getOrElse {
             Napier.w("No signature from native code", it)
             throw it
         }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/cbor/CoseService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/cbor/CoseService.kt
@@ -78,6 +78,16 @@ class DefaultCoseService(private val cryptoService: CryptoService) : CoseService
         }
     }
 
+    /**
+     * + [ByteArray] is processed as it is
+     * + [ByteStringWrapper] is wrapped in Tag(24)
+     * + [MobileSecurityObject] is wrapped as [ByteStringWrapper] and wrapped in Tag(24)
+     * + null is processed as it is
+     *
+     * If other complex data classes need to be serialized other than [MobileSecurityObject]
+     * extend in the same fashion
+     */
+    @Throws(NotImplementedError::class)
     private fun <P : Any?> P.asCosePayload(): ByteArray? = when (this) {
         is ByteArray -> this
         is ByteStringWrapper<*> -> vckCborSerializer.encodeToByteArray(this).wrapInCborTag(24)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/DeviceAuth.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/DeviceAuth.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class DeviceAuth(
     @SerialName("deviceSignature")
-    val deviceSignature: CoseSigned? = null,
+    val deviceSignature: CoseSigned<ByteArray>? = null,
     @SerialName("deviceMac")
-    val deviceMac: CoseSigned? = null, // TODO is COSE_Mac0
+    val deviceMac: CoseSigned<ByteArray>? = null, // TODO is COSE_Mac0
 )

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/DeviceSigned.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/DeviceSigned.kt
@@ -69,7 +69,7 @@ data class DeviceSigned(
          */
         fun fromDeviceSignedItems(
             namespacedItems: Map<String, List<DeviceSignedItem>>,
-            deviceAuth: CoseSigned,
+            deviceAuth: CoseSigned<ByteArray>,
         ): DeviceSigned = DeviceSigned(
             namespaces = ByteStringWrapper(DeviceNameSpaces( namespacedItems.map { (namespace, value) ->
                 namespace to DeviceSignedItemList(value)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/DocRequest.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/DocRequest.kt
@@ -16,7 +16,7 @@ data class DocRequest(
     @ValueTags(24U)
     val itemsRequest: ByteStringWrapper<ItemsRequest>,
     @SerialName("readerAuth")
-    val readerAuth: CoseSigned? = null,
+    val readerAuth: CoseSigned<ByteArray>? = null,
 ) {
     override fun toString(): String {
         return "DocRequest(itemsRequest=${itemsRequest.value}, readerAuth=$readerAuth)"

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/IssuerSigned.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/IssuerSigned.kt
@@ -1,7 +1,6 @@
 package at.asitplus.wallet.lib.iso
 
 import at.asitplus.KmmResult.Companion.wrap
-import at.asitplus.catching
 import at.asitplus.signum.indispensable.cosef.CoseSigned
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import kotlinx.serialization.*
@@ -17,9 +16,6 @@ data class IssuerSigned private constructor(
     @SerialName("issuerAuth")
     val issuerAuth: CoseSigned<ByteStringWrapper<MobileSecurityObject>>,
 ) {
-    fun getIssuerAuthPayloadAsMso() = catching {
-        MobileSecurityObject.deserializeFromIssuerAuth(issuerAuth.payload!!).getOrThrow()
-    }
 
     fun serialize() = vckCborSerializer.encodeToByteArray(this)
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/IssuerSigned.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/IssuerSigned.kt
@@ -2,7 +2,6 @@ package at.asitplus.wallet.lib.iso
 
 import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.signum.indispensable.cosef.CoseSigned
-import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import kotlinx.serialization.*
 
 /**
@@ -14,7 +13,7 @@ data class IssuerSigned private constructor(
     @Serializable(with = NamespacedIssuerSignedListSerializer::class)
     val namespaces: Map<String, @Contextual IssuerSignedList>? = null,
     @SerialName("issuerAuth")
-    val issuerAuth: CoseSigned<ByteStringWrapper<MobileSecurityObject>>,
+    val issuerAuth: CoseSigned<MobileSecurityObject>,
 ) {
 
     fun serialize() = vckCborSerializer.encodeToByteArray(this)
@@ -55,7 +54,7 @@ data class IssuerSigned private constructor(
          */
         fun fromIssuerSignedItems(
             namespacedItems: Map<String, List<IssuerSignedItem>>,
-            issuerAuth: CoseSigned<ByteStringWrapper<MobileSecurityObject>>,
+            issuerAuth: CoseSigned<MobileSecurityObject>,
         ): IssuerSigned = IssuerSigned(
             namespaces = namespacedItems.map { (namespace, value) ->
                 namespace to IssuerSignedList.fromIssuerSignedItems(value, namespace)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/IssuerSigned.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/IssuerSigned.kt
@@ -14,7 +14,7 @@ data class IssuerSigned private constructor(
     @Serializable(with = NamespacedIssuerSignedListSerializer::class)
     val namespaces: Map<String, @Contextual IssuerSignedList>? = null,
     @SerialName("issuerAuth")
-    val issuerAuth: CoseSigned,
+    val issuerAuth: CoseSigned<ByteArray>,
 ) {
     fun getIssuerAuthPayloadAsMso() = catching {
         MobileSecurityObject.deserializeFromIssuerAuth(issuerAuth.payload!!).getOrThrow()
@@ -58,7 +58,7 @@ data class IssuerSigned private constructor(
          */
         fun fromIssuerSignedItems(
             namespacedItems: Map<String, List<IssuerSignedItem>>,
-            issuerAuth: CoseSigned,
+            issuerAuth: CoseSigned<ByteArray>,
         ): IssuerSigned = IssuerSigned(
             namespaces = namespacedItems.map { (namespace, value) ->
                 namespace to IssuerSignedList.fromIssuerSignedItems(value, namespace)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/IssuerSigned.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/IssuerSigned.kt
@@ -3,6 +3,7 @@ package at.asitplus.wallet.lib.iso
 import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.catching
 import at.asitplus.signum.indispensable.cosef.CoseSigned
+import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import kotlinx.serialization.*
 
 /**
@@ -14,7 +15,7 @@ data class IssuerSigned private constructor(
     @Serializable(with = NamespacedIssuerSignedListSerializer::class)
     val namespaces: Map<String, @Contextual IssuerSignedList>? = null,
     @SerialName("issuerAuth")
-    val issuerAuth: CoseSigned<ByteArray>,
+    val issuerAuth: CoseSigned<ByteStringWrapper<MobileSecurityObject>>,
 ) {
     fun getIssuerAuthPayloadAsMso() = catching {
         MobileSecurityObject.deserializeFromIssuerAuth(issuerAuth.payload!!).getOrThrow()
@@ -58,7 +59,7 @@ data class IssuerSigned private constructor(
          */
         fun fromIssuerSignedItems(
             namespacedItems: Map<String, List<IssuerSignedItem>>,
-            issuerAuth: CoseSigned<ByteArray>,
+            issuerAuth: CoseSigned<ByteStringWrapper<MobileSecurityObject>>,
         ): IssuerSigned = IssuerSigned(
             namespaces = namespacedItems.map { (namespace, value) ->
                 namespace to IssuerSignedList.fromIssuerSignedItems(value, namespace)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/MobileSecurityObject.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/MobileSecurityObject.kt
@@ -3,7 +3,11 @@
 package at.asitplus.wallet.lib.iso
 
 import at.asitplus.KmmResult.Companion.wrap
-import kotlinx.serialization.*
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromByteArray
+import kotlinx.serialization.encodeToByteArray
 
 /**
  * Part of the ISO/IEC 18013-5:2021 standard: Data structure for MSO (9.1.2.4)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/MobileSecurityObject.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/MobileSecurityObject.kt
@@ -3,8 +3,6 @@
 package at.asitplus.wallet.lib.iso
 
 import at.asitplus.KmmResult.Companion.wrap
-import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
-import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapperSerializer
 import kotlinx.serialization.*
 
 /**
@@ -28,35 +26,7 @@ data class MobileSecurityObject(
 
     fun serialize() = vckCborSerializer.encodeToByteArray(this)
 
-    /**
-     * Ensures serialization of this structure in [IssuerSigned.issuerAuth]:
-     * ```
-     * IssuerAuth = COSE_Sign1     ; The payload is MobileSecurityObjectBytes
-     * MobileSecurityObjectBytes = #6.24(bstr .cbor MobileSecurityObject)
-     * ```
-     *
-     * See ISO/IEC 18013-5:2021, 9.1.2.4 Signing method and structure for MSO
-     */
-    fun serializeForIssuerAuth() = vckCborSerializer.encodeToByteArray(
-        ByteStringWrapperSerializer(serializer()), ByteStringWrapper(this)
-    ).wrapInCborTag(24)
-
     companion object {
-        /**
-         * Deserializes the structure from the [IssuerSigned.issuerAuth] is deserialized:
-         * ```
-         * IssuerAuth = COSE_Sign1     ; The payload is MobileSecurityObjectBytes
-         * MobileSecurityObjectBytes = #6.24(bstr .cbor MobileSecurityObject)
-         * ```
-         *
-         * See ISO/IEC 18013-5:2021, 9.1.2.4 Signing method and structure for MSO
-         */
-        fun deserializeFromIssuerAuth(it: ByteArray) = kotlin.runCatching {
-            vckCborSerializer.decodeFromByteArray(
-                ByteStringWrapperSerializer(serializer()),
-                it.stripCborTag(24)
-            ).value
-        }.wrap()
 
         fun deserialize(it: ByteArray) = kotlin.runCatching {
             vckCborSerializer.decodeFromByteArray<MobileSecurityObject>(it)

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/CoseServiceTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/CoseServiceTest.kt
@@ -3,6 +3,8 @@ package at.asitplus.wallet.lib.cbor
 import at.asitplus.signum.indispensable.cosef.CoseAlgorithm
 import at.asitplus.signum.indispensable.cosef.CoseHeader
 import at.asitplus.signum.indispensable.cosef.CoseSigned
+import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
+import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.cosef.toCoseKey
 import at.asitplus.wallet.lib.agent.CryptoService
 import at.asitplus.wallet.lib.agent.DefaultCryptoService
@@ -11,8 +13,11 @@ import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.encodeToByteArray
 import kotlin.random.Random
 
+@OptIn(ExperimentalSerializationApi::class)
 class CoseServiceTest : FreeSpec({
 
     lateinit var cryptoService: CryptoService
@@ -41,7 +46,8 @@ class CoseServiceTest : FreeSpec({
         val parsed = CoseSigned.deserialize(signed.serialize()).getOrThrow()
 
         cryptoService.keyMaterial.publicKey.toCoseKey().getOrNull() shouldNotBe null
-        val result = verifierCoseService.verifyCose(parsed, cryptoService.keyMaterial.publicKey.toCoseKey().getOrThrow())
+        val result =
+            verifierCoseService.verifyCose(parsed, cryptoService.keyMaterial.publicKey.toCoseKey().getOrThrow())
         result.isSuccess shouldBe true
     }
 
@@ -58,7 +64,8 @@ class CoseServiceTest : FreeSpec({
         val parsed = CoseSigned.deserialize(signed.serialize()).getOrThrow()
 
         cryptoService.keyMaterial.publicKey.toCoseKey().getOrNull() shouldNotBe null
-        val result = verifierCoseService.verifyCose(parsed, cryptoService.keyMaterial.publicKey.toCoseKey().getOrThrow())
+        val result =
+            verifierCoseService.verifyCose(parsed, cryptoService.keyMaterial.publicKey.toCoseKey().getOrThrow())
         result.isSuccess shouldBe true
     }
 

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/CoseServiceTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/CoseServiceTest.kt
@@ -3,8 +3,6 @@ package at.asitplus.wallet.lib.cbor
 import at.asitplus.signum.indispensable.cosef.CoseAlgorithm
 import at.asitplus.signum.indispensable.cosef.CoseHeader
 import at.asitplus.signum.indispensable.cosef.CoseSigned
-import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
-import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.cosef.toCoseKey
 import at.asitplus.wallet.lib.agent.CryptoService
 import at.asitplus.wallet.lib.agent.DefaultCryptoService
@@ -14,7 +12,6 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.encodeToByteArray
 import kotlin.random.Random
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/DeviceSignedItemSerializationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/DeviceSignedItemSerializationTest.kt
@@ -48,8 +48,8 @@ class DeviceSignedItemSerializationTest : FreeSpec({
             value = Random.nextBytes(32),
         )
         val protectedHeader = ByteStringWrapper(CoseHeader(), CoseHeader().serialize())
-        val issuerAuth = CoseSigned(protectedHeader, null, null, byteArrayOf())
-        val deviceAuth = CoseSigned(protectedHeader, null, null, byteArrayOf())
+        val issuerAuth = CoseSigned<ByteStringWrapper<MobileSecurityObject>>(protectedHeader, null, null, byteArrayOf())
+        val deviceAuth = CoseSigned<ByteArray>(protectedHeader, null, null, byteArrayOf())
 
         val doc = Document(
             docType = uuid4().toString(),

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/DeviceSignedItemSerializationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/DeviceSignedItemSerializationTest.kt
@@ -48,7 +48,7 @@ class DeviceSignedItemSerializationTest : FreeSpec({
             value = Random.nextBytes(32),
         )
         val protectedHeader = ByteStringWrapper(CoseHeader(), CoseHeader().serialize())
-        val issuerAuth = CoseSigned<ByteStringWrapper<MobileSecurityObject>>(protectedHeader, null, null, byteArrayOf())
+        val issuerAuth = CoseSigned<MobileSecurityObject>(protectedHeader, null, null, byteArrayOf())
         val deviceAuth = CoseSigned<ByteArray>(protectedHeader, null, null, byteArrayOf())
 
         val doc = Document(

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/IssuerSignedItemSerializationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/IssuerSignedItemSerializationTest.kt
@@ -46,7 +46,7 @@ class IssuerSignedItemSerializationTest : FreeSpec({
             elementValue = Random.nextBytes(32),
         )
         val protectedHeader = ByteStringWrapper(CoseHeader(), CoseHeader().serialize())
-        val issuerAuth = CoseSigned<ByteStringWrapper<MobileSecurityObject>>(protectedHeader, null, null, byteArrayOf())
+        val issuerAuth = CoseSigned<MobileSecurityObject>(protectedHeader, null, null, byteArrayOf())
         val doc = Document(
             docType = uuid4().toString(),
             issuerSigned = IssuerSigned.fromIssuerSignedItems(

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/IssuerSignedItemSerializationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/IssuerSignedItemSerializationTest.kt
@@ -46,7 +46,7 @@ class IssuerSignedItemSerializationTest : FreeSpec({
             elementValue = Random.nextBytes(32),
         )
         val protectedHeader = ByteStringWrapper(CoseHeader(), CoseHeader().serialize())
-        val issuerAuth = CoseSigned<ByteArray>(protectedHeader, null, null, byteArrayOf())
+        val issuerAuth = CoseSigned<ByteStringWrapper<MobileSecurityObject>>(protectedHeader, null, null, byteArrayOf())
         val doc = Document(
             docType = uuid4().toString(),
             issuerSigned = IssuerSigned.fromIssuerSignedItems(

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/IssuerSignedItemSerializationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/IssuerSignedItemSerializationTest.kt
@@ -46,7 +46,7 @@ class IssuerSignedItemSerializationTest : FreeSpec({
             elementValue = Random.nextBytes(32),
         )
         val protectedHeader = ByteStringWrapper(CoseHeader(), CoseHeader().serialize())
-        val issuerAuth = CoseSigned(protectedHeader, null, null, byteArrayOf())
+        val issuerAuth = CoseSigned<ByteArray>(protectedHeader, null, null, byteArrayOf())
         val doc = Document(
             docType = uuid4().toString(),
             issuerSigned = IssuerSigned.fromIssuerSignedItems(

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/IsoProcessTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/IsoProcessTest.kt
@@ -55,7 +55,10 @@ class Wallet {
         this.storedIssuerAuth = issuerAuth
 
         issuerAuth.payload.shouldNotBeNull()
-        val mso = document.issuerSigned.getIssuerAuthPayloadAsMso().getOrThrow()
+        val mso = document.issuerSigned.issuerAuth
+            .getTypedPayload(ByteStringWrapperSerializer(MobileSecurityObject.serializer()))
+            .getOrThrow()?.value
+            .shouldNotBeNull()
 
         val mdlItems = document.issuerSigned.namespaces?.get(ConstantIndex.AtomicAttribute2023.isoNamespace)
             .shouldNotBeNull()
@@ -197,7 +200,10 @@ class Verifier {
         val issuerAuth = issuerSigned.issuerAuth
         verifierCoseService.verifyCose(issuerAuth, issuerKey).isSuccess shouldBe true
         issuerAuth.payload.shouldNotBeNull()
-        val mso = issuerSigned.getIssuerAuthPayloadAsMso().getOrThrow()
+        val mso = issuerAuth
+            .getTypedPayload(ByteStringWrapperSerializer(MobileSecurityObject.serializer()))
+            .getOrThrow()?.value
+            .shouldNotBeNull()
 
         mso.docType shouldBe ConstantIndex.AtomicAttribute2023.isoDocType
         val mdlItems = mso.valueDigests[ConstantIndex.AtomicAttribute2023.isoNamespace].shouldNotBeNull()

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/IsoProcessTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/IsoProcessTest.kt
@@ -4,6 +4,7 @@ import at.asitplus.signum.indispensable.cosef.CoseHeader
 import at.asitplus.signum.indispensable.cosef.CoseKey
 import at.asitplus.signum.indispensable.cosef.CoseSigned
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
+import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapperSerializer
 import at.asitplus.signum.indispensable.cosef.toCoseKey
 import at.asitplus.wallet.lib.agent.DefaultCryptoService
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
@@ -44,7 +45,7 @@ class Wallet {
     private val coseService = DefaultCoseService(cryptoService)
 
     val deviceKeyInfo = DeviceKeyInfo(cryptoService.keyMaterial.publicKey.toCoseKey().getOrThrow())
-    private var storedIssuerAuth: CoseSigned<ByteArray>? = null
+    private var storedIssuerAuth: CoseSigned<ByteStringWrapper<MobileSecurityObject>>? = null
     private var storedMdlItems: IssuerSignedList? = null
 
     fun storeMdl(deviceResponse: DeviceResponse) {
@@ -138,7 +139,8 @@ class Issuer {
                             ConstantIndex.AtomicAttribute2023.isoNamespace to issuerSigned
                         ),
                         issuerAuth = coseService.createSignedCose(
-                            payload = mso.serializeForIssuerAuth(),
+                            payload = ByteStringWrapper(mso),
+                            serializationStrategy = ByteStringWrapperSerializer(MobileSecurityObject.serializer()),
                             addKeyId = false,
                             addCertificate = true,
                         ).getOrThrow()

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/IsoProcessTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/IsoProcessTest.kt
@@ -44,7 +44,7 @@ class Wallet {
     private val coseService = DefaultCoseService(cryptoService)
 
     val deviceKeyInfo = DeviceKeyInfo(cryptoService.keyMaterial.publicKey.toCoseKey().getOrThrow())
-    private var storedIssuerAuth: CoseSigned? = null
+    private var storedIssuerAuth: CoseSigned<ByteArray>? = null
     private var storedMdlItems: IssuerSignedList? = null
 
     fun storeMdl(deviceResponse: DeviceResponse) {

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/Tag24SerializationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/Tag24SerializationTest.kt
@@ -44,7 +44,13 @@ class Tag24SerializationTest : FreeSpec({
                 )
             ),
             deviceAuth = DeviceAuth(
-                deviceSignature = issuerAuth()
+                deviceSignature = CoseSigned<ByteArray>(
+                    protectedHeader = ByteStringWrapper(CoseHeader()),
+                    unprotectedHeader = null,
+                    payload = byteArrayOf(),
+                    rawSignature = byteArrayOf()
+                )
+
             )
         )
 
@@ -108,7 +114,7 @@ class Tag24SerializationTest : FreeSpec({
             validityInfo = ValidityInfo(Clock.System.now(), Clock.System.now(), Clock.System.now())
         )
         val serializedMso = mso.serializeForIssuerAuth()
-        val input = CoseSigned<ByteArray>(
+        val input = CoseSigned<ByteStringWrapper<MobileSecurityObject>>(
             protectedHeader = ByteStringWrapper(CoseHeader()),
             unprotectedHeader = null,
             payload = serializedMso,
@@ -129,7 +135,7 @@ class Tag24SerializationTest : FreeSpec({
 private fun deviceKeyInfo() =
     DeviceKeyInfo(CoseKey(CoseKeyType.EC2, keyParams = CoseKeyParams.EcYBoolParams(CoseEllipticCurve.P256)))
 
-private fun issuerAuth() = CoseSigned<ByteArray>(
+private fun issuerAuth() = CoseSigned<ByteStringWrapper<MobileSecurityObject>>(
     protectedHeader = ByteStringWrapper(CoseHeader()),
     unprotectedHeader = null,
     payload = byteArrayOf(),

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/Tag24SerializationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/Tag24SerializationTest.kt
@@ -108,7 +108,7 @@ class Tag24SerializationTest : FreeSpec({
             validityInfo = ValidityInfo(Clock.System.now(), Clock.System.now(), Clock.System.now())
         )
         val serializedMso = mso.serializeForIssuerAuth()
-        val input = CoseSigned(
+        val input = CoseSigned<ByteArray>(
             protectedHeader = ByteStringWrapper(CoseHeader()),
             unprotectedHeader = null,
             payload = serializedMso,
@@ -119,7 +119,7 @@ class Tag24SerializationTest : FreeSpec({
 
         serialized.encodeToString(Base16(true)).shouldContainOnlyOnce("D818")
         serializedMso.encodeToString(Base16(true)).shouldStartWith("D818")
-        vckCborSerializer.decodeFromByteArray<CoseSigned>(serialized) shouldBe input
+        vckCborSerializer.decodeFromByteArray<CoseSigned<ByteArray>>(serialized) shouldBe input
         MobileSecurityObject.deserializeFromIssuerAuth(serializedMso).getOrThrow() shouldBe mso
     }
 
@@ -129,7 +129,7 @@ class Tag24SerializationTest : FreeSpec({
 private fun deviceKeyInfo() =
     DeviceKeyInfo(CoseKey(CoseKeyType.EC2, keyParams = CoseKeyParams.EcYBoolParams(CoseEllipticCurve.P256)))
 
-private fun issuerAuth() = CoseSigned(
+private fun issuerAuth() = CoseSigned<ByteArray>(
     protectedHeader = ByteStringWrapper(CoseHeader()),
     unprotectedHeader = null,
     payload = byteArrayOf(),

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/Tag24SerializationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/Tag24SerializationTest.kt
@@ -166,7 +166,7 @@ private fun MobileSecurityObject.Companion.deserializeFromIssuerAuth(it: ByteArr
 private fun deviceKeyInfo() =
     DeviceKeyInfo(CoseKey(CoseKeyType.EC2, keyParams = CoseKeyParams.EcYBoolParams(CoseEllipticCurve.P256)))
 
-private fun issuerAuth() = CoseSigned<ByteStringWrapper<MobileSecurityObject>>(
+private fun issuerAuth() = CoseSigned<MobileSecurityObject>(
     protectedHeader = ByteStringWrapper(CoseHeader()),
     unprotectedHeader = null,
     payload = byteArrayOf(),


### PR DESCRIPTION
Uses type parameter from `CoseSigned` to clarify usages of the payload (and reduce the number of manual tagging payloads).

See also https://github.com/a-sit-plus/signum/pull/194