### PR TITLE
Make expires nullable

### DIFF
--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TokenResponseParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TokenResponseParameters.kt
@@ -38,7 +38,7 @@ data class TokenResponseParameters(
      */
     @SerialName("expires_in")
     @Serializable(with = DurationSecondsIntSerializer::class)
-    val expires: Duration,
+    val expires: Duration? = null,
 
     /**
      * RFC6749:


### PR DESCRIPTION
According to RFC 6749 `expires_in` is only a RECOMMENDED parameter and as such can be null