### PR TITLE
Fix/dependency cleanups

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,2 +1,0 @@
-[versions]
-kmmresult = "1.8.0!!"

--- a/openid-data-classes/build.gradle.kts
+++ b/openid-data-classes/build.gradle.kts
@@ -40,21 +40,6 @@ kotlin {
                 api("at.asitplus:jsonpath4k:${VcLibVersions.jsonpath}")
             }
         }
-
-        commonTest {
-            dependencies {
-            }
-        }
-
-        jvmMain {
-            dependencies {
-            }
-        }
-
-        jvmTest {
-            dependencies {
-            }
-        }
     }
 }
 

--- a/vck-openid-ktor/build.gradle.kts
+++ b/vck-openid-ktor/build.gradle.kts
@@ -68,7 +68,6 @@ kotlin {
 
         iosTest {
             dependencies {
-                implementation("io.arrow-kt:arrow-core:1.2.4") //work around klib bug
                 implementation(ktor("client-darwin"))
             }
         }

--- a/vck-openid/build.gradle.kts
+++ b/vck-openid/build.gradle.kts
@@ -38,6 +38,8 @@ kotlin {
                 api(project(":vck"))
                 api(project(":openid-data-classes"))
                 commonImplementationDependencies()
+                // Add arrow-core dependency because of https://youtrack.jetbrains.com/issue/KT-73858/NullPointerException-when-building-CMP-ios-App
+                api("io.arrow-kt:arrow-core:1.2.4")
             }
         }
 

--- a/vck-openid/build.gradle.kts
+++ b/vck-openid/build.gradle.kts
@@ -60,12 +60,6 @@ kotlin {
                 implementation("org.json:json:${VcLibVersions.Jvm.json}")
             }
         }
-
-        iosTest {
-            dependencies {
-                implementation("io.arrow-kt:arrow-core:1.2.4") //work around klib bug
-            }
-        }
     }
 }
 


### PR DESCRIPTION
* removes obsolete KmmResult and needless arrow implemetation dependencies
* declare arrow as api dependency to work around [KT-73858](https://youtrack.jetbrains.com/issue/KT-73858) 

This allows building valera without issues and without redecalring arrow in valera