### PR TITLE
OpenID4VP: Set exact content type for authentication responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Release 5.5.2:
  - OpenID for Verifiable Presentations:
    - Fix parsing `group` in presentation exchange input descriptors
+   - Set content type for authentication responses to `application/x-www-form-urlencoded`, without the charset appended
 
 Release 5.5.1:
  - OpenID for Verifiable Credential Issuance:


### PR DESCRIPTION
Fixes issues with e.g. [MATTR Verifier](https://tools.mattrlabs.com/mdoc-online-presentation)