### PR TITLE
Fix DCQL Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 Release 5.5.0:
- - tbd
+ - Fix encoding `dcql_query` in authentication request, it is now a string
 
 Release 5.4.0:
 - Extend support for POTENTIAL UC5: Remote qualified electronic signatures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+Release 5.5.0:
+ - tbd
+
 Release 5.4.0:
 - Extend support for POTENTIAL UC5: Remote qualified electronic signatures
   - Update data classes in `rqes-data-classes`

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
-artifactVersion = 5.4.0
+artifactVersion = 5.5.0-SNAPSHOT
 jdk.version=17
 
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthenticationRequestParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthenticationRequestParameters.kt
@@ -7,6 +7,7 @@ import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.signum.indispensable.josef.io.InstantLongSerializer
+import io.github.aakira.napier.Napier
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -179,7 +180,7 @@ data class AuthenticationRequestParameters(
      * OID4VP: dcql_query: A string containing a JSON-encoded DCQL query as defined in Section 6.
      */
     @SerialName("dcql_query")
-    val dcqlQuery: DCQLQuery? = null,
+    val dcqlQueryString: String? = null,
 
     /**
      * RFC9396: The request parameter `authorization_details` contains, in JSON notation, an array of objects.
@@ -367,7 +368,18 @@ data class AuthenticationRequestParameters(
     override val transactionData: Set<String>? = null,
 ) : RequestParameters {
 
+    val dcqlQuery: DCQLQuery? by lazy {
+        dcqlQueryString?.let {
+            runCatching { odcJsonSerializer.decodeFromString<DCQLQuery>(it) }
+                .getOrElse {
+                    Napier.w("dcqlQuery failed to parse from $dcqlQueryString", it)
+                    null
+                }
+        }
+    }
+
     fun serialize() = odcJsonSerializer.encodeToString(this)
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false
@@ -391,7 +403,7 @@ data class AuthenticationRequestParameters(
         if (idTokenType != other.idTokenType) return false
         if (presentationDefinition != other.presentationDefinition) return false
         if (presentationDefinitionUrl != other.presentationDefinitionUrl) return false
-        if (dcqlQuery != other.dcqlQuery) return false
+        if (dcqlQueryString != other.dcqlQueryString) return false
         if (authorizationDetails != other.authorizationDetails) return false
         if (walletIssuer != other.walletIssuer) return false
         if (userHint != other.userHint) return false
@@ -439,7 +451,7 @@ data class AuthenticationRequestParameters(
         result = 31 * result + (idTokenType?.hashCode() ?: 0)
         result = 31 * result + (presentationDefinition?.hashCode() ?: 0)
         result = 31 * result + (presentationDefinitionUrl?.hashCode() ?: 0)
-        result = 31 * result + (dcqlQuery?.hashCode() ?: 0)
+        result = 31 * result + (dcqlQueryString?.hashCode() ?: 0)
         result = 31 * result + (authorizationDetails?.hashCode() ?: 0)
         result = 31 * result + (walletIssuer?.hashCode() ?: 0)
         result = 31 * result + (userHint?.hashCode() ?: 0)

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQuery.kt
@@ -162,7 +162,7 @@ data class DCQLQuery(
                     )
                 }.getOrElse {
                     if (credentialSetQuery.required) {
-                        throw IllegalArgumentException("Required credential set query is not satisfiable.", it)
+                        throw IllegalArgumentException("Required credential set query is not satisfiable: $credentialSetQuery", it)
                     }
                     null
                 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -107,10 +107,12 @@ open class OpenId4VpVerifier(
     val metadataWithEncryption by lazy {
         metadata.copy(
             authorizationEncryptedResponseAlgString = jwsService.encryptionAlgorithm.identifier,
-            authorizationEncryptedResponseEncodingString = jwsService.encryptionEncoding.text
+            authorizationEncryptedResponseEncodingString = jwsService.encryptionEncoding.text,
+            jsonWebKeySet = metadata.jsonWebKeySet?.let {
+                JsonWebKeySet(it.keys.map { it.copy(publicKeyUse = "enc") })
+            }
         )
     }
-
 
     sealed class CreationOptions {
         /**

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -24,6 +24,7 @@ import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.datetime.Clock
 import kotlinx.serialization.encodeToByteArray
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -292,8 +293,8 @@ open class OpenId4VpVerifier(
         idTokenType = IdTokenType.SUBJECT_SIGNED.text,
         responseMode = requestOptions.responseMode,
         state = requestOptions.state,
-        dcqlQuery = if (requestOptions.presentationMechanism == PresentationMechanismEnum.DCQL) {
-            requestOptions.toDCQLQuery()
+        dcqlQueryString = if (requestOptions.presentationMechanism == PresentationMechanismEnum.DCQL) {
+            requestOptions.toDCQLQuery()?.let { odcJsonSerializer.encodeToString(it) }
         } else null,
         presentationDefinition = if (requestOptions.presentationMechanism == PresentationMechanismEnum.PresentationExchange) {
             requestOptions.toPresentationDefinition(containerJwt, containerSdJwt)


### PR DESCRIPTION
Quoting [OpenID4VP](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-new-parameters): 
`dcql_query`: A string containing a JSON-encoded DCQL query as defined in [Section 6](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#dcql_query).