### PR TITLE
Enable atrust signing

### DIFF
--- a/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/SignatureResponse.kt
+++ b/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/SignatureResponse.kt
@@ -13,7 +13,7 @@ sealed class SignatureResponse {
         @SerialName("signatures")
         val signatures: List<String>,
         @SerialName("responseID")
-        val responseId: String?,
+        val responseId: String? = null,
     ) : SignatureResponse()
 
     @Serializable

--- a/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesOpenId4VpHolder.kt
+++ b/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesOpenId4VpHolder.kt
@@ -9,6 +9,7 @@ import at.asitplus.rqes.SignHashParameters
 import at.asitplus.rqes.collection_entries.CscCertificateParameters
 import at.asitplus.rqes.collection_entries.CscDocumentDigest
 import at.asitplus.rqes.collection_entries.CscKeyParameters
+import at.asitplus.rqes.collection_entries.DocumentLocation
 import at.asitplus.rqes.collection_entries.OAuthDocumentDigest
 import at.asitplus.rqes.enums.ConformanceLevel
 import at.asitplus.rqes.enums.SignatureFormat
@@ -113,12 +114,14 @@ class RqesOpenId4VpHolder(
     suspend fun getCscAuthenticationDetails(
         documentDigests: Collection<OAuthDocumentDigest>,
         hashAlgorithm: Digest,
+        documentLocation: Collection<DocumentLocation>? = null
     ): AuthorizationDetails = signingCredential?.let { signingCred ->
         CscAuthorizationDetails(
             credentialID = signingCred.credentialId,
             signatureQualifier = signatureProperties.signatureQualifier,
             hashAlgorithmOid = hashAlgorithm.oid,
-            documentDigests = documentDigests
+            documentDigests = documentDigests,
+            documentLocations = documentLocation
         )
     } ?: throw Exception("Please set a signing credential before using CSC functionality.")
 
@@ -157,9 +160,10 @@ class RqesOpenId4VpHolder(
         redirectUrl: String = this.redirectUrl,
         hashAlgorithm: Digest,
         optionalParameters: OAuth2RqesParameters.Optional? = null,
+        documentLocation: Collection<DocumentLocation>? = null
     ): AuthenticationRequestParameters = oauth2Client.createAuthRequest(
         state = uuid4().toString(),
-        authorizationDetails = setOf(getCscAuthenticationDetails(documentDigests, hashAlgorithm)),
+        authorizationDetails = setOf(getCscAuthenticationDetails(documentDigests, hashAlgorithm, documentLocation)),
     ).enrichAuthRequest(
         redirectUrl = redirectUrl,
         optionalParameters = optionalParameters


### PR DESCRIPTION
- Make `reponseId` optional
- Add `documentLocation` to `getCscAuthenticationDetails` and `createAuthRequest`