### PR TITLE
Fix erroneous encoding via contextual serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 Release 5.6.0:
+- Fix erroneous `InputDescriptor` encoding in `PresentationDefinition` when more specific type 
+was known (i.e. `DidInputDescriptor`/`QesInputDescriptor`) via contexutal serialziation
 - Allow fully compliant OID4VP and UC5 `transactionData` handling
 - Deprecate `RqesOpenId4VpVerifier`
 - Change `TransactionData` from sealed class to interface

--- a/dif-data-classes/src/commonMain/kotlin/at/asitplus/dif/BaseInputDescriptorSerializer.kt
+++ b/dif-data-classes/src/commonMain/kotlin/at/asitplus/dif/BaseInputDescriptorSerializer.kt
@@ -1,0 +1,8 @@
+package at.asitplus.dif
+
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+
+object BaseInputDescriptorSerializer : JsonContentPolymorphicSerializer<InputDescriptor>(InputDescriptor::class) {
+    override fun selectDeserializer(element: JsonElement) = DifInputDescriptor.serializer()
+}

--- a/dif-data-classes/src/commonMain/kotlin/at/asitplus/dif/Json.kt
+++ b/dif-data-classes/src/commonMain/kotlin/at/asitplus/dif/Json.kt
@@ -1,6 +1,24 @@
 package at.asitplus.dif
 
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
+import kotlinx.serialization.modules.polymorphic
+
+private val inputDescriptorModule = SerializersModule {
+    polymorphic(InputDescriptor::class) {
+        subclass(DifInputDescriptor::class, DifInputDescriptor.serializer())
+    }
+    polymorphicDefaultSerializer(
+        InputDescriptor::class,
+        defaultSerializerProvider = { BaseInputDescriptorSerializer },
+    )
+    polymorphicDefaultDeserializer(
+        InputDescriptor::class,
+        defaultDeserializerProvider = { BaseInputDescriptorSerializer }
+    )
+    contextual(BaseInputDescriptorSerializer)
+}
 
 val ddcJsonSerializer by lazy {
     Json {
@@ -8,5 +26,6 @@ val ddcJsonSerializer by lazy {
         encodeDefaults = false
         classDiscriminator = "type"
         ignoreUnknownKeys = true
+        serializersModule = inputDescriptorModule
     }
 }

--- a/dif-data-classes/src/commonMain/kotlin/at/asitplus/dif/PresentationDefinition.kt
+++ b/dif-data-classes/src/commonMain/kotlin/at/asitplus/dif/PresentationDefinition.kt
@@ -2,8 +2,10 @@ package at.asitplus.dif
 
 import at.asitplus.catching
 import com.benasher44.uuid.uuid4
+import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 /**
  * Data class for
@@ -18,7 +20,7 @@ data class PresentationDefinition(
     @SerialName("purpose")
     val purpose: String? = null,
     @SerialName("input_descriptors")
-    val inputDescriptors: Collection<InputDescriptor>,
+    val inputDescriptors: Collection<@Contextual InputDescriptor>,
     @SerialName("submission_requirements")
     val submissionRequirements: Collection<SubmissionRequirement>? = null,
 ) {

--- a/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/Json.kt
+++ b/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/Json.kt
@@ -3,11 +3,7 @@ package at.asitplus.rqes
 import CscAuthorizationDetails
 import at.asitplus.dif.DifInputDescriptor
 import at.asitplus.dif.InputDescriptor
-import at.asitplus.openid.AuthenticationRequestParameters
-import at.asitplus.openid.AuthorizationDetails
-import at.asitplus.openid.OpenIdAuthorizationDetails
-import at.asitplus.openid.RequestParameters
-import at.asitplus.openid.TransactionData
+import at.asitplus.openid.*
 import at.asitplus.rqes.collection_entries.QCertCreationAcceptance
 import at.asitplus.rqes.collection_entries.QesAuthorization
 import at.asitplus.rqes.serializers.DeprecatedBase64URLTransactionDataSerializer
@@ -16,6 +12,7 @@ import at.asitplus.rqes.serializers.RequestParametersSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
+import kotlinx.serialization.modules.overwriteWith
 import kotlinx.serialization.modules.polymorphic
 
 private val inputDescriptorModule = SerializersModule {
@@ -31,6 +28,7 @@ private val inputDescriptorModule = SerializersModule {
         InputDescriptor::class,
         defaultDeserializerProvider = { InputDescriptorSerializer }
     )
+    contextual(InputDescriptorSerializer)
 }
 
 private val requestParametersModule = SerializersModule {
@@ -66,6 +64,7 @@ private val transactionDataModule = SerializersModule {
         subclass(QesAuthorization::class, QesAuthorization.serializer())
         subclass(QCertCreationAcceptance::class, QCertCreationAcceptance.serializer())
     }
+    contextual(DeprecatedBase64URLTransactionDataSerializer)
 }
 
 /**
@@ -77,7 +76,6 @@ private val extendedOpenIdSerializerModule = SerializersModule {
     include(requestParametersModule)
     include(authorizationDetailsModule)
     include(transactionDataModule)
-    contextual(DeprecatedBase64URLTransactionDataSerializer)
 }
 
 
@@ -87,6 +85,6 @@ val rdcJsonSerializer by lazy {
         encodeDefaults = false
         classDiscriminator = "type"
         ignoreUnknownKeys = true
-        serializersModule = extendedOpenIdSerializerModule
+        serializersModule = odcJsonSerializer.serializersModule.overwriteWith(extendedOpenIdSerializerModule)
     }
 }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.lib.openid
 
+import at.asitplus.dif.DifInputDescriptor
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
@@ -10,9 +11,9 @@ import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
 import com.benasher44.uuid.uuid4
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.http.*
-import kotlinx.serialization.encodeToString
 
 class AuthenticationRequestParameterFromSerializerTest : FreeSpec({
 
@@ -58,6 +59,7 @@ class AuthenticationRequestParameterFromSerializerTest : FreeSpec({
 
         "Json test $representation" {
             val authnRequest = verifierOid4vp.createAuthnRequest(requestOptions = reqOptions).serialize()
+            authnRequest.shouldNotContain(DifInputDescriptor::class.simpleName!!)
             val params = holderOid4vp.parseAuthenticationRequestParameters(authnRequest).getOrThrow()
 
             val serialized = vckJsonSerializer.encodeToString(params)

--- a/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/RqesRequestOptionsTest.kt
+++ b/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/RqesRequestOptionsTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.http.*
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
@@ -70,8 +71,11 @@ class RqesRequestOptionsTest : FreeSpec({
         "Authentication request contains transactionData" - {
             val authnRequest = rqesVerifier.createAuthnRequest(requestOptions = requestOptions)
             val inputDescriptor = authnRequest.presentationDefinition!!.inputDescriptors.first()
+            val serialized = vckJsonSerializer.encodeToString(inputDescriptor)
             authnRequest.presentationDefinition.shouldNotBeNull()
             inputDescriptor.shouldBeInstanceOf<QesInputDescriptor>()
+            serialized.shouldNotContain(QesInputDescriptor::class.simpleName!!)
+
 
             "OID4VP" {
                 authnRequest.transactionData shouldNotBe null

--- a/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/TransactionDataInterop.kt
+++ b/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/TransactionDataInterop.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.lib.rqes
 
+import at.asitplus.dif.DifInputDescriptor
 import at.asitplus.dif.InputDescriptor
 import at.asitplus.dif.PresentationDefinition
 import at.asitplus.openid.TransactionData
@@ -13,21 +14,16 @@ import at.asitplus.rqes.serializers.DeprecatedBase64URLTransactionDataSerializer
 import at.asitplus.signum.indispensable.asn1.KnownOIDs.sha_256
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.io.ByteArrayBase64Serializer
-import at.asitplus.wallet.lib.data.vckJsonSerializer
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.util.*
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import kotlinx.serialization.PolymorphicSerializer
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.*
 
 /**
  * Test vectors taken from "Transaction Data entries as defined in D3.1: UC Specification WP3"
@@ -98,12 +94,23 @@ class TransactionDataInterop : FreeSpec({
         decoded.shouldBeInstanceOf<QCertCreationAcceptance>()
     }
 
-    "InputDescriptor serializable" {
+    "QesInputDescriptor serializable" {
         val input = QesInputDescriptor(
             id = "123",
             transactionData = listOf(transactionDataTest)
         )
         val serialized = rdcJsonSerializer.encodeToString(input)
+        serialized.shouldNotContain("type")
+        rdcJsonSerializer.decodeFromString(PolymorphicSerializer(InputDescriptor::class), serialized)
+            .shouldBe(input)
+    }
+
+    "DifInputDescriptor Sanity Check" {
+        val input = DifInputDescriptor(
+            id = "123"
+        )
+        val serialized = rdcJsonSerializer.encodeToString(input)
+        serialized.shouldNotContain("type")
         rdcJsonSerializer.decodeFromString(PolymorphicSerializer(InputDescriptor::class), serialized)
             .shouldBe(input)
     }


### PR DESCRIPTION
Issue:
In bigger structures, when the specific class was known, kotlinx.serialization would pick the generic polymorphic serializer for `InputDescriptor` instead of the specific `InputDescriptorSerializer` which is defined for the interface. In this case the `type` discriminator was added.

Solution:
To address this we force the serializer to use the contextual serializer instead which we set to the appropriate `InputDescriptorSerializer`.
To this end we also add a `BaseInputDescriptorSerializer` which only calls the `DifInputDescriptor` serializer without adding the type discriminator.
We need contextual serialization because `InputDescriptor` as an interface allows for open polymorphism and in our use case specifically `QesInputDescriptor` is not defined in the DIF artifact which means the Serializer cannot be hard-coded into the `PresentationDefintion` class.

Also added some tests.