### PR TITLE
Fix/direct post response jwt

### DIFF
--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
@@ -2,6 +2,8 @@ package at.asitplus.wallet.lib.openid
 
 import at.asitplus.openid.*
 import at.asitplus.openid.OpenIdConstants.ResponseMode.*
+import at.asitplus.openid.RelyingPartyMetadata
+import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JweAlgorithm
 import at.asitplus.signum.indispensable.josef.JweHeader
@@ -15,6 +17,7 @@ import at.asitplus.wallet.lib.oidvci.encodeToParameters
 import at.asitplus.wallet.lib.oidvci.formUrlEncode
 import io.github.aakira.napier.Napier
 import io.ktor.http.*
+import kotlinx.serialization.builtins.serializer
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.random.Random
 
@@ -93,7 +96,7 @@ internal class AuthenticationResponseFactory(
     }
 
     /**
-     * Per OID4VP, the response may either be signed, or encrypted, or even signed and encrypted
+     * Per OID4VP, the response must either be signed, or encrypted, or even signed and encrypted
      */
     @Throws(OAuth2Exception::class, CancellationException::class)
     private suspend fun buildJarm(
@@ -104,7 +107,7 @@ internal class AuthenticationResponseFactory(
     } else if (response.requestsSignature()) {
         sign(response.params)
     } else {
-        odcJsonSerializer.encodeToString(response)
+        throw InvalidRequest("Response must be either signed, encrypted or both.")
     }
 
     private suspend fun sign(payload: AuthenticationResponseParameters): String =

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/JarmTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/JarmTest.kt
@@ -1,0 +1,79 @@
+package at.asitplus.wallet.lib.openid
+
+import at.asitplus.openid.*
+import at.asitplus.wallet.eupid.EuPidScheme
+import at.asitplus.wallet.lib.agent.*
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
+import at.asitplus.wallet.lib.data.vckJsonSerializer
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception
+import com.benasher44.uuid.uuid4
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class JarmTest : FreeSpec({
+    lateinit var clientId: String
+    lateinit var holderKeyMaterial: KeyMaterial
+    lateinit var verifierKeyMaterial: KeyMaterial
+    lateinit var holderAgent: Holder
+    lateinit var holderOid4vp: OpenId4VpHolder
+    lateinit var verifierOid4vp: OpenId4VpVerifier
+
+    beforeEach {
+        holderKeyMaterial = EphemeralKeyWithoutCert()
+        verifierKeyMaterial = EphemeralKeyWithoutCert()
+        clientId = "https://example.com/rp/${uuid4()}"
+        holderAgent = HolderAgent(holderKeyMaterial)
+
+        holderAgent.storeCredential(
+            IssuerAgent().issueCredential(
+                DummyCredentialDataProvider.getCredential(holderKeyMaterial.publicKey, AtomicAttribute2023, SD_JWT)
+                    .getOrThrow()
+            ).getOrThrow().toStoreCredentialInput()
+        )
+        holderAgent.storeCredential(
+            IssuerAgent().issueCredential(
+                DummyCredentialDataProvider.getCredential(holderKeyMaterial.publicKey, EuPidScheme, SD_JWT)
+                    .getOrThrow()
+            ).getOrThrow().toStoreCredentialInput()
+        )
+
+        holderOid4vp = OpenId4VpHolder(
+            holder = holderAgent,
+        )
+        verifierOid4vp = OpenId4VpVerifier(
+            keyMaterial = verifierKeyMaterial,
+            clientIdScheme = ClientIdScheme.RedirectUri(clientId)
+        )
+    }
+
+    /**
+     * Incorrect behaviour arises when the [RelyingPartyMetadata.jsonWebKeySet] cannot be
+     * retrieved and [RelyingPartyMetadata.authorizationSignedResponseAlgString] is not set.
+     */
+    "DirectPostJwt must either be signed or encrypted" {
+        val authnRequest = verifierOid4vp.createAuthnRequest(
+            OpenIdRequestOptions(
+                credentials = setOf(
+                    RequestOptionsCredential(AtomicAttribute2023, SD_JWT, setOf(AtomicAttribute2023.CLAIM_GIVEN_NAME))
+                ),
+                responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
+                responseUrl = "https://example.com/${uuid4()}"
+            )
+        )
+        authnRequest shouldNotBe null
+
+        val invalidReq = authnRequest.copy(
+            clientMetadata = authnRequest.clientMetadata?.copy(
+                jsonWebKeySet = null,
+                jsonWebKeySetUrl = "https://example.com/rp/${uuid4()}",
+                authorizationSignedResponseAlgString = null
+            )
+        )
+
+        val response = holderOid4vp.createAuthnResponse(vckJsonSerializer.encodeToString(invalidReq))
+        response.exceptionOrNull() shouldNotBe null
+        response.exceptionOrNull().shouldBeInstanceOf<OAuth2Exception.InvalidRequest>()
+    }
+})


### PR DESCRIPTION
In order for the response to a `direct_post.jwt` request to be valid the response must contain a JWT we cannot simply be serialize the data class to JsonString.