### PR TITLE
Fix/request parser 2

### DIFF
--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/RequestParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/RequestParser.kt
@@ -78,7 +78,7 @@ class RequestParser(
         }
 
     private fun parseRequestObjectJws(requestObject: String): RequestParametersFrom<*>? {
-        return JwsSigned.deserialize<RequestParameters>(requestObject, vckJsonSerializer).getOrNull()
+        return JwsSigned.deserialize<RequestParameters>(PolymorphicSerializer(RequestParameters::class), requestObject, vckJsonSerializer).getOrNull()
             ?.let { jws ->
                 if (requestObjectJwsVerifier.invoke(jws)) {
                     RequestParametersFrom.JwsSigned(jws, jws.payload)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialIssuer.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialIssuer.kt
@@ -196,7 +196,7 @@ class CredentialIssuer(
     }
 
     private suspend fun String.validateJwtProof(): CryptoPublicKey {
-        val jwsSigned = JwsSigned.deserialize<JsonWebToken>(this, vckJsonSerializer).getOrNull()
+        val jwsSigned = JwsSigned.deserialize<JsonWebToken>(JsonWebToken.serializer(), this, vckJsonSerializer).getOrNull()
             ?: throw OAuth2Exception(Errors.INVALID_PROOF)
                 .also { Napier.w("client did provide invalid proof: $this") }
         val jwt = jwsSigned.payload

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopProtocolTest.kt
@@ -151,7 +151,7 @@ class OidcSiopProtocolTest : FreeSpec({
         authnRequest.clientId shouldBe clientId
         val jar = authnRequest.request
             .shouldNotBeNull()
-        val jwsObject = JwsSigned.deserialize<AuthenticationRequestParameters>(jar, vckJsonSerializer).getOrThrow()
+        val jwsObject = JwsSigned.deserialize<AuthenticationRequestParameters>(AuthenticationRequestParameters.serializer(), jar, vckJsonSerializer).getOrThrow()
         DefaultVerifierJwsService().verifyJwsObject(jwsObject).shouldBeTrue()
 
         val authnResponse = holderSiop.createAuthnResponse(jar).getOrThrow()
@@ -195,7 +195,7 @@ class OidcSiopProtocolTest : FreeSpec({
         authnResponse.url.shouldBe(clientId)
         authnResponse.params.shouldHaveSize(2)
         val jarmResponse = authnResponse.params.entries.first { it.key == "response" }.value
-        val jwsObject = JwsSigned.deserialize<AuthenticationResponseParameters>(jarmResponse).getOrThrow()
+        val jwsObject = JwsSigned.deserialize<AuthenticationResponseParameters>(AuthenticationResponseParameters.serializer(), jarmResponse).getOrThrow()
         DefaultVerifierJwsService().verifyJwsObject(jwsObject).shouldBeTrue()
 
         val result = verifierSiop.validateAuthnResponseFromPost(authnResponse.params.formUrlEncode())
@@ -446,7 +446,7 @@ private suspend fun buildAttestationJwt(
 private fun attestationJwtVerifier(trustedKey: JsonWebKey) =
     object : RequestObjectJwsVerifier {
         override fun invoke(jws: JwsSigned<RequestParameters>): Boolean {
-            val attestationJwt = jws.header.attestationJwt?.let { JwsSigned.deserialize<JsonWebToken>(it).getOrThrow() }
+            val attestationJwt = jws.header.attestationJwt?.let { JwsSigned.deserialize<JsonWebToken>(JsonWebToken.serializer(), it).getOrThrow() }
                 ?: return false
             val verifierJwsService = DefaultVerifierJwsService()
             if (!verifierJwsService.verifyJws(attestationJwt, trustedKey))

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OpenId4VpInteropTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OpenId4VpInteropTest.kt
@@ -112,7 +112,7 @@ class OpenId4VpInteropTest : FreeSpec({
         requestUrlForWallet shouldContain verifierClientId.encodeURLParameter()
         requestUrlForWallet shouldStartWith "haip://"
 
-        val jar = JwsSigned.deserialize<AuthenticationRequestParameters>(requestObject, vckJsonSerializer).getOrThrow()
+        val jar = JwsSigned.deserialize<AuthenticationRequestParameters>(AuthenticationRequestParameters.serializer(), requestObject, vckJsonSerializer).getOrThrow()
 
         jar.header.algorithm shouldBe JwsAlgorithm.ES256
         jar.header.type shouldBe "oauth-authz-req+jwt"
@@ -202,7 +202,7 @@ class OpenId4VpInteropTest : FreeSpec({
             .i7Kli1T5RZzo2-TvWsw9-JpxjYPBUae8Lrc_ORfTdabHlXmuPucGVrE5lkBu7vLss2RKKEmdFFy57-ZvRFn4Tg
         """.trimIndent()
 
-        val jar = JwsSigned.deserialize<AuthenticationRequestParameters>(input, vckJsonSerializer).getOrThrow()
+        val jar = JwsSigned.deserialize<AuthenticationRequestParameters>(AuthenticationRequestParameters.serializer(), input, vckJsonSerializer).getOrThrow()
 
         jar.header.algorithm shouldBe JwsAlgorithm.ES256
         jar.header.type shouldBe " oauth-authz-req+jwt " // that's a typo in the document ...

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciCodeFlowTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciCodeFlowTest.kt
@@ -127,7 +127,7 @@ class OidvciCodeFlowTest : FreeSpec({
         credential.format shouldBe CredentialFormatEnum.JWT_VC
         val serializedCredential = credential.credential.shouldNotBeNull()
 
-        JwsSigned.deserialize<VerifiableCredentialJws>(serializedCredential, vckJsonSerializer).getOrThrow()
+        JwsSigned.deserialize<VerifiableCredentialJws>(VerifiableCredentialJws.serializer(), serializedCredential, vckJsonSerializer).getOrThrow()
             .payload.vc.credentialSubject.shouldBeInstanceOf<at.asitplus.wallet.lib.data.AtomicAttribute2023>()
     }
 
@@ -206,7 +206,7 @@ class OidvciCodeFlowTest : FreeSpec({
         credential.format shouldBe CredentialFormatEnum.VC_SD_JWT
         val serializedCredential = credential.credential.shouldNotBeNull()
 
-        val sdJwt = JwsSigned.deserialize<VerifiableCredentialSdJwt>(serializedCredential.substringBefore("~"))
+        val sdJwt = JwsSigned.deserialize<VerifiableCredentialSdJwt>(VerifiableCredentialSdJwt.serializer(), serializedCredential.substringBefore("~"))
             .getOrThrow().payload
 
         sdJwt.disclosureDigests
@@ -226,7 +226,7 @@ class OidvciCodeFlowTest : FreeSpec({
         credential.format shouldBe CredentialFormatEnum.VC_SD_JWT
         val serializedCredential = credential.credential.shouldNotBeNull()
 
-        val sdJwt = JwsSigned.deserialize<VerifiableCredentialSdJwt>(serializedCredential.substringBefore("~"))
+        val sdJwt = JwsSigned.deserialize<VerifiableCredentialSdJwt>(VerifiableCredentialSdJwt.serializer(), serializedCredential.substringBefore("~"))
             .getOrThrow().payload
 
         sdJwt.disclosureDigests
@@ -243,7 +243,7 @@ class OidvciCodeFlowTest : FreeSpec({
         credential.format shouldBe CredentialFormatEnum.VC_SD_JWT
         val serializedCredential = credential.credential.shouldNotBeNull()
 
-        val sdJwt = JwsSigned.deserialize<VerifiableCredentialSdJwt>(serializedCredential.substringBefore("~"))
+        val sdJwt = JwsSigned.deserialize<VerifiableCredentialSdJwt>(VerifiableCredentialSdJwt.serializer(), serializedCredential.substringBefore("~"))
             .getOrThrow().payload
 
         sdJwt.disclosureDigests

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Parser.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Parser.kt
@@ -37,7 +37,7 @@ class Parser(
      */
     fun parseVpJws(input: String, challenge: String, clientId: String): ParseVpResult {
         Napier.d("Parsing VP $input")
-        val jws = JwsSigned.deserialize<VerifiablePresentationJws>(input, vckJsonSerializer).getOrNull()
+        val jws = JwsSigned.deserialize<VerifiablePresentationJws>(VerifiablePresentationJws.serializer(), input, vckJsonSerializer).getOrNull()
             ?: return ParseVpResult.InvalidStructure(input)
                 .also { Napier.w("Could not parse JWS: $input") }
         return parseVpJws(input, jws.payload, challenge, clientId)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -138,7 +138,7 @@ class VerifiablePresentationFactory(
         val issuerJwtPlusDisclosures = SdJwtSigned.sdHashInput(validSdJwtCredential, filteredDisclosures)
         val keyBinding = createKeyBindingJws(audienceId, challenge, issuerJwtPlusDisclosures)
         val issuerSignedJwsSerialized = validSdJwtCredential.vcSerialized.substringBefore("~")
-        val issuerSignedJws = JwsSigned.deserialize<JsonElement>(issuerSignedJwsSerialized, vckJsonSerializer).getOrElse {
+        val issuerSignedJws = JwsSigned.deserialize<JsonElement>(JsonElement.serializer(), issuerSignedJwsSerialized, vckJsonSerializer).getOrElse {
             Napier.w("Could not re-create JWS from stored SD-JWT", it)
             throw PresentationException(it)
         }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifierAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifierAgent.kt
@@ -42,7 +42,7 @@ class VerifierAgent(
                 Verifier.VerifyPresentationResult.InvalidStructure(input)
             }
         }
-        val jwsSigned = JwsSigned.deserialize<VerifiablePresentationJws>(input, vckJsonSerializer).getOrNull()
+        val jwsSigned = JwsSigned.deserialize<VerifiablePresentationJws>(VerifiablePresentationJws.serializer(), input, vckJsonSerializer).getOrNull()
         if (jwsSigned != null) {
             return runCatching {
                 validator.verifyVpJws(input, challenge, identifier)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/SdJwtSigned.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/SdJwtSigned.kt
@@ -59,7 +59,7 @@ data class SdJwtSigned(
             val stringList = input.replace("[^A-Za-z0-9-_.~]".toRegex(), "").split("~")
             if (stringList.isEmpty())
                 return null.also { Napier.w("Could not parse SD-JWT: $input") }
-            val jws = JwsSigned.deserialize<JsonElement>(stringList.first(), vckJsonSerializer).getOrNull()
+            val jws = JwsSigned.deserialize<JsonElement>(JsonElement.serializer(), stringList.first(), vckJsonSerializer).getOrNull()
                 ?: return null.also { Napier.w("Could not parse JWS from SD-JWT: $input") }
             val stringListWithoutJws = stringList.drop(1)
             val rawDisclosures = stringListWithoutJws
@@ -67,7 +67,7 @@ data class SdJwtSigned(
                 .filterNot { it.isEmpty() }
             val keyBindingString = stringList.drop(1 + rawDisclosures.size).firstOrNull()
             val keyBindingJws = keyBindingString
-                ?.let { JwsSigned.deserialize<KeyBindingJws>(it, vckJsonSerializer).getOrNull() }
+                ?.let { JwsSigned.deserialize<KeyBindingJws>(KeyBindingJws.serializer(), it, vckJsonSerializer).getOrNull() }
             return SdJwtSigned(jws, rawDisclosures, keyBindingJws)
         }
 

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
@@ -193,7 +193,7 @@ private suspend fun createSdJwtPresentation(
     val issuerJwtPlusDisclosures = SdJwtSigned.sdHashInput(validSdJwtCredential, filteredDisclosures)
     val keyBinding = createKeyBindingJws(jwsService, audienceId, challenge, issuerJwtPlusDisclosures)
     val sdJwtSerialized = validSdJwtCredential.vcSerialized.substringBefore("~")
-    val jwsFromIssuer = JwsSigned.deserialize<VerifiableCredentialSdJwt>(sdJwtSerialized).getOrElse {
+    val jwsFromIssuer = JwsSigned.deserialize<VerifiableCredentialSdJwt>(VerifiableCredentialSdJwt.serializer(), sdJwtSerialized).getOrElse {
         Napier.w("Could not re-create JWS from stored SD-JWT", it)
         throw PresentationException(it)
     }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceTest.kt
@@ -45,7 +45,7 @@ class JwsServiceTest : FreeSpec({
             jwsService.createSignedJwt(JwsContentTypeConstants.JWT, payload, ByteArraySerializer()).getOrThrow()
                 .serialize()
 
-        val parsed = JwsSigned.deserialize<ByteArray>(signed).getOrThrow()
+        val parsed = JwsSigned.deserialize<ByteArray>(ByteArraySerializer(), signed).getOrThrow()
         parsed.serialize() shouldBe signed
         parsed.payload shouldBe payload
 

--- a/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceJvmTest.kt
+++ b/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceJvmTest.kt
@@ -131,7 +131,7 @@ class JwsServiceJvmTest : FreeSpec({
 
                     // Parsing to our structure verifying payload
                     val signedLibObject = libObject.serialize()
-                    val parsedJwsSigned = JwsSigned.deserialize<JsonElement>(signedLibObject).getOrThrow()
+                    val parsedJwsSigned = JwsSigned.deserialize<JsonElement>(JsonElement.serializer(), signedLibObject).getOrThrow()
                     parsedJwsSigned.payload.jsonPrimitive.content shouldBe randomPayload.content
                     val parsedSig = parsedJwsSigned.signature.rawByteArray.encodeToString(Base64UrlStrict)
 


### PR DESCRIPTION
Do not cast everything to `AuthenticationRequestParameter`.
Necessitates [a-sit-plus/signum/212](https://github.com/a-sit-plus/signum/pull/212) because iOS cannot deal with polymorphic serialization otherwise