### PR TITLE
Add Wallet Attestations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Release 5.5.0:
    - Remove proof type `cwt`, which has been removed from draft 14
    - The `CredentialIssuer` issues more the same credential to different keys, if more than one proof is contained in the credential request
    - Add rudimentary implementation of key attestation proofs in `WalletService` and `CredentialIssuer`
+   - `SimpleAuthorizationService` implements pushed authorization requests as defined in [RFC 9126](https://www.rfc-editor.org/rfc/rfc9126.html)
  - Update dependencies:
    - Update `signum` to 3.14.0, supporting X.509 certificates in v1, v2 too
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Release 5.5.0:
  - Update implementation of authorization service for [OpenID4VC High Assurance Interoperability Profile](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html) draft 03:
    - `SimpleAuthorizationService` implements pushed authorization requests as defined in [RFC 9126](https://www.rfc-editor.org/rfc/rfc9126.html)
    - `SimpleAuthorizationService` implements attestation-based client authentication as defined in [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-05.html)
+   - In `SimpleAuthorizationService` add constructor parameter to validate the client attestation JWT
  - Update dependencies:
    - Update `signum` to 3.14.0, supporting X.509 certificates in v1, v2 too
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ Release 5.5.0:
    - Remove proof type `cwt`, which has been removed from draft 14
    - The `CredentialIssuer` issues more the same credential to different keys, if more than one proof is contained in the credential request
    - Add rudimentary implementation of key attestation proofs in `WalletService` and `CredentialIssuer`
+ - Update implementation of authorization service for [OpenID4VC High Assurance Interoperability Profile](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html) draft 03:
    - `SimpleAuthorizationService` implements pushed authorization requests as defined in [RFC 9126](https://www.rfc-editor.org/rfc/rfc9126.html)
+   - `SimpleAuthorizationService` implements attestation-based client authentication as defined in [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-05.html)
  - Update dependencies:
    - Update `signum` to 3.14.0, supporting X.509 certificates in v1, v2 too
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
@@ -345,6 +345,11 @@ object OpenIdConstants {
         const val INVALID_REQUEST = "invalid_request"
 
         /**
+         * Invalid client, e.g. missing client authentication: `invalid_client`
+         */
+        const val INVALID_CLIENT = "invalid_client"
+
+        /**
          * The requested scope is invalid, unknown, or malformed: `invalid_scope`
          */
         const val INVALID_SCOPE = "invalid_scope"

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
@@ -226,6 +226,7 @@ class OpenId4VciClientTest : FunSpec() {
         val authorizationEndpointPath = "/authorize"
         val tokenEndpointPath = "/token"
         val credentialEndpointPath = "/credential"
+        val parEndpointPath = "/par"
         val publicContext = "http://issuer.example.com"
         val authorizationService = SimpleAuthorizationService(
             strategy = CredentialAuthorizationServiceStrategy(
@@ -235,6 +236,7 @@ class OpenId4VciClientTest : FunSpec() {
             publicContext = publicContext,
             authorizationEndpointPath = authorizationEndpointPath,
             tokenEndpointPath = tokenEndpointPath,
+            pushedAuthorizationRequestEndpointPath = parEndpointPath,
         )
         val credentialIssuer = CredentialIssuer(
             authorizationService = authorizationService,
@@ -256,6 +258,16 @@ class OpenId4VciClientTest : FunSpec() {
                     vckJsonSerializer.encodeToString(authorizationService.metadata),
                     headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 )
+
+                request.url.fullPath.startsWith(parEndpointPath) -> {
+                    val requestBody = request.body.toByteArray().decodeToString()
+                    val authnRequest: AuthenticationRequestParameters = requestBody.decodeFromPostBody()
+                    val result = authorizationService.par(authnRequest).getOrThrow()
+                    respond(
+                        vckJsonSerializer.encodeToString(result),
+                        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    )
+                }
 
                 request.url.fullPath.startsWith(authorizationEndpointPath) -> {
                     val requestBody = request.body.toByteArray().decodeToString()

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2Client.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2Client.kt
@@ -76,6 +76,21 @@ class OAuth2Client(
         codeChallengeMethod = CODE_CHALLENGE_METHOD_SHA256
     )
 
+    /**
+     * Send the result as parameters (either POST or GET) to the server at `/authorize` (or more specific
+     * [OAuth2AuthorizationServerMetadata.authorizationEndpoint]).
+     * Use this method if the previous authn request was sent as a pushed authorization request (RFC 9126),
+     * and the server has answered with [PushedAuthenticationResponseParameters].
+     *
+     * @param parResponse response from the AS to the PAR request
+     */
+    suspend fun createAuthRequestAfterPar(
+        parResponse: PushedAuthenticationResponseParameters,
+    ) = AuthenticationRequestParameters(
+        clientId = clientId,
+        requestUri = parResponse.requestUri,
+    )
+
     @OptIn(ExperimentalStdlibApi::class)
     suspend fun generateCodeVerifier(state: String): String {
         val codeVerifier = Random.nextBytes(32).toHexString(HexFormat.Default)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2Client.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2Client.kt
@@ -5,7 +5,6 @@ import at.asitplus.openid.OpenIdConstants.CODE_CHALLENGE_METHOD_SHA256
 import at.asitplus.openid.OpenIdConstants.GRANT_TYPE_CODE
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.wallet.lib.iso.sha256
-import at.asitplus.wallet.lib.jws.JwsService
 import at.asitplus.wallet.lib.oidvci.DefaultMapStore
 import at.asitplus.wallet.lib.oidvci.MapStore
 import at.asitplus.wallet.lib.oidvci.WalletService
@@ -152,7 +151,7 @@ class OAuth2Client(
      * ```
      *
      * Be sure to include a DPoP header if [OAuth2AuthorizationServerMetadata.dpopSigningAlgValuesSupported] is set,
-     * see [JwsService.buildDPoPHeader].
+     * see [buildDPoPHeader].
      *
      * @param state to keep internal state in further requests
      * @param authorization for the token endpoint

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/Extensions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/Extensions.kt
@@ -198,6 +198,7 @@ fun Issuer.IssuedCredential.toCredentialResponseSingleCredential(): CredentialRe
     }
 
 class OAuth2Exception : Throwable {
+    constructor(error: String, errorDescription: String, cause: Throwable) : super("$error: $errorDescription", cause)
     constructor(error: String, errorDescription: String) : super("$error: $errorDescription")
     constructor(error: String, cause: Throwable) : super(error, cause)
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2AuthorizationServerAdapter.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2AuthorizationServerAdapter.kt
@@ -35,6 +35,12 @@ interface OAuth2AuthorizationServerAdapter {
     val supportsClientNonce: Boolean
 
     /**
+     * Whether this authorization server implements pushed authorization requests as defined in
+     * [RFC 9126](https://www.rfc-editor.org/rfc/rfc9126.html).
+     */
+    val supportsPushedAuthorizationRequests: Boolean
+
+    /**
      * Called by [CredentialIssuer] to verify that nonces contained in proof-of-possession statements from clients
      * are indeed valid.
      */

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2SecurityExtensions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2SecurityExtensions.kt
@@ -1,0 +1,121 @@
+package at.asitplus.wallet.lib.oidvci
+
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import at.asitplus.signum.indispensable.josef.ConfirmationClaim
+import at.asitplus.signum.indispensable.josef.JsonWebKey
+import at.asitplus.signum.indispensable.josef.JsonWebToken
+import at.asitplus.signum.indispensable.josef.JwsHeader
+import at.asitplus.wallet.lib.iso.sha256
+import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
+import at.asitplus.wallet.lib.jws.JwsService
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import kotlinx.datetime.Clock
+import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * To be set as header `DPoP` in making request to [url],
+ * see [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449)
+ */
+suspend fun JwsService.buildDPoPHeader(
+    url: String,
+    httpMethod: String = "POST",
+    accessToken: String? = null,
+) = createSignedJwsAddingParams(
+    header = JwsHeader(
+        algorithm = algorithm,
+        type = JwsContentTypeConstants.DPOP_JWT
+    ),
+    payload = JsonWebToken(
+        jwtId = Random.Default.nextBytes(12).encodeToString(Base64UrlStrict),
+        httpMethod = httpMethod,
+        httpTargetUrl = url,
+        accessTokenHash = accessToken?.encodeToByteArray()?.sha256()?.encodeToString(Base64UrlStrict),
+        issuedAt = Clock.System.now(),
+    ),
+    serializer = JsonWebToken.Companion.serializer(),
+    addKeyId = false,
+    addJsonWebKey = true,
+    addX5c = false,
+).getOrThrow().serialize()
+
+/**
+ * Client attestation JWT, issued by the backend service to a client, which can be sent to an OAuth2 Authorization
+ * Server if needed, e.g. as HTTP header `OAuth-Client-Attestation`, see
+ * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-04.html)
+ *
+ * @param clientId OAuth 2.0 client ID of the wallet
+ * @param issuer a unique identifier for the entity that issued the JWT
+ * @param clientKey key to be attested, i.e. included in a [at.asitplus.signum.indispensable.josef.ConfirmationClaim]
+ * @param walletName human-readable name of the Wallet
+ * @param walletLink URL for further information about the Wallet Provider
+ * @param lifetime validity period of the assertion (minus the [clockSkew])
+ * @param clockSkew duration to subtract from [Clock.System.now] when setting the creation timestamp
+ */
+// TODO Use this in an test, also HAIP requires the credential issuer to require client attestation!
+suspend fun JwsService.buildClientAttestationJwt(
+    clientId: String,
+    issuer: String,
+    clientKey: JsonWebKey,
+    walletName: String? = null,
+    walletLink: String? = null,
+    lifetime: Duration = 60.minutes,
+    clockSkew: Duration = 5.minutes,
+) = createSignedJwsAddingParams(
+    header = JwsHeader(
+        algorithm = algorithm,
+        type = JwsContentTypeConstants.CLIENT_ATTESTATION_JWT
+    ),
+    payload = JsonWebToken(
+        issuer = issuer,
+        subject = clientId,
+        issuedAt = Clock.System.now() - clockSkew,
+        expiration = Clock.System.now() - clockSkew + lifetime,
+        walletName = walletName,
+        walletLink = walletLink,
+        confirmationClaim = ConfirmationClaim(
+            jsonWebKey = clientKey,
+        )
+    ),
+    serializer = JsonWebToken.Companion.serializer(),
+    addKeyId = false,
+    addJsonWebKey = false,
+    addX5c = false,
+).getOrThrow()
+
+/**
+ * Client attestation PoP JWT, issued by the client, which can be sent to an OAuth2 Authorization Server if needed,
+ * e.g. as HTTP header `OAuth-Client-Attestation-PoP`, see
+ * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-04.html)
+ *
+ * @param clientId OAuth 2.0 client ID of the wallet
+ * @param audience The RFC8414 issuer identifier URL of the authorization server MUST be used
+ * @param nonce optionally provided from the authorization server
+ * @param lifetime validity period of the assertion (minus the [clockSkew])
+ * @param clockSkew duration to subtract from [Clock.System.now] when setting the creation timestamp
+ */
+suspend fun JwsService.buildClientAttestationPoPJwt(
+    clientId: String,
+    audience: String,
+    nonce: String? = null,
+    lifetime: Duration = 10.minutes,
+    clockSkew: Duration = 5.minutes,
+) = createSignedJwsAddingParams(
+    header = JwsHeader(
+        algorithm = algorithm,
+        type = JwsContentTypeConstants.CLIENT_ATTESTATION_POP_JWT
+    ),
+    payload = JsonWebToken(
+        issuer = clientId,
+        audience = audience,
+        jwtId = Random.Default.nextBytes(12).encodeToString(Base64UrlStrict),
+        nonce = nonce,
+        issuedAt = Clock.System.now() - clockSkew,
+        expiration = Clock.System.now() - clockSkew + lifetime,
+    ),
+    serializer = JsonWebToken.Companion.serializer(),
+    addKeyId = false,
+    addJsonWebKey = false,
+    addX5c = false,
+).getOrThrow()

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2SecurityExtensions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2SecurityExtensions.kt
@@ -53,7 +53,6 @@ suspend fun JwsService.buildDPoPHeader(
  * @param lifetime validity period of the assertion (minus the [clockSkew])
  * @param clockSkew duration to subtract from [Clock.System.now] when setting the creation timestamp
  */
-// TODO Use this in an test, also HAIP requires the credential issuer to require client attestation!
 suspend fun JwsService.buildClientAttestationJwt(
     clientId: String,
     issuer: String,
@@ -80,8 +79,8 @@ suspend fun JwsService.buildClientAttestationJwt(
     ),
     serializer = JsonWebToken.Companion.serializer(),
     addKeyId = false,
-    addJsonWebKey = false,
-    addX5c = false,
+    addJsonWebKey = true,
+    addX5c = true,
 ).getOrThrow()
 
 /**

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/SerializerSketch.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/SerializerSketch.kt
@@ -5,13 +5,7 @@ import io.ktor.http.*
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.JsonUnquotedLiteral
-import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.*
 
 typealias Parameters = Map<String, String>
 
@@ -33,7 +27,7 @@ inline fun <reified T> String.decodeFromPostBody(): T = split("&")
     .associate {
         val key = it.substringBefore("=")
         val value = it.substringAfter("=", "")
-        key.safeDecodeUrlQueryComponent() to value.safeDecodeUrlQueryComponent()
+        key.safeDecodeUrlQueryComponent(plusIsSpace = true) to value.safeDecodeUrlQueryComponent(plusIsSpace = true)
     }
     .decode()
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletService.kt
@@ -5,7 +5,6 @@ import at.asitplus.catching
 import at.asitplus.openid.*
 import at.asitplus.openid.OpenIdConstants.Errors
 import at.asitplus.openid.OpenIdConstants.ProofType
-import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.*
 import at.asitplus.wallet.lib.RemoteResourceRetrieverFunction
 import at.asitplus.wallet.lib.RemoteResourceRetrieverInput
@@ -19,20 +18,14 @@ import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
 import at.asitplus.wallet.lib.data.ConstantIndex.supportsIso
 import at.asitplus.wallet.lib.data.ConstantIndex.supportsSdJwt
 import at.asitplus.wallet.lib.data.ConstantIndex.supportsVcJwt
-import at.asitplus.wallet.lib.iso.sha256
 import at.asitplus.wallet.lib.jws.DefaultJwsService
-import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.jws.JwsService
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
 import com.benasher44.uuid.uuid4
 import io.github.aakira.napier.Napier
 import io.ktor.http.*
 import io.ktor.util.*
-import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.datetime.Clock
-import kotlin.random.Random
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.minutes
 
 /**
  * Client service to retrieve credentials using OID4VCI
@@ -233,7 +226,7 @@ class WalletService(
      * see [TokenResponseParameters.toHttpHeaderValue].
      *
      * Be sure to include a DPoP header if [TokenResponseParameters.tokenType] is `DPoP`,
-     * see [JwsService.buildDPoPHeader].
+     * see [buildDPoPHeader].
      *
      * See [OAuth2Client.createTokenRequestParameters].
      *
@@ -392,110 +385,3 @@ class WalletService(
             credentialConfigurationId = scope
         )
 }
-
-
-/**
- * To be set as header `DPoP` in making request to [url],
- * see [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449)
- */
-suspend fun JwsService.buildDPoPHeader(
-    url: String,
-    httpMethod: String = "POST",
-    accessToken: String? = null,
-) = createSignedJwsAddingParams(
-    header = JwsHeader(
-        algorithm = algorithm,
-        type = JwsContentTypeConstants.DPOP_JWT
-    ),
-    payload = JsonWebToken(
-        jwtId = Random.nextBytes(12).encodeToString(Base64UrlStrict),
-        httpMethod = httpMethod,
-        httpTargetUrl = url,
-        accessTokenHash = accessToken?.encodeToByteArray()?.sha256()?.encodeToString(Base64UrlStrict),
-        issuedAt = Clock.System.now(),
-    ),
-    serializer = JsonWebToken.serializer(),
-    addKeyId = false,
-    addJsonWebKey = true,
-    addX5c = false,
-).getOrThrow().serialize()
-
-/**
- * Client attestation JWT, issued by the backend service to a client, which can be sent to an OAuth2 Authorization
- * Server if needed, e.g. as HTTP header `OAuth-Client-Attestation`, see
- * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-04.html)
- *
- * @param clientId OAuth 2.0 client ID of the wallet
- * @param issuer a unique identifier for the entity that issued the JWT
- * @param clientKey key to be attested, i.e. included in a [ConfirmationClaim]
- * @param walletName human-readable name of the Wallet
- * @param walletLink URL for further information about the Wallet Provider
- * @param lifetime validity period of the assertion (minus the [clockSkew])
- * @param clockSkew duration to subtract from [Clock.System.now] when setting the creation timestamp
- */
-// TODO Use this in an test, also HAIP requires the credential issuer to require client attestation!
-suspend fun JwsService.buildClientAttestationJwt(
-    clientId: String,
-    issuer: String,
-    clientKey: JsonWebKey,
-    walletName: String? = null,
-    walletLink: String? = null,
-    lifetime: Duration = 60.minutes,
-    clockSkew: Duration = 5.minutes,
-) = createSignedJwsAddingParams(
-    header = JwsHeader(
-        algorithm = algorithm,
-        type = JwsContentTypeConstants.CLIENT_ATTESTATION_JWT
-    ),
-    payload = JsonWebToken(
-        issuer = issuer,
-        subject = clientId,
-        issuedAt = Clock.System.now() - clockSkew,
-        expiration = Clock.System.now() - clockSkew + lifetime,
-        walletName = walletName,
-        walletLink = walletLink,
-        confirmationClaim = ConfirmationClaim(
-            jsonWebKey = clientKey,
-        )
-    ),
-    serializer = JsonWebToken.serializer(),
-    addKeyId = false,
-    addJsonWebKey = false,
-    addX5c = false,
-).getOrThrow()
-
-/**
- * Client attestation PoP JWT, issued by the client, which can be sent to an OAuth2 Authorization Server if needed,
- * e.g. as HTTP header `OAuth-Client-Attestation-PoP`, see
- * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-04.html)
- *
- * @param clientId OAuth 2.0 client ID of the wallet
- * @param audience The RFC8414 issuer identifier URL of the authorization server MUST be used
- * @param nonce optionally provided from the authorization server
- * @param lifetime validity period of the assertion (minus the [clockSkew])
- * @param clockSkew duration to subtract from [Clock.System.now] when setting the creation timestamp
- */
-suspend fun JwsService.buildClientAttestationPoPJwt(
-    clientId: String,
-    audience: String,
-    nonce: String? = null,
-    lifetime: Duration = 10.minutes,
-    clockSkew: Duration = 5.minutes,
-) = createSignedJwsAddingParams(
-    header = JwsHeader(
-        algorithm = algorithm,
-        type = JwsContentTypeConstants.CLIENT_ATTESTATION_POP_JWT
-    ),
-    payload = JsonWebToken(
-        issuer = clientId,
-        audience = audience,
-        jwtId = Random.nextBytes(12).encodeToString(Base64UrlStrict),
-        nonce = nonce,
-        issuedAt = Clock.System.now() - clockSkew,
-        expiration = Clock.System.now() - clockSkew + lifetime,
-    ),
-    serializer = JsonWebToken.serializer(),
-    addKeyId = false,
-    addJsonWebKey = false,
-    addX5c = false,
-).getOrThrow()

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/ResponseParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/ResponseParser.kt
@@ -32,8 +32,8 @@ class ResponseParser(
     suspend fun parseAuthnResponse(input: String): ResponseParametersFrom {
         val paramsFrom = runCatching {
             val url = Url(input)
-            if (url.fragment.isNotEmpty()) {
-                url.fragment.decodeFromPostBody<AuthenticationResponseParameters>().let {
+            if (url.encodedFragment.isNotEmpty()) {
+                url.encodedFragment.decodeFromUrlQuery<AuthenticationResponseParameters>().let {
                     ResponseParametersFrom.Uri(url, it)
                 }
             } else {

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
@@ -1,0 +1,148 @@
+package at.asitplus.wallet.lib.oauth2
+
+import at.asitplus.openid.*
+import at.asitplus.signum.indispensable.josef.JsonWebToken
+import at.asitplus.signum.indispensable.josef.JwsSigned
+import at.asitplus.wallet.lib.agent.DefaultCryptoService
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
+import at.asitplus.wallet.lib.jws.DefaultJwsService
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception
+import at.asitplus.wallet.lib.oidvci.buildClientAttestationJwt
+import at.asitplus.wallet.lib.oidvci.buildClientAttestationPoPJwt
+import at.asitplus.wallet.lib.oidvci.randomString
+import at.asitplus.wallet.lib.openid.AuthenticationResponseResult
+import com.benasher44.uuid.uuid4
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.json.JsonObject
+
+class OAuth2ClientAuthenticationTest : FunSpec({
+
+    lateinit var scope: String
+    lateinit var client: OAuth2Client
+    lateinit var user: OidcUserInfoExtended
+    lateinit var server: SimpleAuthorizationService
+    lateinit var clientAttestation: JwsSigned<JsonWebToken>
+    lateinit var clientAttestationPop: JwsSigned<JsonWebToken>
+
+    beforeEach {
+        scope = randomString()
+        client = OAuth2Client()
+        user = OidcUserInfoExtended(OidcUserInfo(randomString()), JsonObject(mapOf()))
+        server = SimpleAuthorizationService(
+            strategy = object : AuthorizationServiceStrategy {
+                override suspend fun loadUserInfo(
+                    request: AuthenticationRequestParameters,
+                    code: String,
+                ): OidcUserInfoExtended? = user
+
+                override fun validScopes(): String = scope
+
+                override fun validAuthorizationDetails(): Collection<OpenIdAuthorizationDetails> = listOf()
+
+                override fun filterAuthorizationDetails(authorizationDetails: Collection<AuthorizationDetails>): Set<OpenIdAuthorizationDetails> =
+                    setOf()
+
+                override fun filterScope(scope: String): String? = scope
+
+            },
+            enforceClientAuthentication = true
+        )
+        val attesterBackend = DefaultJwsService(DefaultCryptoService(EphemeralKeyWithSelfSignedCert()))
+        val clientKey = EphemeralKeyWithSelfSignedCert()
+        val jwsService = DefaultJwsService(DefaultCryptoService(clientKey))
+        clientAttestation =
+            attesterBackend.buildClientAttestationJwt(client.clientId, "someissuer", clientKey.jsonWebKey)
+        clientAttestationPop = jwsService.buildClientAttestationPoPJwt(client.clientId, "some server")
+    }
+
+
+    test("process with pushed authorization request") {
+        val state = uuid4().toString()
+        val authnRequest = client.createAuthRequest(
+            state = state,
+            scope = scope,
+        )
+        val parResponse = server.par(
+            authnRequest,
+            clientAttestation.serialize(),
+            clientAttestationPop.serialize()
+        ).getOrThrow()
+            .shouldBeInstanceOf<PushedAuthenticationResponseParameters>()
+        val authnResponse = server.authorize(client.createAuthRequestAfterPar(parResponse)).getOrThrow()
+            .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+        val code = authnResponse.params.code
+            .shouldNotBeNull()
+
+        val tokenRequest = client.createTokenRequestParameters(
+            state = state,
+            authorization = OAuth2Client.AuthorizationForToken.Code(code),
+            scope = scope
+        )
+        val token = server.token(
+            tokenRequest,
+            clientAttestation.serialize(),
+            clientAttestationPop.serialize()
+        ).getOrThrow()
+        token.authorizationDetails.shouldBeNull()
+    }
+
+    test("process with pushed authorization request without client authentication") {
+        val state = uuid4().toString()
+        val authnRequest = client.createAuthRequest(
+            state = state,
+            scope = scope,
+        )
+        shouldThrow<OAuth2Exception> {
+            server.par(authnRequest).getOrThrow()
+        }
+    }
+
+    test("process with authorization code flow and client authentication") {
+        val state = uuid4().toString()
+        val authnRequest = client.createAuthRequest(
+            state = state,
+            scope = scope,
+        )
+        val authnResponse = server.authorize(authnRequest).getOrThrow()
+            .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+        val code = authnResponse.params.code
+            .shouldNotBeNull()
+
+        val tokenRequest = client.createTokenRequestParameters(
+            state = state,
+            authorization = OAuth2Client.AuthorizationForToken.Code(code),
+            scope = scope
+        )
+        val token = server.token(
+            tokenRequest,
+            clientAttestation.serialize(),
+            clientAttestationPop.serialize()
+        ).getOrThrow()
+        token.authorizationDetails.shouldBeNull()
+    }
+
+    test("process with authorization code flow without client authentication") {
+        val state = uuid4().toString()
+        val authnRequest = client.createAuthRequest(
+            state = state,
+            scope = scope,
+        )
+        val authnResponse = server.authorize(authnRequest).getOrThrow()
+            .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+        val code = authnResponse.params.code
+            .shouldNotBeNull()
+
+        val tokenRequest = client.createTokenRequestParameters(
+            state = state,
+            authorization = OAuth2Client.AuthorizationForToken.Code(code),
+            scope = scope
+        )
+        shouldThrow<OAuth2Exception> { server.token(tokenRequest).getOrThrow() }
+    }
+
+})


### PR DESCRIPTION
As required by [OpenID4VC HAIP](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html) and defined in [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-05.html), add client authentication to the OAuth2 endpoints.
Details (e.g. where to get the `nonce` for the PoP JWT) are not sketched out in the drafts, so we skip that too.