### PR TITLE
OAuth2: DPoP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@ Release 5.5.0:
  - Update implementation of authorization service for [OpenID4VC High Assurance Interoperability Profile](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html) draft 03:
    - `SimpleAuthorizationService` implements pushed authorization requests as defined in [RFC 9126](https://www.rfc-editor.org/rfc/rfc9126.html)
    - `SimpleAuthorizationService` implements attestation-based client authentication as defined in [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-05.html)
+   - `SimpleAuthorizationService` implements sender-constrained access tokens as defined in [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)
    - In `SimpleAuthorizationService` add constructor parameter to validate the client attestation JWT
+   - In `CredentialIssuer.credential()` callers need to pass the whole `Authorization` header instead of just the access token value
  - Update dependencies:
    - Update `signum` to 3.14.0, supporting X.509 certificates in v1, v2 too
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
@@ -22,9 +22,11 @@ object OpenIdConstants {
 
     const val TOKEN_PREFIX_BEARER = "Bearer "
 
+    const val TOKEN_PREFIX_DPOP = "DPoP "
+
     const val TOKEN_TYPE_BEARER = "bearer"
 
-    const val TOKEN_TYPE_DPOP = "dpop"
+    const val TOKEN_TYPE_DPOP = "DPoP"
 
     const val URN_TYPE_JWK_THUMBPRINT = "urn:ietf:params:oauth:jwk-thumbprint"
 
@@ -338,6 +340,11 @@ object OpenIdConstants {
          * Invalid access token: `invalid_token`
          */
         const val INVALID_TOKEN = "invalid_token"
+
+        /**
+         * Invalid DPoP proof (RFC 9449): `invalid_dpop_proof`
+         */
+        const val INVALID_DPOP_PROOF = "invalid_dpop_proof"
 
         /**
          * Invalid request in general: `invalid_request`

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
@@ -311,7 +311,7 @@ class OpenId4VciClient(
                 contentType(ContentType.Application.Json)
                 setBody(credentialRequest)
                 headers {
-                    append(HttpHeaders.Authorization, "${tokenResponse.tokenType} ${tokenResponse.accessToken}")
+                    append(HttpHeaders.Authorization, tokenResponse.toHttpHeaderValue())
                     dpopHeader?.let { append(HttpHeaders.DPoP, it) }
                 }
             }.body()

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
@@ -301,6 +301,8 @@ class OpenId4VciClientTest : FunSpec() {
                         request.headers["OAuth-Client-Attestation"],
                         request.headers["OAuth-Client-Attestation-PoP"],
                         request.headers["DPoP"],
+                        request.url.toString(),
+                        request.method,
                     ).getOrThrow()
                     respond(
                         vckJsonSerializer.encodeToString(result),
@@ -315,7 +317,9 @@ class OpenId4VciClientTest : FunSpec() {
                     val result = credentialIssuer.credential(
                         authorizationHeader,
                         params,
-                        request.headers["DPoP"]
+                        request.headers["DPoP"],
+                        request.url.toString(),
+                        request.method,
                     ).getOrThrow()
                     respond(
                         vckJsonSerializer.encodeToString(result),

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialIssuer.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialIssuer.kt
@@ -22,6 +22,7 @@ import at.asitplus.wallet.lib.jws.DefaultVerifierJwsService
 import at.asitplus.wallet.lib.jws.VerifierJwsService
 import com.benasher44.uuid.uuid4
 import io.github.aakira.napier.Napier
+import io.ktor.http.HttpMethod
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Clock.System
 import kotlin.time.Duration
@@ -179,17 +180,23 @@ class CredentialIssuer(
      * @param authorizationHeader value of HTTP header `Authorization` sent by the client, with all prefixes
      * @param params Parameters the client sent JSON-serialized in the HTTP body
      * @param dpopHeader value of HTTP header `DPoP` sent by the client
+     * @param requestUrl public-facing URL that the client has used (to validate `DPoP`)
+     * @param requestUrl HTTP method that the client has used (to validate `DPoP`)
      */
     suspend fun credential(
         authorizationHeader: String,
         params: CredentialRequestParameters,
         dpopHeader: String? = null,
+        requestUrl: String? = null,
+        requestMethod: HttpMethod? = null,
     ): KmmResult<CredentialResponseParameters> = catching {
         val userInfo = authorizationService.getUserInfo(
             authorizationHeader,
             dpopHeader,
             params.credentialIdentifier,
-            params.credentialConfigurationId
+            params.credentialConfigurationId,
+            requestUrl,
+            requestMethod,
         ).getOrElse {
             Napier.w("credential: access token not valid", it)
             throw it

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialIssuer.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialIssuer.kt
@@ -169,23 +169,25 @@ class CredentialIssuer(
     )
 
     /**
-     * Verifies the [accessToken] to contain a token from [authorizationService],
+     * Verifies the [authorizationHeader] to contain a token from [authorizationService],
      * verifies the proof sent by the client (must contain a nonce sent from [authorizationService]),
      * and issues credentials to the client.
      *
      * Callers need to send the result JSON-serialized back to the client.
      * HTTP status code MUST be 202.
      *
-     * @param accessToken The value of HTTP header `Authorization` sent by the client,
-     *                    with the prefix `Bearer ` removed, so the plain access token
+     * @param authorizationHeader value of HTTP header `Authorization` sent by the client, with all prefixes
      * @param params Parameters the client sent JSON-serialized in the HTTP body
+     * @param dpopHeader value of HTTP header `DPoP` sent by the client
      */
     suspend fun credential(
-        accessToken: String,
+        authorizationHeader: String,
         params: CredentialRequestParameters,
+        dpopHeader: String? = null,
     ): KmmResult<CredentialResponseParameters> = catching {
         val userInfo = authorizationService.getUserInfo(
-            accessToken,
+            authorizationHeader,
+            dpopHeader,
             params.credentialIdentifier,
             params.credentialConfigurationId
         ).getOrElse {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2AuthorizationServerAdapter.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2AuthorizationServerAdapter.kt
@@ -23,10 +23,18 @@ interface OAuth2AuthorizationServerAdapter {
     suspend fun providePreAuthorizedCode(user: OidcUserInfoExtended): String
 
     /**
-     * Get the [OidcUserInfoExtended] (holding [at.asitplus.openid.OidcUserInfo]) associated with the [accessToken],
-     * that was created before at the Authorization Server.
+     * Get the [OidcUserInfoExtended] (holding [at.asitplus.openid.OidcUserInfo]) associated with the access token in
+     * [authorizationHeader], that was created before at the Authorization Server.
+     *
+     * @param authorizationHeader value of the HTTP header `Authorization`
+     * @param dpopHeader value of the HTTP header `DPoP`
      */
-    suspend fun getUserInfo(accessToken: String, credentialIdentifier: String?, credentialConfigurationId: String?): KmmResult<OidcUserInfoExtended>
+    suspend fun getUserInfo(
+        authorizationHeader: String,
+        dpopHeader: String?,
+        credentialIdentifier: String?,
+        credentialConfigurationId: String?,
+    ): KmmResult<OidcUserInfoExtended>
 
     /**
      * Whether this authorization server includes [at.asitplus.openid.TokenResponseParameters.clientNonce] it its

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2AuthorizationServerAdapter.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2AuthorizationServerAdapter.kt
@@ -3,6 +3,7 @@ package at.asitplus.wallet.lib.oidvci
 import at.asitplus.KmmResult
 import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.OidcUserInfoExtended
+import io.ktor.http.HttpMethod
 
 /**
  * Used in OID4VCI by [CredentialIssuer] to obtain user data when issuing credentials using OID4VCI.
@@ -28,12 +29,16 @@ interface OAuth2AuthorizationServerAdapter {
      *
      * @param authorizationHeader value of the HTTP header `Authorization`
      * @param dpopHeader value of the HTTP header `DPoP`
+     * @param requestUrl public-facing URL that the client has used (to validate `DPoP`)
+     * @param requestUrl HTTP method that the client has used (to validate `DPoP`)
      */
     suspend fun getUserInfo(
         authorizationHeader: String,
         dpopHeader: String?,
         credentialIdentifier: String?,
         credentialConfigurationId: String?,
+        requestUrl: String? = null,
+        requestMethod: HttpMethod? = null,
     ): KmmResult<OidcUserInfoExtended>
 
     /**

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2SecurityExtensions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2SecurityExtensions.kt
@@ -22,6 +22,7 @@ suspend fun JwsService.buildDPoPHeader(
     url: String,
     httpMethod: String = "POST",
     accessToken: String? = null,
+    nonce: String? = null,
 ) = createSignedJwsAddingParams(
     header = JwsHeader(
         algorithm = algorithm,
@@ -33,6 +34,7 @@ suspend fun JwsService.buildDPoPHeader(
         httpTargetUrl = url,
         accessTokenHash = accessToken?.encodeToByteArray()?.sha256()?.encodeToString(Base64UrlStrict),
         issuedAt = Clock.System.now(),
+        nonce = nonce,
     ),
     serializer = JsonWebToken.Companion.serializer(),
     addKeyId = false,

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientDPoPTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientDPoPTest.kt
@@ -1,0 +1,151 @@
+package at.asitplus.wallet.lib.oauth2
+
+import at.asitplus.openid.*
+import at.asitplus.openid.OpenIdConstants.TOKEN_TYPE_DPOP
+import at.asitplus.wallet.lib.agent.DefaultCryptoService
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.agent.KeyMaterial
+import at.asitplus.wallet.lib.jws.DefaultJwsService
+import at.asitplus.wallet.lib.jws.JwsService
+import at.asitplus.wallet.lib.oidvci.buildDPoPHeader
+import at.asitplus.wallet.lib.oidvci.randomString
+import at.asitplus.wallet.lib.openid.AuthenticationResponseResult
+import com.benasher44.uuid.uuid4
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.json.JsonObject
+import io.kotest.matchers.shouldBe
+import io.kotest.assertions.throwables.shouldThrow
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception
+
+class OAuth2ClientDPoPTest : FunSpec({
+
+    lateinit var scope: String
+    lateinit var client: OAuth2Client
+    lateinit var user: OidcUserInfoExtended
+    lateinit var authorizationServiceStrategy: AuthorizationServiceStrategy
+    lateinit var server: SimpleAuthorizationService
+    lateinit var clientKey: KeyMaterial
+    lateinit var jwsService: JwsService
+
+    beforeEach {
+        scope = randomString()
+        client = OAuth2Client()
+        user = OidcUserInfoExtended(OidcUserInfo(randomString()), JsonObject(mapOf()))
+        authorizationServiceStrategy = object : AuthorizationServiceStrategy {
+            override suspend fun loadUserInfo(
+                request: AuthenticationRequestParameters,
+                code: String,
+            ): OidcUserInfoExtended? = user
+
+            override fun validScopes(): String = scope
+
+            override fun validAuthorizationDetails(): Collection<OpenIdAuthorizationDetails> = listOf()
+
+            override fun filterAuthorizationDetails(authorizationDetails: Collection<AuthorizationDetails>): Set<OpenIdAuthorizationDetails> =
+                setOf()
+
+            override fun filterScope(scope: String): String? = scope
+
+        }
+        server = SimpleAuthorizationService(
+            strategy = authorizationServiceStrategy,
+            enforceDpop = true,
+        )
+        clientKey = EphemeralKeyWithSelfSignedCert()
+        jwsService = DefaultJwsService(DefaultCryptoService(clientKey))
+    }
+
+    suspend fun getCode(state: String): String {
+        val authnRequest = client.createAuthRequest(
+            state = state,
+            scope = scope,
+        )
+        val authnResponse = server.authorize(authnRequest).getOrThrow()
+            .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+        val code = authnResponse.params.code
+            .shouldNotBeNull()
+        return code
+    }
+
+    test("authorization code flow with DPoP") {
+        val state = uuid4().toString()
+        val code = getCode(state)
+
+        val token = server.token(
+            client.createTokenRequestParameters(
+                state = state,
+                authorization = OAuth2Client.AuthorizationForToken.Code(code),
+                scope = scope
+            ),
+            dpop = jwsService.buildDPoPHeader("url")
+        ).getOrThrow().also {
+            it.tokenType shouldBe TOKEN_TYPE_DPOP
+        }
+
+        val dpopForResource = jwsService.buildDPoPHeader("url", accessToken = token.accessToken)
+        // this is our protected resource
+        server.getUserInfo(
+            token.toHttpHeaderValue(),
+            dpopHeader = dpopForResource,
+            credentialIdentifier = null,
+            credentialConfigurationId = scope
+        ).getOrThrow()
+    }
+
+    test("authorization code flow without DPoP for resource") {
+        val state = uuid4().toString()
+        val code = getCode(state)
+
+        val token = server.token(
+            client.createTokenRequestParameters(
+                state = state,
+                authorization = OAuth2Client.AuthorizationForToken.Code(code),
+                scope = scope
+            ),
+            dpop = jwsService.buildDPoPHeader("url")
+        ).getOrThrow().also {
+            it.tokenType shouldBe TOKEN_TYPE_DPOP
+        }
+
+        // this is our protected resource
+        shouldThrow<OAuth2Exception> {
+            server.getUserInfo(
+                token.toHttpHeaderValue(),
+                dpopHeader = null,
+                credentialIdentifier = null,
+                credentialConfigurationId = scope
+            ).getOrThrow()
+        }
+    }
+
+    test("authorization code flow with DPoP from other key") {
+        val state = uuid4().toString()
+        val code = getCode(state)
+
+        val token = server.token(
+            client.createTokenRequestParameters(
+                state = state,
+                authorization = OAuth2Client.AuthorizationForToken.Code(code),
+                scope = scope
+            ),
+            dpop = jwsService.buildDPoPHeader("url")
+        ).getOrThrow()
+
+        val wrongJwsService = DefaultJwsService(DefaultCryptoService(EphemeralKeyWithoutCert()))
+        // TODO Test and assert URL
+        val dpopForResource = wrongJwsService.buildDPoPHeader("url", accessToken = token.accessToken)
+
+        // this is our protected resource
+        shouldThrow<OAuth2Exception> {
+            server.getUserInfo(
+                token.toHttpHeaderValue(),
+                dpopHeader = dpopForResource,
+                credentialIdentifier = null,
+                credentialConfigurationId = scope
+            ).getOrThrow()
+        }
+    }
+})

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciAttestationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciAttestationTest.kt
@@ -86,7 +86,7 @@ class OidvciAttestationTest : FunSpec({
         val scope = credentialFormat.scope.shouldNotBeNull()
         val token = getToken(scope)
         client.createCredentialRequest(token, issuer.metadata, credentialFormat).getOrThrow().forEach {
-            val credential = issuer.credential(token.accessToken, it).getOrThrow()
+            val credential = issuer.credential(token.toHttpHeaderValue(), it).getOrThrow()
             val serializedCredential = credential.credentials.shouldNotBeEmpty()
                 .first().credentialString.shouldNotBeNull()
 
@@ -119,7 +119,7 @@ class OidvciAttestationTest : FunSpec({
         val token = getToken(scope)
         client.createCredentialRequest(token, issuer.metadata, credentialFormat).getOrThrow().forEach {
             shouldThrow<OAuth2Exception> {
-                issuer.credential(token.accessToken, it).getOrThrow()
+                issuer.credential(token.toHttpHeaderValue(), it).getOrThrow()
             }
         }
     }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciCodeFlowTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciCodeFlowTest.kt
@@ -104,7 +104,7 @@ class OidvciCodeFlowTest : FreeSpec({
         val scope = credentialFormat.scope.shouldNotBeNull()
         val token = getToken(scope)
         val credential = issuer.credential(
-            token.accessToken,
+            token.toHttpHeaderValue(),
             client.createCredentialRequest(
                 tokenResponse = token,
                 metadata = issuer.metadata,
@@ -134,7 +134,7 @@ class OidvciCodeFlowTest : FreeSpec({
 
         requestOptions.forEach {
             issuer.credential(
-                token.accessToken,
+                token.toHttpHeaderValue(),
                 client.createCredentialRequest(
                     tokenResponse = token,
                     metadata = issuer.metadata,
@@ -165,7 +165,7 @@ class OidvciCodeFlowTest : FreeSpec({
         )
 
         val credentials: Collection<CredentialResponseSingleCredential> =
-            issuer.credential(token.accessToken, credentialRequest)
+            issuer.credential(token.toHttpHeaderValue(), credentialRequest)
                 .getOrThrow()
                 .credentials.shouldNotBeEmpty().shouldHaveSize(2)
         // subject identifies the key of the client, here the keys of different proofs, so they should be unique
@@ -207,7 +207,7 @@ class OidvciCodeFlowTest : FreeSpec({
         val token = getToken(scope)
 
         val credential = issuer.credential(
-            token.accessToken,
+            token.toHttpHeaderValue(),
             client.createCredentialRequest(
                 tokenResponse = token,
                 metadata = issuer.metadata,
@@ -227,7 +227,7 @@ class OidvciCodeFlowTest : FreeSpec({
         val token = getToken(scope, false) // do not set scope in token request, only in authn request
 
         val credential = issuer.credential(
-            token.accessToken,
+            token.toHttpHeaderValue(),
             client.createCredentialRequest(
                 tokenResponse = token,
                 metadata = issuer.metadata,
@@ -279,7 +279,7 @@ class OidvciCodeFlowTest : FreeSpec({
         val token = getToken(authorizationDetails)
 
         val credential = issuer.credential(
-            token.accessToken,
+            token.toHttpHeaderValue(),
             client.createCredentialRequest(
                 tokenResponse = token,
                 metadata = issuer.metadata,
@@ -304,7 +304,7 @@ class OidvciCodeFlowTest : FreeSpec({
         val token = getToken(authorizationDetails, false) // do not set authn details in token request
 
         val credential = issuer.credential(
-            token.accessToken,
+            token.toHttpHeaderValue(),
             client.createCredentialRequest(
                 tokenResponse = token,
                 metadata = issuer.metadata,
@@ -353,7 +353,7 @@ class OidvciCodeFlowTest : FreeSpec({
 
         shouldThrow<OAuth2Exception> {
             issuer.credential(
-                token.accessToken,
+                token.toHttpHeaderValue(),
                 client.createCredentialRequest(
                     tokenResponse = token,
                     metadata = issuer.metadata,
@@ -370,7 +370,8 @@ class OidvciCodeFlowTest : FreeSpec({
 
     "request credential in SD-JWT, using authorization details in token, but scope in credential request" {
         val credentialFormat =
-            client.selectSupportedCredentialFormat(RequestOptions(AtomicAttribute2023, SD_JWT), issuer.metadata).shouldNotBeNull()
+            client.selectSupportedCredentialFormat(RequestOptions(AtomicAttribute2023, SD_JWT), issuer.metadata)
+                .shouldNotBeNull()
         val scope = credentialFormat.scope.shouldNotBeNull()
         val authorizationDetails = client.buildAuthorizationDetails(
             credentialConfigurationId = AtomicAttribute2023.toCredentialIdentifier(SD_JWT),
@@ -380,7 +381,7 @@ class OidvciCodeFlowTest : FreeSpec({
 
         shouldThrow<OAuth2Exception> {
             issuer.credential(
-                token.accessToken,
+                token.toHttpHeaderValue(),
                 client.createCredentialRequest(
                     tokenResponse = token,
                     metadata = issuer.metadata,
@@ -402,7 +403,8 @@ class OidvciCodeFlowTest : FreeSpec({
         val token = getToken(scope)
 
         val credential = issuer.credential(
-            token.accessToken, client.createCredentialRequest(
+            token.toHttpHeaderValue(),
+            client.createCredentialRequest(
                 tokenResponse = token,
                 metadata = issuer.metadata,
                 credentialFormat = credentialFormat,

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciPreAuthTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciPreAuthTest.kt
@@ -74,7 +74,7 @@ class OidvciPreAuthTest : FreeSpec({
             credentialFormat = credentialFormat,
         ).getOrThrow()
 
-        val credential = issuer.credential(token.accessToken, credentialRequest.first())
+        val credential = issuer.credential(token.toHttpHeaderValue(), credentialRequest.first())
             .getOrThrow()
         credential.credentials.shouldNotBeEmpty().first().credentialString.shouldNotBeNull()
     }
@@ -99,7 +99,7 @@ class OidvciPreAuthTest : FreeSpec({
                 credentialFormat = credentialFormat,
             ).getOrThrow()
 
-            issuer.credential(token.accessToken, credentialRequest.first())
+            issuer.credential(token.toHttpHeaderValue(), credentialRequest.first())
                 .getOrThrow()
                 .credentials.shouldNotBeEmpty().first()
                 .credentialString.shouldNotBeNull()
@@ -131,7 +131,7 @@ class OidvciPreAuthTest : FreeSpec({
             credentialFormat = supportedCredentialFormat,
         ).getOrThrow()
 
-        issuer.credential(token.accessToken, credentialRequest.first())
+        issuer.credential(token.toHttpHeaderValue(), credentialRequest.first())
             .getOrThrow()
             .credentials.shouldNotBeEmpty().first()
             .credentialString.shouldNotBeNull()
@@ -163,7 +163,7 @@ class OidvciPreAuthTest : FreeSpec({
             )
         )
 
-        val credentials = issuer.credential(token.accessToken, credentialRequest)
+        val credentials = issuer.credential(token.toHttpHeaderValue(), credentialRequest)
             .getOrThrow()
             .credentials.shouldNotBeEmpty()
             .shouldHaveSize(2)


### PR DESCRIPTION
Implements sender-constrained access tokens as defined in [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449), mandated by [OpenID4VC HAIP](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html)