### PR TITLE
prepare proper removal of arrow

### DIFF
--- a/vck-openid/build.gradle.kts
+++ b/vck-openid/build.gradle.kts
@@ -38,8 +38,6 @@ kotlin {
                 api(project(":vck"))
                 api(project(":openid-data-classes"))
                 commonImplementationDependencies()
-                // Add arrow-core dependency because of https://youtrack.jetbrains.com/issue/KT-73858/NullPointerException-when-building-CMP-ios-App
-                api("io.arrow-kt:arrow-core:1.2.4")
             }
         }
 
@@ -47,6 +45,12 @@ kotlin {
             dependencies {
                 implementation("at.asitplus.wallet:eupidcredential:${VcLibVersions.eupidcredential}")
                 implementation("at.asitplus.wallet:mobiledrivinglicence:${VcLibVersions.mdl}")
+                // Add arrow-core dependency because of https://youtrack.jetbrains.com/issue/KT-73858/NullPointerException-when-building-CMP-ios-App
+                // credentials depend on older VC-K version, which pulls in old KmmResult and arrow dependency
+                // KLIB dependency resolution is somewhat borked, so we need this here until newer credentials are published based on this VC-K version
+                // that uses the most recent KmmResult without Arrow dependency
+                //TODO REMOVE ONCE mDL and PID are updated to this VC-K release with KmmResul 1.9.0
+                implementation("io.arrow-kt:arrow-core:1.2.4")
             }
         }
 


### PR DESCRIPTION
This removes the arrow dependency for good.

- We still need to update and release all credentials to use this VC-K version once released
- Then we need pull those updated credentials into Valera (or wherever we use them)
- Finally, our Valera build issues will also be resolved for good.