### PR TITLE
Fix: Remove parameter restriction on OpenId4VpWallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ TBA
    - Rename `SignDocResponse` to `SignDocResponseParameters`
    - Rename `SignHashResponse` to `SignHashResponseParameters`
  - Fixed default values for CSC data classes
+ - Fixed `OpenIdVpWallet` parameter requirements for finalizing an authorization response
 
 Release 5.5.0:
  - Remove elements deprecated in 5.4.0 when introducing DCQL:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ TBA
    - Rename `SignDocResponse` to `SignDocResponseParameters`
    - Rename `SignHashResponse` to `SignHashResponseParameters`
  - Fixed default values for CSC data classes
- - Fixed `OpenIdVpWallet` parameter requirements for finalizing an authorization response
+ - Fixed `OpenId4VpWallet` parameter requirements for finalizing an authorization response
 
 Release 5.5.0:
  - Remove elements deprecated in 5.4.0 when introducing DCQL:

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWallet.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWallet.kt
@@ -16,16 +16,20 @@ import at.asitplus.wallet.lib.openid.AuthenticationResponseResult
 import at.asitplus.wallet.lib.openid.AuthorizationResponsePreparationState
 import at.asitplus.wallet.lib.openid.OpenId4VpHolder
 import io.github.aakira.napier.Napier
-import io.ktor.client.*
-import io.ktor.client.call.*
-import io.ktor.client.engine.*
-import io.ktor.client.plugins.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.request.*
-import io.ktor.client.request.forms.*
-import io.ktor.client.statement.*
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.call.body
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.client.statement.readRawBytes
 import io.ktor.http.*
-import io.ktor.serialization.kotlinx.json.*
+import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
@@ -128,7 +132,7 @@ class OpenId4VpWallet(
      */
     suspend fun finalizeAuthorizationResponse(
         request: RequestParametersFrom<AuthenticationRequestParameters>,
-        clientMetadata: RelyingPartyMetadata,
+        clientMetadata: RelyingPartyMetadata?,
         credentialPresentation: CredentialPresentation,
     ): KmmResult<Unit> = catching {
         Napier.i("startPresentation: $request")

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestOptions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestOptions.kt
@@ -1,15 +1,7 @@
 package at.asitplus.wallet.lib.openid
 
 import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
-import at.asitplus.dif.Constraint
-import at.asitplus.dif.ConstraintField
-import at.asitplus.dif.ConstraintFilter
-import at.asitplus.dif.DifInputDescriptor
-import at.asitplus.dif.FormatContainerJwt
-import at.asitplus.dif.FormatContainerSdJwt
-import at.asitplus.dif.FormatHolder
-import at.asitplus.dif.InputDescriptor
-import at.asitplus.dif.PresentationDefinition
+import at.asitplus.dif.*
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
 import at.asitplus.openid.AuthenticationRequestParameters
@@ -18,16 +10,7 @@ import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.OpenIdConstants.SCOPE_OPENID
 import at.asitplus.openid.OpenIdConstants.SCOPE_PROFILE
 import at.asitplus.openid.OpenIdConstants.VP_TOKEN
-import at.asitplus.openid.dcql.DCQLClaimsPathPointer
-import at.asitplus.openid.dcql.DCQLClaimsQueryList
-import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
-import at.asitplus.openid.dcql.DCQLCredentialQueryInstance
-import at.asitplus.openid.dcql.DCQLCredentialQueryList
-import at.asitplus.openid.dcql.DCQLIsoMdocClaimsQuery
-import at.asitplus.openid.dcql.DCQLIsoMdocCredentialMetadataAndValidityConstraints
-import at.asitplus.openid.dcql.DCQLJsonClaimsQuery
-import at.asitplus.openid.dcql.DCQLQuery
-import at.asitplus.openid.dcql.DCQLSdJwtCredentialMetadataAndValidityConstraints
+import at.asitplus.openid.dcql.*
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
 import at.asitplus.wallet.lib.data.ConstantIndex.supportsSdJwt
@@ -141,6 +124,7 @@ data class OpenIdRequestOptions(
                 } ?: listOf())
 
                 val claims = requestedAttributes.map { (attribute, isRequired) ->
+                    // TODO: how to properly handle non-required claims?
                     when (credential.representation) {
                         CredentialRepresentation.SD_JWT,
                         CredentialRepresentation.PLAIN_JWT -> DCQLJsonClaimsQuery(


### PR DESCRIPTION
Corresponding changes to imports are because of moving to default IDEA import formatting policy