### PR TITLE
Feature/verify transaction data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ Release 5.6.0:
    - Deprecate `RqesOpenId4VpVerifier`
    - Change `TransactionData` from sealed class to interface
    - Fix erroneous `TransactionData` encoding in `AuthenticationRequest`
- - OpenID for Verifiable Credential Issuance:
+   - Change transaction data and related data elements from set to list
+   - Change transaction data elements from their class to JsonPrimitive
+   - Add `TransactionDataBase64Uri` typealias for JsonPrimitive
+   - Add transaction data verification to `OpenID4VpVerifier.validateAuthnResponse`
+  - OpenID for Verifiable Credential Issuance:
    - Remove code elements deprecated in 5.5.0
  - OpenID for Verifiable Presentations:
    - In `OpenId4VpVerifier` add constructor parameter `supportedAlgorithms`

--- a/openid-data-classes/build.gradle.kts
+++ b/openid-data-classes/build.gradle.kts
@@ -35,10 +35,7 @@ kotlin {
                 api(project(":dif-data-classes"))
                 api(ktor("http"))
                 implementation(napier())
-                api("at.asitplus.signum:indispensable:${VcLibVersions.signum}")
-                api("at.asitplus.signum:indispensable-cosef:${VcLibVersions.signum}")
-                api("at.asitplus.signum:indispensable-josef:${VcLibVersions.signum}")
-                api("at.asitplus:jsonpath4k:${VcLibVersions.jsonpath}")
+                commonImplementationAndApiDependencies()
             }
         }
     }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthenticationRequestParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthenticationRequestParameters.kt
@@ -362,7 +362,7 @@ data class AuthenticationRequestParameters(
     /**
      * CSC: OPTIONAL
      * Arbitrary data from the signature application. It can be used to handle a
-     * transaction identifier or other application-spe cific data that may be useful for
+     * transaction identifier or other application-specific data that may be useful for
      * debugging purposes
      */
     @SerialName("clientData")

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthenticationRequestParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthenticationRequestParameters.kt
@@ -378,7 +378,7 @@ data class AuthenticationRequestParameters(
      * For the contextual serializer see [at.asitplus.rqes.serializers.Base64URLTransactionDataSerializer]
      */
     @SerialName("transaction_data")
-    override val transactionData: Set<@Contextual TransactionData>? = null,
+    override val transactionData: List<TransactionDataBase64Url>? = null,
 ) : RequestParameters {
 
     /**

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestObjectParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestObjectParameters.kt
@@ -3,7 +3,6 @@ package at.asitplus.openid
 import at.asitplus.KmmResult.Companion.wrap
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 
 /**
  * OpenID4VP: This request is (optionally) sent from the wallet when requesting the Request Object from the Verifier.
@@ -42,7 +41,7 @@ data class RequestObjectParameters(
     override val audience: String? = null
     override val issuer: String? = null
     override val state: String? = null
-    override val transactionData: Set<TransactionData>? = null
+    override val transactionData: List<TransactionDataBase64Url>? = null
 
     fun serialize() = odcJsonSerializer.encodeToString(this)
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParameters.kt
@@ -9,7 +9,7 @@ interface RequestParameters {
     val issuer: String?
     val audience: String?
     val state: String?
-    val transactionData: Set<TransactionData>?
+    val transactionData: List<TransactionDataBase64Url>?
 
     /**
      * Reads the [OpenIdConstants.ClientIdScheme] of this request either directly from [clientIdScheme],

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TransactionData.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TransactionData.kt
@@ -1,6 +1,19 @@
 package at.asitplus.openid
-import kotlinx.serialization.PolymorphicSerializer
+
 import kotlinx.serialization.ContextualSerializer
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.json.JsonPrimitive
+
+
+/**
+ * Denotes a JSON string containing a Base64Url encoded [TransactionData] element
+ * This is useful in classes defined in OpenID4VP since JSON string representation is not
+ * strongly standardized (normal vs pretty-print etc) so de-/serialization between
+ * different parties with different serializer settings may lead to erroneous
+ * request rejection.
+ */
+typealias TransactionDataBase64Url = JsonPrimitive
+
 
 /**
  * OID4VP Draft 24: OPTIONAL. Array of strings, where each string is a base64url encoded JSON object that contains a typed parameter
@@ -34,4 +47,6 @@ interface TransactionData {
      * `sha-256` hash algorithm.
      */
     val transactionDataHashAlgorithms: Set<String>?
+
+    fun toBase64UrlString(): TransactionDataBase64Url
 }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TransactionData.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TransactionData.kt
@@ -54,7 +54,7 @@ interface TransactionData {
      */
     val transactionDataHashAlgorithms: Set<String>?
 
-    fun toBase64UrlString(): TransactionDataBase64Url
+    fun toBase64UrlJsonString(): TransactionDataBase64Url
 
-    fun sha256(): ByteArray = toBase64UrlString().sha256()
+    fun sha256(): ByteArray = toBase64UrlJsonString().sha256()
 }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TransactionData.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TransactionData.kt
@@ -1,8 +1,12 @@
 package at.asitplus.openid
 
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import io.ktor.util.*
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import kotlinx.serialization.ContextualSerializer
 import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.json.JsonPrimitive
+import okio.ByteString.Companion.toByteString
 
 
 /**
@@ -14,6 +18,8 @@ import kotlinx.serialization.json.JsonPrimitive
  */
 typealias TransactionDataBase64Url = JsonPrimitive
 
+fun TransactionDataBase64Url.sha256(): ByteArray =
+    this.content.decodeToByteArray(Base64UrlStrict).toByteString().sha256().toByteArray()
 
 /**
  * OID4VP Draft 24: OPTIONAL. Array of strings, where each string is a base64url encoded JSON object that contains a typed parameter
@@ -49,4 +55,6 @@ interface TransactionData {
     val transactionDataHashAlgorithms: Set<String>?
 
     fun toBase64UrlString(): TransactionDataBase64Url
+
+    fun sha256(): ByteArray = toBase64UrlString().sha256()
 }

--- a/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/QesInputDescriptor.kt
+++ b/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/QesInputDescriptor.kt
@@ -4,7 +4,7 @@ import at.asitplus.dif.Constraint
 import at.asitplus.dif.FormatHolder
 import at.asitplus.dif.InputDescriptor
 import at.asitplus.openid.TransactionData
-import at.asitplus.rqes.serializers.DeprecatedBase64URLTransactionDataSerializer
+import at.asitplus.openid.TransactionDataBase64Url
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -24,7 +24,7 @@ data class QesInputDescriptor(
     override val constraints: Constraint? = null,
     @Deprecated("Obsoleted by OpenID4VP draft 23. Remove after UC5 piloting")
     @SerialName("transaction_data")
-    val transactionData: List<@Serializable(DeprecatedBase64URLTransactionDataSerializer::class) TransactionData>? = null,
+    val transactionData: List<TransactionDataBase64Url>? = null,
 ) : InputDescriptor {
 
     @Deprecated("To be replaced with groups, see #267")

--- a/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/SignatureRequestParameters.kt
+++ b/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/SignatureRequestParameters.kt
@@ -1,9 +1,6 @@
 package at.asitplus.rqes
 
-import at.asitplus.openid.OpenIdConstants
-import at.asitplus.openid.RequestParameters
-import at.asitplus.openid.SignatureQualifier
-import at.asitplus.openid.TransactionData
+import at.asitplus.openid.*
 import at.asitplus.rqes.collection_entries.DocumentLocation
 import at.asitplus.rqes.collection_entries.OAuthDocumentDigest
 import at.asitplus.signum.indispensable.Digest
@@ -135,7 +132,7 @@ data class SignatureRequestParameters(
      * data not conforming to the respective type definition.
      */
     @SerialName("transaction_data")
-    override val transactionData: Set<TransactionData>? = null,
+    override val transactionData: List<TransactionDataBase64Url>? = null,
 ) : RequestParameters {
 
     override val redirectUrl: String? = null

--- a/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/collection_entries/QCertCreationAcceptance.kt
+++ b/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/collection_entries/QCertCreationAcceptance.kt
@@ -1,11 +1,15 @@
 package at.asitplus.rqes.collection_entries
 
 import at.asitplus.openid.TransactionData
+import at.asitplus.rqes.rdcJsonSerializer
+import at.asitplus.rqes.serializers.DeprecatedBase64URLTransactionDataSerializer
 import at.asitplus.signum.indispensable.asn1.ObjectIdSerializer
 import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
 import at.asitplus.signum.indispensable.io.ByteArrayBase64Serializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * D3.1: UC Specification WP3:
@@ -77,6 +81,12 @@ data class QCertCreationAcceptance(
 
 ) : TransactionData {
 
+    override fun toBase64UrlString(): JsonPrimitive =
+        rdcJsonSerializer.parseToJsonElement(
+            rdcJsonSerializer.encodeToString(
+                DeprecatedBase64URLTransactionDataSerializer, this
+            )
+        ) as JsonPrimitive
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/collection_entries/QCertCreationAcceptance.kt
+++ b/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/collection_entries/QCertCreationAcceptance.kt
@@ -81,7 +81,7 @@ data class QCertCreationAcceptance(
 
 ) : TransactionData {
 
-    override fun toBase64UrlString(): JsonPrimitive =
+    override fun toBase64UrlJsonString(): JsonPrimitive =
         rdcJsonSerializer.parseToJsonElement(
             rdcJsonSerializer.encodeToString(
                 DeprecatedBase64URLTransactionDataSerializer, this

--- a/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/collection_entries/QesAuthorization.kt
+++ b/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/collection_entries/QesAuthorization.kt
@@ -4,9 +4,11 @@ import at.asitplus.KmmResult
 import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.openid.SignatureQualifier
 import at.asitplus.openid.TransactionData
-import at.asitplus.rqes.collection_entries.TransactionData.QesAuthorization
+import at.asitplus.rqes.rdcJsonSerializer
+import at.asitplus.rqes.serializers.DeprecatedBase64URLTransactionDataSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * D3.1: UC Specification WP3:
@@ -77,6 +79,14 @@ data class QesAuthorization(
     override val transactionDataHashAlgorithms: Set<String>? = null
 
 ) : TransactionData {
+
+    override fun toBase64UrlString(): JsonPrimitive =
+        rdcJsonSerializer.parseToJsonElement(
+            rdcJsonSerializer.encodeToString(
+                DeprecatedBase64URLTransactionDataSerializer, this
+            )
+        ) as JsonPrimitive
+
     /**
      * Validation according to D3.1: UC Specification WP3
      */
@@ -96,7 +106,7 @@ data class QesAuthorization(
             credentialIds: Set<String>? = null,
             transactionDataHashAlgorithms: Set<String>? = null,
         ): KmmResult<TransactionData> = runCatching {
-           QesAuthorization(
+            QesAuthorization(
                 signatureQualifier = signatureQualifier,
                 credentialID = credentialId,
                 credentialIds = credentialIds,

--- a/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/collection_entries/QesAuthorization.kt
+++ b/rqes-data-classes/src/commonMain/kotlin/at/asitplus/rqes/collection_entries/QesAuthorization.kt
@@ -80,7 +80,7 @@ data class QesAuthorization(
 
 ) : TransactionData {
 
-    override fun toBase64UrlString(): JsonPrimitive =
+    override fun toBase64UrlJsonString(): JsonPrimitive =
         rdcJsonSerializer.parseToJsonElement(
             rdcJsonSerializer.encodeToString(
                 DeprecatedBase64URLTransactionDataSerializer, this

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
@@ -11,6 +11,8 @@ import at.asitplus.signum.indispensable.josef.JwkType
 import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.jws.EncryptJweFun
 import at.asitplus.wallet.lib.jws.SignJwtFun
+import at.asitplus.wallet.lib.data.vckJsonSerializer
+import at.asitplus.wallet.lib.jws.JwsService
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidRequest
 import at.asitplus.wallet.lib.oidvci.encodeToParameters

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
@@ -2,8 +2,6 @@ package at.asitplus.wallet.lib.openid
 
 import at.asitplus.openid.*
 import at.asitplus.openid.OpenIdConstants.ResponseMode.*
-import at.asitplus.openid.RelyingPartyMetadata
-import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JweAlgorithm
 import at.asitplus.signum.indispensable.josef.JweHeader
@@ -11,15 +9,12 @@ import at.asitplus.signum.indispensable.josef.JwkType
 import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.jws.EncryptJweFun
 import at.asitplus.wallet.lib.jws.SignJwtFun
-import at.asitplus.wallet.lib.data.vckJsonSerializer
-import at.asitplus.wallet.lib.jws.JwsService
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidRequest
 import at.asitplus.wallet.lib.oidvci.encodeToParameters
 import at.asitplus.wallet.lib.oidvci.formUrlEncode
 import io.github.aakira.napier.Napier
 import io.ktor.http.*
-import kotlinx.serialization.builtins.serializer
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.random.Random
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -305,8 +305,8 @@ open class OpenId4VpVerifier(
         state = state,
         dcqlQuery = if (isDcql) toDCQLQuery() else null,
         presentationDefinition = if (isPresentationExchange)
-            toPresentationDefinition(containerJwt, containerSdJwt) else null,
-        transactionData = transactionData?.map { it.toBase64UrlString() }
+            toPresentationDefinition(containerJwt, containerSdJwt, rqesFlow) else null,
+        transactionData = if (rqesFlow != PresentationRequestParameters.Flow.UC5) transactionData?.map { it.toBase64UrlString() } else null
     )
 
     /**
@@ -461,7 +461,8 @@ open class OpenId4VpVerifier(
                         expectedNonce,
                         responseParameters,
                         authnRequest.clientId,
-                        authnRequest.responseUrl
+                        authnRequest.responseUrl,
+                        authnRequest.parseTransactionData()
                     )
                 }.getOrElse {
                     Napier.w("Invalid presentation format: $relatedPresentation", it)
@@ -489,7 +490,8 @@ open class OpenId4VpVerifier(
                     expectedNonce,
                     responseParameters,
                     authnRequest.clientId,
-                    authnRequest.responseUrl
+                    authnRequest.responseUrl,
+                    authnRequest.parseTransactionData()
                 ).mapToAuthnResponseResult(state)
             }
             return AuthnResponseResult.VerifiableDCQLPresentationValidationResults(presentation)
@@ -533,11 +535,13 @@ open class OpenId4VpVerifier(
         input: ResponseParametersFrom,
         clientId: String?,
         responseUrl: String?,
+        transactionData: Pair<PresentationRequestParameters.Flow, List<TransactionDataBase64Url>>?,
     ) = when (claimFormat) {
         ClaimFormat.JWT_SD, ClaimFormat.SD_JWT -> verifier.verifyPresentationSdJwt(
             input = SdJwtSigned.Companion.parse(relatedPresentation.jsonPrimitive.content)
                 ?: throw IllegalArgumentException("relatedPresentation"),
-            challenge = expectedNonce
+            challenge = expectedNonce,
+            transactionData = transactionData
         )
 
         ClaimFormat.JWT_VP -> verifier.verifyPresentationVcJwt(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -306,7 +306,7 @@ open class OpenId4VpVerifier(
         dcqlQuery = if (isDcql) toDCQLQuery() else null,
         presentationDefinition = if (isPresentationExchange)
             toPresentationDefinition(containerJwt, containerSdJwt) else null,
-        transactionData = transactionData
+        transactionData = transactionData?.map { it.toBase64UrlString() }
     )
 
     /**

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -306,7 +306,7 @@ open class OpenId4VpVerifier(
         dcqlQuery = if (isDcql) toDCQLQuery() else null,
         presentationDefinition = if (isPresentationExchange)
             toPresentationDefinition(containerJwt, containerSdJwt, rqesFlow) else null,
-        transactionData = if (rqesFlow != PresentationRequestParameters.Flow.UC5) transactionData?.map { it.toBase64UrlString() } else null
+        transactionData = if (rqesFlow != PresentationRequestParameters.Flow.UC5) transactionData?.map { it.toBase64UrlJsonString() } else null
     )
 
     /**

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestOptions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestOptions.kt
@@ -4,20 +4,17 @@ import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
 import at.asitplus.dif.*
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.jsonpath.core.NormalizedJsonPathSegment.NameSegment
-import at.asitplus.openid.AuthenticationRequestParameters
-import at.asitplus.openid.CredentialFormatEnum
-import at.asitplus.openid.OpenIdConstants
+import at.asitplus.openid.*
 import at.asitplus.openid.OpenIdConstants.SCOPE_OPENID
 import at.asitplus.openid.OpenIdConstants.SCOPE_PROFILE
 import at.asitplus.openid.OpenIdConstants.VP_TOKEN
-import at.asitplus.openid.TransactionData
 import at.asitplus.openid.dcql.*
-import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.*
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
 import at.asitplus.wallet.lib.data.ConstantIndex.supportsSdJwt
 import at.asitplus.wallet.lib.data.ConstantIndex.supportsVcJwt
 import com.benasher44.uuid.uuid4
-import io.ktor.http.quote
+import io.ktor.http.*
 
 typealias RequestedAttributes = Set<String>
 
@@ -77,7 +74,7 @@ interface RequestOptions {
     val isPresentationExchange
         get() = presentationMechanism == PresentationMechanismEnum.PresentationExchange
 
-    val transactionData: Set<TransactionData>?
+    val transactionData: List<TransactionData>?
 
     fun buildScope(): String = listOf(SCOPE_OPENID, SCOPE_PROFILE).joinToString(" ")
 
@@ -103,7 +100,7 @@ data class OpenIdRequestOptions(
     override val clientMetadataUrl: String? = null,
     override val encryption: Boolean = false,
     override val presentationMechanism: PresentationMechanismEnum = PresentationMechanismEnum.PresentationExchange,
-    override val transactionData: Set<TransactionData>? = null,
+    override val transactionData: List<TransactionData>? = null,
 ) : RequestOptions {
 
     override fun toDCQLQuery(): DCQLQuery? = if (credentials.isEmpty()) null else DCQLQuery(

--- a/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesOpenId4VpVerifier.kt
+++ b/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesOpenId4VpVerifier.kt
@@ -73,15 +73,17 @@ class RqesOpenId4VpVerifier(
 
         override fun toPresentationDefinition(
             containerJwt: FormatContainerJwt,
-            containerSdJwt: FormatContainerSdJwt
+            containerSdJwt: FormatContainerSdJwt,
+            flow: PresentationRequestParameters.Flow?
         ): PresentationDefinition = PresentationDefinition(
             id = uuid4().toString(),
-            inputDescriptors = this.toInputDescriptor(containerJwt, containerSdJwt)
+            inputDescriptors = this.toInputDescriptor(containerJwt, containerSdJwt, flow)
         )
 
         override fun toInputDescriptor(
             containerJwt: FormatContainerJwt,
             containerSdJwt: FormatContainerSdJwt,
+            flow: PresentationRequestParameters.Flow?
         ): List<InputDescriptor> = credentials.map { requestOptionCredential ->
             QesInputDescriptor(
                 id = requestOptionCredential.buildId(),

--- a/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesOpenId4VpVerifier.kt
+++ b/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesOpenId4VpVerifier.kt
@@ -13,12 +13,7 @@ import at.asitplus.wallet.lib.cbor.DefaultVerifierCoseService
 import at.asitplus.wallet.lib.cbor.VerifierCoseService
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKey
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKeyFun
-import at.asitplus.wallet.lib.jws.DefaultJwsService
-import at.asitplus.wallet.lib.jws.DefaultVerifierJwsService
-import at.asitplus.wallet.lib.jws.JwsService
-import at.asitplus.wallet.lib.jws.VerifierJwsService
-import at.asitplus.wallet.lib.jws.VerifyJwsObject
-import at.asitplus.wallet.lib.jws.VerifyJwsObjectFun
+import at.asitplus.wallet.lib.jws.*
 import at.asitplus.wallet.lib.oidvci.DefaultMapStore
 import at.asitplus.wallet.lib.oidvci.DefaultNonceService
 import at.asitplus.wallet.lib.oidvci.MapStore
@@ -33,7 +28,10 @@ import kotlinx.datetime.Clock
 /**
  * Verifier with access to [TransactionData] class can now generate requests containing [TransactionData]
  */
-@Deprecated("OpenId4VpVerifier can now access TransactionData, for RqesRequests use RqesRequestOptions", ReplaceWith("OpenId4VpVerifier"))
+@Deprecated(
+    "OpenId4VpVerifier can now access TransactionData, for RqesRequests use RqesRequestOptions",
+    ReplaceWith("OpenId4VpVerifier")
+)
 class RqesOpenId4VpVerifier(
     private val clientIdScheme: ClientIdScheme,
     private val keyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
@@ -89,7 +87,7 @@ class RqesOpenId4VpVerifier(
                 id = requestOptionCredential.buildId(),
                 format = requestOptionCredential.toFormatHolder(containerJwt, containerSdJwt),
                 constraints = requestOptionCredential.toConstraint(),
-                transactionData = transactionData?.toList()
+                transactionData = transactionData?.map { it.toBase64UrlString() }
             )
         }
     }

--- a/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesOpenId4VpVerifier.kt
+++ b/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesOpenId4VpVerifier.kt
@@ -89,7 +89,7 @@ class RqesOpenId4VpVerifier(
                 id = requestOptionCredential.buildId(),
                 format = requestOptionCredential.toFormatHolder(containerJwt, containerSdJwt),
                 constraints = requestOptionCredential.toConstraint(),
-                transactionData = transactionData?.map { it.toBase64UrlString() }
+                transactionData = transactionData?.map { it.toBase64UrlJsonString() }
             )
         }
     }

--- a/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesRequestOptions.kt
+++ b/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesRequestOptions.kt
@@ -43,7 +43,7 @@ data class RqesRequestOptions(
             format = requestOptionCredential.toFormatHolder(containerJwt, containerSdJwt),
             constraints = requestOptionCredential.toConstraint(),
             transactionData = if (flow != PresentationRequestParameters.Flow.OID4VP) transactionData?.mapNotNull { entry ->
-                entry.makeUC5compliant()?.toBase64UrlString()
+                entry.makeUC5compliant()?.toBase64UrlJsonString()
             } else null
         )
     }

--- a/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesRequestOptions.kt
+++ b/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesRequestOptions.kt
@@ -5,6 +5,7 @@ import at.asitplus.openid.TransactionData
 import at.asitplus.rqes.QesInputDescriptor
 import at.asitplus.rqes.collection_entries.QCertCreationAcceptance
 import at.asitplus.rqes.collection_entries.QesAuthorization
+import at.asitplus.wallet.lib.agent.PresentationRequestParameters
 import at.asitplus.wallet.lib.openid.OpenIdRequestOptions
 import at.asitplus.wallet.lib.openid.RequestOptions
 import com.benasher44.uuid.uuid4
@@ -18,30 +19,32 @@ data class RqesRequestOptions(
 ) : RequestOptions by baseRequestOptions {
 
     init {
-        val transactionIds = transactionData?.mapNotNull { it.credentialIds?.toList() }?.flatten()?.sorted()
-        val credentialIds = credentials.map { it.id }.sorted()
-        transactionIds?.let { require(it == credentialIds) { "OpenId4VP defines that the credential_ids that must be part of a transaction_data element has to be an ID from InputDescriptor" } }
+        val transactionIds = transactionData?.mapNotNull { it.credentialIds?.toList() }?.flatten()?.sorted()?.distinct()
+        val credentialIds = credentials.map { it.id }.sorted().distinct()
+        transactionIds?.let { require(it == credentialIds) { "OpenId4VP defines that the credential_ids that must be part of a transaction_data element have to be an ID from InputDescriptor" } }
     }
 
     override fun toPresentationDefinition(
         containerJwt: FormatContainerJwt,
-        containerSdJwt: FormatContainerSdJwt
+        containerSdJwt: FormatContainerSdJwt,
+        flow: PresentationRequestParameters.Flow?
     ): PresentationDefinition = PresentationDefinition(
         id = uuid4().toString(),
-        inputDescriptors = this.toInputDescriptor(containerJwt, containerSdJwt)
+        inputDescriptors = this.toInputDescriptor(containerJwt, containerSdJwt, flow)
     )
 
     override fun toInputDescriptor(
         containerJwt: FormatContainerJwt,
         containerSdJwt: FormatContainerSdJwt,
+        flow: PresentationRequestParameters.Flow?
     ): List<InputDescriptor> = credentials.map { requestOptionCredential ->
         QesInputDescriptor(
             id = requestOptionCredential.buildId(),
             format = requestOptionCredential.toFormatHolder(containerJwt, containerSdJwt),
             constraints = requestOptionCredential.toConstraint(),
-            transactionData = transactionData?.mapNotNull { entry ->
+            transactionData = if (flow != PresentationRequestParameters.Flow.OID4VP) transactionData?.mapNotNull { entry ->
                 entry.makeUC5compliant()?.toBase64UrlString()
-            }
+            } else null
         )
     }
 

--- a/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesRequestOptions.kt
+++ b/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesRequestOptions.kt
@@ -20,7 +20,7 @@ data class RqesRequestOptions(
     init {
         val transactionIds = transactionData?.mapNotNull { it.credentialIds?.toList() }?.flatten()?.sorted()
         val credentialIds = credentials.map { it.id }.sorted()
-        transactionIds?.let { require(it == credentialIds) {"OpenId4VP defines that the credential_ids that must be part of a transaction_data element has to be an ID from InputDescriptor"} }
+        transactionIds?.let { require(it == credentialIds) { "OpenId4VP defines that the credential_ids that must be part of a transaction_data element has to be an ID from InputDescriptor" } }
     }
 
     override fun toPresentationDefinition(
@@ -39,7 +39,9 @@ data class RqesRequestOptions(
             id = requestOptionCredential.buildId(),
             format = requestOptionCredential.toFormatHolder(containerJwt, containerSdJwt),
             constraints = requestOptionCredential.toConstraint(),
-            transactionData = transactionData?.mapNotNull { it.makeUC5compliant() }
+            transactionData = transactionData?.mapNotNull { entry ->
+                entry.makeUC5compliant()?.toBase64UrlString()
+            }
         )
     }
 

--- a/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/helper/OpenIdRqesParameters.kt
+++ b/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/helper/OpenIdRqesParameters.kt
@@ -7,6 +7,6 @@ import at.asitplus.openid.TransactionData
  */
 @Deprecated("Subsumed", ReplaceWith("RqesRequestOptions"))
 data class OpenIdRqesParameters(
-    val transactionData: Set<TransactionData>,
+    val transactionData: List<TransactionData>,
 )
 

--- a/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/DummyCredentialDataProvider.kt
+++ b/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/DummyCredentialDataProvider.kt
@@ -7,6 +7,7 @@ import at.asitplus.wallet.eupid.EuPidScheme
 import at.asitplus.wallet.lib.agent.ClaimToBeIssued
 import at.asitplus.wallet.lib.agent.CredentialToBeIssued
 import at.asitplus.wallet.lib.data.ConstantIndex
+import io.ktor.util.*
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlin.time.Duration.Companion.minutes
@@ -39,6 +40,7 @@ object DummyCredentialDataProvider {
                         optionalClaim(claimNames, GIVEN_NAME, givenName),
                         optionalClaim(claimNames, GIVEN_NAME_BIRTH, givenName),
                         optionalClaim(claimNames, BIRTH_DATE, birthDate),
+                        optionalClaim(claimNames, EuPidScheme.Attributes.BIRTH_DATE, birthDate), //incorrect encoding in german test vector?
                         optionalClaim(claimNames, AGE_EQUAL_OR_OVER_18, true),
                         optionalClaim(claimNames, NATIONALITIES, listOf(nationality)),
                         optionalClaim(claimNames, ISSUANCE_DATE, issuance),

--- a/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/KeyBindingTests.kt
+++ b/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/KeyBindingTests.kt
@@ -1,9 +1,12 @@
 package at.asitplus.wallet.lib.rqes
 
 import at.asitplus.openid.AuthenticationRequestParameters
+import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.contentEquals
 import at.asitplus.rqes.QesInputDescriptor
+import at.asitplus.rqes.collection_entries.QCertCreationAcceptance
 import at.asitplus.rqes.collection_entries.QesAuthorization
+import at.asitplus.signum.indispensable.Digest
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.wallet.eupid.EuPidScheme
 import at.asitplus.wallet.lib.agent.*
@@ -11,13 +14,14 @@ import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.iso.sha256
 import at.asitplus.wallet.lib.oidvci.DefaultMapStore
-import at.asitplus.wallet.lib.oidvci.MapStore
 import at.asitplus.wallet.lib.oidvci.encodeToParameters
 import at.asitplus.wallet.lib.openid.*
 import at.asitplus.wallet.lib.openid.OpenId4VpVerifier.CreationOptions.Query
+import com.benasher44.uuid.bytes
 import com.benasher44.uuid.uuid4
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -60,6 +64,14 @@ class KeyBindingTests : FreeSpec({
             clientIdScheme = ClientIdScheme.RedirectUri(clientId),
             stateToAuthnRequestStore = externalMapStore
         )
+
+        val cibaWalletTransactionData = """
+                    eyJ0eXBlIjoicWNlcnRfY3JlYXRpb25fYWNjZXB0YW5jZSIsImNyZWRlbnRpYWxfaWRzIjpbIjYwNzUxMGE5LWM5NTctNDA5NS05MDZkLWY5OWZkMDA2YzRhZSJdLCJRQ190ZXJtc19jb25kaXRpb25zX3VyaSI6Imh0dHBzOi8vd3d3LmQtdHJ1c3QubmV0L2RlL2FnYiIsIlFDX2hhc2giOiI3UXptNUVqdXpYS1NIRmxjME9IOVBQOXFVYUgtVkJsMmFHTmJ3WWoxb09BIiwiUUNfaGFzaEFsZ29yaXRobU9JRCI6IjIuMTYuODQwLjEuMTAxLjMuNC4yLjEiLCJ0cmFuc2FjdGlvbl9kYXRhX2hhc2hlc19hbGciOlsic2hhLTI1NiJdfQ
+                """.trimIndent()
+
+        val cibaWalletTestVector = """
+                {"response_type":"vp_token","client_id":"redirect_uri:$clientId","scope":"","state":"iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg","nonce":"f90d0982-52f4-4a1c-8525-bdf1d33c232b","client_metadata":{"jwks_uri":"https://cibawallet.local-ip.medicmobile.org/wallet/jarm/iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg/jwks.json","id_token_signed_response_alg":"RS256","authorization_encrypted_response_alg":"ECDH-ES","authorization_encrypted_response_enc":"A128CBC-HS256","id_token_encrypted_response_alg":"RSA-OAEP-256","id_token_encrypted_response_enc":"A128CBC-HS256","subject_syntax_types_supported":["urn:ietf:params:oauth:jwk-thumbprint"],"vp_formats":{"vc+sd-jwt":{"sd-jwt_alg_values":["ES256"],"kb-jwt_alg_values":["ES256"]},"dc+sd-jwt":{"sd-jwt_alg_values":["ES256"],"kb-jwt_alg_values":["ES256"]},"mso_mdoc":{"alg":["ES256"]}}},"presentation_definition":{"id":"4c7038cf-bd1e-47c0-8f70-eaf9d62c6fae","name":"Cibazmaj","purpose":"where su pare","input_descriptors":[{"id":"607510a9-c957-4095-906d-f99fd006c4ae","name":"niko kao","purpose":"hajduk iz splita","format":{"vc+sd-jwt":{"sd-jwt_alg_values":["ES256"],"kb-jwt_alg_values":["ES256"]}},"constraints":{"fields":[{"path":["${'$'}.family_name"]},{"path":["${'$'}.given_name"]},{"path":["${'$'}.birth_date"]},{"path":["${'$'}.vct"],"filter":{"type":"string","enum":["urn:eu.europa.ec.eudi:pid:1"]}}]}}]},"response_mode":"direct_post","response_uri":"https://cibawallet.local-ip.medicmobile.org/wallet/direct_post/iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg","aud":"https://self-issued.me/v2","iat":1744198186,"transaction_data":["eyJ0eXBlIjoicWNlcnRfY3JlYXRpb25fYWNjZXB0YW5jZSIsImNyZWRlbnRpYWxfaWRzIjpbIjYwNzUxMGE5LWM5NTctNDA5NS05MDZkLWY5OWZkMDA2YzRhZSJdLCJRQ190ZXJtc19jb25kaXRpb25zX3VyaSI6Imh0dHBzOi8vd3d3LmQtdHJ1c3QubmV0L2RlL2FnYiIsIlFDX2hhc2giOiI3UXptNUVqdXpYS1NIRmxjME9IOVBQOXFVYUgtVkJsMmFHTmJ3WWoxb09BIiwiUUNfaGFzaEFsZ29yaXRobU9JRCI6IjIuMTYuODQwLjEuMTAxLjMuNC4yLjEiLCJ0cmFuc2FjdGlvbl9kYXRhX2hhc2hlc19hbGciOlsic2hhLTI1NiJdfQ"]}
+            """.trimIndent()
 
         "KB-JWT contains transaction data" - {
             "OID4VP" {
@@ -117,7 +129,7 @@ class KeyBindingTests : FreeSpec({
                 }
                 with(result.sdJwtSigned.keyBindingJws.shouldNotBeNull().payload) {
                     transactionData.shouldNotBeNull()
-                    transactionData shouldBe originalTransactionData.map { it.toBase64UrlString() }
+                    transactionData shouldBe originalTransactionData.map { it.toBase64UrlJsonString() }
                     transactionDataHashes.shouldBeNull()
                     transactionDataHashesAlgorithm.shouldBeNull()
                 }
@@ -144,22 +156,75 @@ class KeyBindingTests : FreeSpec({
             }
         }
 
+        "Incorrect TransactionData is rejected" {
+            val requestOptions = buildRqesRequestOptions(null, OpenIdConstants.ResponseMode.DirectPost)
+            val authnRequest = rqesVerifier.createAuthnRequest(requestOptions)
+
+            val malignResponse =
+                holderOid4vp.createAuthnResponse(
+                    vckJsonSerializer.encodeToString(
+                        authnRequest.copy(
+                            transactionData = listOf(
+                                QCertCreationAcceptance(
+                                    qcTermsConditionsUri = uuid4().toString(),
+                                    qcHash = uuid4().bytes,
+                                    qcHashAlgorithmOid = Digest.SHA256.oid,
+                                ).toBase64UrlJsonString()
+                            )
+                        )
+                    )
+                ).getOrThrow()
+                    .shouldBeInstanceOf<AuthenticationResponseResult.Post>()
+
+            val result = rqesVerifier.validateAuthnResponse(malignResponse.params)
+            result.shouldBeInstanceOf<AuthnResponseResult.ValidationError>()
+        }
+
+        "Transaction Data validation can be turned off" {
+            val clientIdScheme = ClientIdScheme.RedirectUri(clientId)
+            val lenientVerifier = OpenId4VpVerifier(
+                keyMaterial = EphemeralKeyWithoutCert(),
+                clientIdScheme = clientIdScheme,
+                stateToAuthnRequestStore = externalMapStore,
+                verifier = VerifierAgent(identifier = clientIdScheme.clientId, validator = Validator(verifyTransactionData = false))
+            )
+
+            val requestOptions = buildRqesRequestOptions(null, OpenIdConstants.ResponseMode.DirectPost)
+            val authnRequest = lenientVerifier.createAuthnRequest(requestOptions)
+
+            val malignResponse =
+                holderOid4vp.createAuthnResponse(
+                    vckJsonSerializer.encodeToString(
+                        authnRequest.copy(
+                            transactionData = listOf(
+                                QCertCreationAcceptance(
+                                    qcTermsConditionsUri = uuid4().toString(),
+                                    qcHash = uuid4().bytes,
+                                    qcHashAlgorithmOid = Digest.SHA256.oid,
+                                ).toBase64UrlJsonString()
+                            )
+                        )
+                    )
+                ).getOrThrow()
+                    .shouldBeInstanceOf<AuthenticationResponseResult.Post>()
+
+            val result = lenientVerifier.validateAuthnResponse(malignResponse.params)
+            result.shouldBeInstanceOf<AuthnResponseResult.SuccessSdJwt>()
+        }
+
         "Hash of transaction data is not changed during processing" {
-            val germanTransactionDataOriginal = """
-                    eyJ0eXBlIjoicWNlcnRfY3JlYXRpb25fYWNjZXB0YW5jZSIsImNyZWRlbnRpYWxfaWRzIjpbIjYwNzUxMGE5LWM5NTctNDA5NS05MDZkLWY5OWZkMDA2YzRhZSJdLCJRQ190ZXJtc19jb25kaXRpb25zX3VyaSI6Imh0dHBzOi8vd3d3LmQtdHJ1c3QubmV0L2RlL2FnYiIsIlFDX2hhc2giOiI3UXptNUVqdXpYS1NIRmxjME9IOVBQOXFVYUgtVkJsMmFHTmJ3WWoxb09BIiwiUUNfaGFzaEFsZ29yaXRobU9JRCI6IjIuMTYuODQwLjEuMTAxLjMuNC4yLjEiLCJ0cmFuc2FjdGlvbl9kYXRhX2hhc2hlc19hbGciOlsic2hhLTI1NiJdfQ
-                """.trimIndent().replace("\n", "").replace("\r", "").replace(" ", "")
+            val referenceHash = cibaWalletTransactionData.decodeToByteArray(Base64UrlStrict).sha256()
 
-            val germanTestVector2 = """
-                {"response_type":"vp_token","client_id":"redirect_uri:$clientId","scope":"","state":"iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg","nonce":"f90d0982-52f4-4a1c-8525-bdf1d33c232b","client_metadata":{"jwks_uri":"https://cibawallet.local-ip.medicmobile.org/wallet/jarm/iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg/jwks.json","id_token_signed_response_alg":"RS256","authorization_encrypted_response_alg":"ECDH-ES","authorization_encrypted_response_enc":"A128CBC-HS256","id_token_encrypted_response_alg":"RSA-OAEP-256","id_token_encrypted_response_enc":"A128CBC-HS256","subject_syntax_types_supported":["urn:ietf:params:oauth:jwk-thumbprint"],"vp_formats":{"vc+sd-jwt":{"sd-jwt_alg_values":["ES256"],"kb-jwt_alg_values":["ES256"]},"dc+sd-jwt":{"sd-jwt_alg_values":["ES256"],"kb-jwt_alg_values":["ES256"]},"mso_mdoc":{"alg":["ES256"]}}},"presentation_definition":{"id":"4c7038cf-bd1e-47c0-8f70-eaf9d62c6fae","name":"Cibazmaj","purpose":"where su pare","input_descriptors":[{"id":"607510a9-c957-4095-906d-f99fd006c4ae","name":"niko kao","purpose":"hajduk iz splita","format":{"vc+sd-jwt":{"sd-jwt_alg_values":["ES256"],"kb-jwt_alg_values":["ES256"]}},"constraints":{"fields":[{"path":["${'$'}.family_name"]},{"path":["${'$'}.given_name"]},{"path":["${'$'}.birth_date"]},{"path":["${'$'}.vct"],"filter":{"type":"string","enum":["urn:eu.europa.ec.eudi:pid:1"]}}]}}]},"response_mode":"direct_post","response_uri":"https://cibawallet.local-ip.medicmobile.org/wallet/direct_post/iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg","aud":"https://self-issued.me/v2","iat":1744198186,"transaction_data":["eyJ0eXBlIjoicWNlcnRfY3JlYXRpb25fYWNjZXB0YW5jZSIsImNyZWRlbnRpYWxfaWRzIjpbIjYwNzUxMGE5LWM5NTctNDA5NS05MDZkLWY5OWZkMDA2YzRhZSJdLCJRQ190ZXJtc19jb25kaXRpb25zX3VyaSI6Imh0dHBzOi8vd3d3LmQtdHJ1c3QubmV0L2RlL2FnYiIsIlFDX2hhc2giOiI3UXptNUVqdXpYS1NIRmxjME9IOVBQOXFVYUgtVkJsMmFHTmJ3WWoxb09BIiwiUUNfaGFzaEFsZ29yaXRobU9JRCI6IjIuMTYuODQwLjEuMTAxLjMuNC4yLjEiLCJ0cmFuc2FjdGlvbl9kYXRhX2hhc2hlc19hbGciOlsic2hhLTI1NiJdfQ"]}
-            """.trimIndent()
+            val authenticationRequest =
+                holderOid4vp.parseAuthenticationRequestParameters(cibaWalletTestVector).getOrThrow()
+            authenticationRequest.parameters.transactionData.shouldNotBeEmpty().shouldNotBeNull()
 
+            externalMapStore.put(
+                "iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg",
+                authenticationRequest.parameters
+            )
 
-            val referenceHash = germanTransactionDataOriginal.decodeToByteArray(Base64UrlStrict).sha256()
-
-            val test2 = holderOid4vp.parseAuthenticationRequestParameters(germanTestVector2).getOrThrow()
-            externalMapStore.put("iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg", test2.parameters)
-
-            val authnResponse = holderOid4vp.createAuthnResponse(test2).getOrThrow()
+            val authnResponse = holderOid4vp.createAuthnResponse(authenticationRequest).getOrThrow()
             authnResponse shouldNotBe null
             authnResponse.shouldBeInstanceOf<AuthenticationResponseResult.Post>()
 

--- a/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/KeyBindingTests.kt
+++ b/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/KeyBindingTests.kt
@@ -1,0 +1,172 @@
+package at.asitplus.wallet.lib.rqes
+
+import at.asitplus.openid.AuthenticationRequestParameters
+import at.asitplus.openid.contentEquals
+import at.asitplus.rqes.QesInputDescriptor
+import at.asitplus.rqes.collection_entries.QesAuthorization
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import at.asitplus.wallet.eupid.EuPidScheme
+import at.asitplus.wallet.lib.agent.*
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
+import at.asitplus.wallet.lib.data.vckJsonSerializer
+import at.asitplus.wallet.lib.iso.sha256
+import at.asitplus.wallet.lib.oidvci.DefaultMapStore
+import at.asitplus.wallet.lib.oidvci.MapStore
+import at.asitplus.wallet.lib.oidvci.encodeToParameters
+import at.asitplus.wallet.lib.openid.*
+import at.asitplus.wallet.lib.openid.OpenId4VpVerifier.CreationOptions.Query
+import com.benasher44.uuid.uuid4
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.http.*
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
+
+class KeyBindingTests : FreeSpec({
+
+    lateinit var holderKeyMaterial: KeyMaterial
+    lateinit var holderAgent: Holder
+    lateinit var holderOid4vp: OpenId4VpHolder
+
+    val externalMapStore = DefaultMapStore<String, AuthenticationRequestParameters>()
+
+    beforeEach {
+        holderKeyMaterial = EphemeralKeyWithoutCert()
+        holderAgent = HolderAgent(holderKeyMaterial)
+
+        holderAgent.storeCredential(
+            IssuerAgent().issueCredential(
+                DummyCredentialDataProvider.getCredential(holderKeyMaterial.publicKey, EuPidScheme, SD_JWT)
+                    .getOrThrow()
+            ).getOrThrow().toStoreCredentialInput()
+        )
+
+        holderOid4vp = OpenId4VpHolder(
+            holder = holderAgent,
+        )
+
+    }
+
+    "Rqes Request with EU PID credential" - {
+        val walletUrl = "https://example.com/wallet/${uuid4()}"
+        val clientId = "https://example.com/rp/${uuid4()}"
+        val rqesVerifier = OpenId4VpVerifier(
+            keyMaterial = EphemeralKeyWithoutCert(),
+            clientIdScheme = ClientIdScheme.RedirectUri(clientId),
+            stateToAuthnRequestStore = externalMapStore
+        )
+
+        "KB-JWT contains transaction data" - {
+            "OID4VP" {
+                //[AuthenticationRequestParameters] do not contain [transactionData] in [presentationDefinition]
+                val requestOptions = buildRqesRequestOptions(PresentationRequestParameters.Flow.OID4VP)
+                val rawRequest = rqesVerifier.createAuthnRequest(requestOptions)
+                val newInputDescriptors = rawRequest.presentationDefinition!!.inputDescriptors.map {
+                    (it as QesInputDescriptor).copy(transactionData = null)
+                }
+                val authnRequest =
+                    rawRequest.copy(presentationDefinition = rawRequest.presentationDefinition!!.copy(inputDescriptors = newInputDescriptors))
+
+                val authnRequestUrl = URLBuilder(walletUrl).apply {
+                    authnRequest.encodeToParameters()
+                        .forEach { parameters.append(it.key, it.value) }
+                }.buildString()
+
+                authnRequestUrl shouldContain "transaction_data"
+
+                val authnResponse = holderOid4vp.createAuthnResponse(authnRequestUrl).getOrThrow()
+                    .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+
+                val result = rqesVerifier.validateAuthnResponse(authnResponse.url)
+                    .shouldBeInstanceOf<AuthnResponseResult.SuccessSdJwt>()
+
+                with(result.sdJwtSigned.keyBindingJws.shouldNotBeNull().payload) {
+                    transactionData.shouldBeNull()
+                    transactionDataHashes.shouldNotBeNull()
+                    transactionDataHashes.contentEquals(requestOptions.transactionData!!.getReferenceHashes())
+                    transactionDataHashesAlgorithm.shouldNotBeNull()
+                }
+            }
+
+            "UC5" {
+                //[AuthenticationRequestParameters] do not contain [transactionData] directly; only in [QesInputDescriptor]
+                val requestOptions = buildRqesRequestOptions(PresentationRequestParameters.Flow.UC5)
+                val authnRequest = rqesVerifier.createAuthnRequest(requestOptions)
+
+                val authnRequestUrl = URLBuilder(walletUrl).apply {
+                    authnRequest.encodeToParameters()
+                        .forEach { parameters.append(it.key, it.value) }
+                }.buildString()
+
+                val authnResponse = holderOid4vp.createAuthnResponse(authnRequestUrl).getOrThrow()
+                    .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+
+                val result = rqesVerifier.validateAuthnResponse(authnResponse.url)
+                    .shouldBeInstanceOf<AuthnResponseResult.SuccessSdJwt>()
+
+                val originalTransactionData = requestOptions.transactionData!!.map {
+                    (it as QesAuthorization).copy(
+                        transactionDataHashAlgorithms = null,
+                        credentialIds = null
+                    )
+                }
+                with(result.sdJwtSigned.keyBindingJws.shouldNotBeNull().payload) {
+                    transactionData.shouldNotBeNull()
+                    transactionData shouldBe originalTransactionData.map { it.toBase64UrlString() }
+                    transactionDataHashes.shouldBeNull()
+                    transactionDataHashesAlgorithm.shouldBeNull()
+                }
+            }
+
+            "Generic" {
+                //[AuthenticationRequestParameters] contain both versions - in this case for the response we prefer OID4VP
+                val requestOptions = buildRqesRequestOptions(null)
+                val authnRequestUrl = rqesVerifier.createAuthnRequest(requestOptions, Query(walletUrl)).getOrThrow().url
+
+                val authnResponse = holderOid4vp.createAuthnResponse(authnRequestUrl).getOrThrow()
+                    .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+
+                val result = rqesVerifier.validateAuthnResponse(authnResponse.url)
+                    .shouldBeInstanceOf<AuthnResponseResult.SuccessSdJwt>()
+
+                with(result.sdJwtSigned.keyBindingJws.shouldNotBeNull().payload) {
+                    transactionData.shouldBeNull()
+                    transactionDataHashes.shouldNotBeNull()
+                    transactionDataHashes!!.shouldHaveSize(2)
+                    transactionDataHashes.contentEquals(requestOptions.transactionData!!.getReferenceHashes())
+                    transactionDataHashesAlgorithm.shouldNotBeNull()
+                }
+            }
+        }
+
+        "Hash of transaction data is not changed during processing" {
+            val germanTransactionDataOriginal = """
+                    eyJ0eXBlIjoicWNlcnRfY3JlYXRpb25fYWNjZXB0YW5jZSIsImNyZWRlbnRpYWxfaWRzIjpbIjYwNzUxMGE5LWM5NTctNDA5NS05MDZkLWY5OWZkMDA2YzRhZSJdLCJRQ190ZXJtc19jb25kaXRpb25zX3VyaSI6Imh0dHBzOi8vd3d3LmQtdHJ1c3QubmV0L2RlL2FnYiIsIlFDX2hhc2giOiI3UXptNUVqdXpYS1NIRmxjME9IOVBQOXFVYUgtVkJsMmFHTmJ3WWoxb09BIiwiUUNfaGFzaEFsZ29yaXRobU9JRCI6IjIuMTYuODQwLjEuMTAxLjMuNC4yLjEiLCJ0cmFuc2FjdGlvbl9kYXRhX2hhc2hlc19hbGciOlsic2hhLTI1NiJdfQ
+                """.trimIndent().replace("\n", "").replace("\r", "").replace(" ", "")
+
+            val germanTestVector2 = """
+                {"response_type":"vp_token","client_id":"redirect_uri:$clientId","scope":"","state":"iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg","nonce":"f90d0982-52f4-4a1c-8525-bdf1d33c232b","client_metadata":{"jwks_uri":"https://cibawallet.local-ip.medicmobile.org/wallet/jarm/iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg/jwks.json","id_token_signed_response_alg":"RS256","authorization_encrypted_response_alg":"ECDH-ES","authorization_encrypted_response_enc":"A128CBC-HS256","id_token_encrypted_response_alg":"RSA-OAEP-256","id_token_encrypted_response_enc":"A128CBC-HS256","subject_syntax_types_supported":["urn:ietf:params:oauth:jwk-thumbprint"],"vp_formats":{"vc+sd-jwt":{"sd-jwt_alg_values":["ES256"],"kb-jwt_alg_values":["ES256"]},"dc+sd-jwt":{"sd-jwt_alg_values":["ES256"],"kb-jwt_alg_values":["ES256"]},"mso_mdoc":{"alg":["ES256"]}}},"presentation_definition":{"id":"4c7038cf-bd1e-47c0-8f70-eaf9d62c6fae","name":"Cibazmaj","purpose":"where su pare","input_descriptors":[{"id":"607510a9-c957-4095-906d-f99fd006c4ae","name":"niko kao","purpose":"hajduk iz splita","format":{"vc+sd-jwt":{"sd-jwt_alg_values":["ES256"],"kb-jwt_alg_values":["ES256"]}},"constraints":{"fields":[{"path":["${'$'}.family_name"]},{"path":["${'$'}.given_name"]},{"path":["${'$'}.birth_date"]},{"path":["${'$'}.vct"],"filter":{"type":"string","enum":["urn:eu.europa.ec.eudi:pid:1"]}}]}}]},"response_mode":"direct_post","response_uri":"https://cibawallet.local-ip.medicmobile.org/wallet/direct_post/iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg","aud":"https://self-issued.me/v2","iat":1744198186,"transaction_data":["eyJ0eXBlIjoicWNlcnRfY3JlYXRpb25fYWNjZXB0YW5jZSIsImNyZWRlbnRpYWxfaWRzIjpbIjYwNzUxMGE5LWM5NTctNDA5NS05MDZkLWY5OWZkMDA2YzRhZSJdLCJRQ190ZXJtc19jb25kaXRpb25zX3VyaSI6Imh0dHBzOi8vd3d3LmQtdHJ1c3QubmV0L2RlL2FnYiIsIlFDX2hhc2giOiI3UXptNUVqdXpYS1NIRmxjME9IOVBQOXFVYUgtVkJsMmFHTmJ3WWoxb09BIiwiUUNfaGFzaEFsZ29yaXRobU9JRCI6IjIuMTYuODQwLjEuMTAxLjMuNC4yLjEiLCJ0cmFuc2FjdGlvbl9kYXRhX2hhc2hlc19hbGciOlsic2hhLTI1NiJdfQ"]}
+            """.trimIndent()
+
+
+            val referenceHash = germanTransactionDataOriginal.decodeToByteArray(Base64UrlStrict).sha256()
+
+            val test2 = holderOid4vp.parseAuthenticationRequestParameters(germanTestVector2).getOrThrow()
+            externalMapStore.put("iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg", test2.parameters)
+
+            val authnResponse = holderOid4vp.createAuthnResponse(test2).getOrThrow()
+            authnResponse shouldNotBe null
+            authnResponse.shouldBeInstanceOf<AuthenticationResponseResult.Post>()
+
+            val result = rqesVerifier.validateAuthnResponse(authnResponse.params)
+            result.shouldBeInstanceOf<AuthnResponseResult.SuccessSdJwt>()
+            result.sdJwtSigned.keyBindingJws.shouldNotBeNull().payload.transactionDataHashes!!.first()
+                .contentEquals(referenceHash)
+        }
+    }
+})

--- a/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/TransactionDataInterop.kt
+++ b/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/TransactionDataInterop.kt
@@ -96,7 +96,7 @@ class TransactionDataInterop : FreeSpec({
         val input = QesInputDescriptor(
             id = "123",
             transactionData = listOf(
-                transactionDataTest.toBase64UrlString()
+                transactionDataTest.toBase64UrlJsonString()
             )
         )
         val serialized = vckJsonSerializer.encodeToString(input)

--- a/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/TransactionDataInterop.kt
+++ b/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/TransactionDataInterop.kt
@@ -67,9 +67,7 @@ class TransactionDataInterop : FreeSpec({
     """.trimIndent().replace("\n", "").replace("\r", "").replace(" ", "")
 
     val transactionDataTest = QCertCreationAcceptance(
-        qcTermsConditionsUri = "abc",
-        qcHash = "cde".decodeBase64Bytes(),
-        qcHashAlgorithmOid = sha_256
+        qcTermsConditionsUri = "abc", qcHash = "cde".decodeBase64Bytes(), qcHashAlgorithmOid = sha_256
     )
 
     "Polymorphic Serialization is stable" {
@@ -82,8 +80,7 @@ class TransactionDataInterop : FreeSpec({
 
     "Base64Url Serialization is stable" {
         val encoded = vckJsonSerializer.encodeToString(Base64URLTransactionDataSerializer, transactionDataTest)
-        vckJsonSerializer.decodeFromString(Base64URLTransactionDataSerializer, encoded)
-            .shouldBe(transactionDataTest)
+        vckJsonSerializer.decodeFromString(Base64URLTransactionDataSerializer, encoded).shouldBe(transactionDataTest)
     }
 
     "Backwards compatible with escaped Json" {
@@ -104,33 +101,27 @@ class TransactionDataInterop : FreeSpec({
         )
         val serialized = vckJsonSerializer.encodeToString(input)
         serialized.shouldNotContain("type")
-        vckJsonSerializer.decodeFromString(PolymorphicSerializer(InputDescriptor::class), serialized)
-            .shouldBe(input)
+        vckJsonSerializer.decodeFromString(PolymorphicSerializer(InputDescriptor::class), serialized).shouldBe(input)
     }
 
     "DifInputDescriptor Sanity Check" {
-        val input = DifInputDescriptor(
-            id = "123"
-        )
+        val input = DifInputDescriptor(id = "123")
         val serialized = vckJsonSerializer.encodeToString(input)
         serialized.shouldNotContain("type")
-        vckJsonSerializer.decodeFromString(PolymorphicSerializer(InputDescriptor::class), serialized)
-            .shouldBe(input)
+        vckJsonSerializer.decodeFromString(PolymorphicSerializer(InputDescriptor::class), serialized).shouldBe(input)
     }
 
     "QesAuthorization can be parsed" - {
         val testVector =
             "ewogICJ0eXBlIjogInFlc19hdXRob3JpemF0aW9uIiwKICAic2lnbmF0dXJlUXVhbGlmaWVyIjogImV1X2VpZGFzX3FlcyIsCiAgImNyZWRlbnRpYWxJRCI6ICJvRW92QzJFSEZpRUZyRHBVeDhtUjBvN3llR0hrMmg3NGIzWHl3a05nQkdvPSIsCiAgImRvY3VtZW50RGlnZXN0cyI6IFsKICAgIHsKICAgICAgImxhYmVsIjogIkV4YW1wbGUgQ29udHJhY3QiLAogICAgICAiaGFzaCI6ICJzVE9nd09tKzQ3NGdGajBxMHgxaVNOc3BLcWJjc2U0SWVpcWxEZy9IV3VJPSIsCiAgICAgICJoYXNoQWxnb3JpdGhtT0lEIjogIjIuMTYuODQwLjEuMTAxLjMuNC4yLjEiLAogICAgICAiZG9jdW1lbnRMb2NhdGlvbl91cmkiOiAiaHR0cHM6Ly9wcm90ZWN0ZWQucnAuZXhhbXBsZS9jb250cmFjdC0wMS5wZGY/dG9rZW49SFM5bmFKS1d3cDkwMWhCY0szNDhJVUhpdUg4Mzc0IiwKICAgICAgImRvY3VtZW50TG9jYXRpb25fbWV0aG9kIjogewogICAgICAgICJkb2N1bWVudF9hY2Nlc3NfbW9kZSI6ICJPVFAiLAogICAgICAgICJvbmVUaW1lUGFzc3dvcmQiOiAibXlGaXJzdFBhc3N3b3JkIgogICAgICB9LAogICAgICAiRFRCUy9SIjogIlZZRGw0b1RlSjVUbUlQQ1hLZFRYMU1TV1JMSTlDS1ljeU1SejZ4bGFHZyIsCiAgICAgICJEVEJTL1JIYXNoQWxnb3JpdGhtT0lEIjogIjIuMTYuODQwLjEuMTAxLjMuNC4yLjEiCiAgICB9CiAgXSwKICAicHJvY2Vzc0lEIjogImVPWjZVd1h5ZUZMSzk4RG81MXgzM2ZtdXY0T3FBejVaYzRsc2hLTnRFZ1E9Igp9"
         val transactionData = vckJsonSerializer.decodeFromString(
-            Base64URLTransactionDataSerializer,
-            vckJsonSerializer.encodeToString(testVector)
+            Base64URLTransactionDataSerializer, vckJsonSerializer.encodeToString(testVector)
         )
 
         "Data classes are deserialized correctly" {
             transactionData.shouldBeInstanceOf<QesAuthorization>()
             transactionData.documentDigests shouldNotBe emptyList<RqesDocumentDigestEntry>()
             transactionData.documentDigests.first().documentLocationMethod shouldNotBe null
-            @Suppress("DEPRECATION")
             transactionData.documentDigests.first().documentLocationMethod!!.documentAccessMode shouldBe RqesDocumentDigestEntry.DocumentLocationMethod.DocumentAccessMode.OTP
             transactionData.documentDigests.first().documentLocationMethod!!.oneTimePassword shouldNotBe null
         }
@@ -177,8 +168,7 @@ class TransactionDataInterop : FreeSpec({
             "ewogICJ0eXBlIjogInFjZXJ0X2NyZWF0aW9uX2FjY2VwdGFuY2UiLAogICJRQ190ZXJtc19jb25kaXRpb25zX3VyaSI6ICJodHRwczovL2V4YW1wbGUuY29tL3RvcyIsCiAgIlFDX2hhc2giOiAia1hBZ3dEY2RBZTNvYnhwbzhVb0RrQytEK2I3T0NyRG84SU9HWmpTWDgvTT0iLAogICJRQ19oYXNoQWxnb3JpdGhtT0lEIjogIjIuMTYuODQwLjEuMTAxLjMuNC4yLjEiCn0="
 
         val transactionData = vckJsonSerializer.decodeFromString(
-            Base64URLTransactionDataSerializer,
-            vckJsonSerializer.encodeToString(testVector)
+            Base64URLTransactionDataSerializer, vckJsonSerializer.encodeToString(testVector)
         )
         "Data classes are deserialized correctly" {
             transactionData.shouldBeInstanceOf<QCertCreationAcceptance>()
@@ -190,16 +180,14 @@ class TransactionDataInterop : FreeSpec({
             ).canonicalize()
 
             vckJsonSerializer.encodeToJsonElement(PolymorphicSerializer(TransactionData::class), transactionData)
-                .canonicalize()
-                .shouldBe(expected)
+                .canonicalize().shouldBe(expected)
         }
     }
 
     "The presentation Definition can be parsed" {
         val presentationDefinition =
             vckJsonSerializer.decodeFromString<PresentationDefinition>(presentationDefinitionAsJsonString)
-        val first = presentationDefinition.inputDescriptors.first()
-            .shouldBeInstanceOf<QesInputDescriptor>()
+        val first = presentationDefinition.inputDescriptors.first().shouldBeInstanceOf<QesInputDescriptor>()
         first.transactionData shouldNotBe null
     }
 })
@@ -207,12 +195,11 @@ class TransactionDataInterop : FreeSpec({
 /**
  * Sorts all entries of the JsonElement which is necessary in case we want to compare two objects
  */
-fun JsonElement.canonicalize(serializer: Json = vckJsonSerializer): JsonElement =
-    when (this) {
-        is JsonObject -> JsonObject(this.entries.sortedBy { it.key }
-            .sortedBy { serializer.encodeToString(it.value) }.associate { it.key to it.value.canonicalize(serializer) })
+fun JsonElement.canonicalize(serializer: Json = vckJsonSerializer): JsonElement = when (this) {
+    is JsonObject -> JsonObject(this.entries.sortedBy { it.key }.sortedBy { serializer.encodeToString(it.value) }
+        .associate { it.key to it.value.canonicalize(serializer) })
 
-        is JsonArray -> JsonArray(this.map { it.canonicalize() }.sortedBy { serializer.encodeToString(it) })
-        is JsonPrimitive -> this
-        JsonNull -> this
-    }
+    is JsonArray -> JsonArray(this.map { it.canonicalize() }.sortedBy { serializer.encodeToString(it) })
+    is JsonPrimitive -> this
+    JsonNull -> this
+}

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationDataClasses.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationDataClasses.kt
@@ -5,13 +5,12 @@ import at.asitplus.dif.ConstraintField
 import at.asitplus.dif.PresentationSubmission
 import at.asitplus.jsonpath.core.NodeList
 import at.asitplus.jsonpath.core.NormalizedJsonPath
-import at.asitplus.openid.TransactionData
+import at.asitplus.openid.TransactionDataBase64Url
 import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
 import at.asitplus.signum.indispensable.cosef.CoseSigned
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.JwsSigned
-import at.asitplus.wallet.lib.data.DeprecatedBase64URLTransactionDataSerializer
 import at.asitplus.wallet.lib.data.VerifiablePresentationJws
 import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.iso.DeviceNameSpaces
@@ -36,7 +35,7 @@ import kotlinx.serialization.json.buildJsonObject
 data class PresentationRequestParameters(
     val nonce: String,
     val audience: String,
-    val transactionData: Pair<Flow, Collection<TransactionData>>? = null,
+    val transactionData: Pair<Flow, Collection<TransactionDataBase64Url>>? = null,
     /**
      * Handle calculating device signature for ISO mDocs, as this depends on the transport protocol
      * (OpenID4VP with ISO/IEC 18013-7)
@@ -56,14 +55,9 @@ data class PresentationRequestParameters(
         UC5
     }
 
-    internal fun getTransactionDataHashes(): Set<ByteArray>? = transactionData?.second?.map {
-        (vckJsonSerializer.encodeToJsonElement(
-            DeprecatedBase64URLTransactionDataSerializer,
-            it
-        ) as JsonPrimitive).content.decodeToByteArray(
-            Base64UrlStrict
-        ).sha256()
-    }?.toSet()
+    internal fun getTransactionDataHashes(): List<ByteArray>? = transactionData?.second?.map {
+        it.content.decodeToByteArray(Base64UrlStrict).sha256()
+    }
 }
 
 sealed interface PresentationResponseParameters {

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationDataClasses.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationDataClasses.kt
@@ -35,7 +35,7 @@ import kotlinx.serialization.json.buildJsonObject
 data class PresentationRequestParameters(
     val nonce: String,
     val audience: String,
-    val transactionData: Pair<Flow, Collection<TransactionDataBase64Url>>? = null,
+    val transactionData: Pair<Flow, List<TransactionDataBase64Url>>? = null,
     /**
      * Handle calculating device signature for ISO mDocs, as this depends on the transport protocol
      * (OpenID4VP with ISO/IEC 18013-7)
@@ -53,10 +53,6 @@ data class PresentationRequestParameters(
     enum class Flow {
         OID4VP,
         UC5
-    }
-
-    internal fun getTransactionDataHashes(): List<ByteArray>? = transactionData?.second?.map {
-        it.content.decodeToByteArray(Base64UrlStrict).sha256()
     }
 }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationDataClasses.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationDataClasses.kt
@@ -7,6 +7,7 @@ import at.asitplus.jsonpath.core.NodeList
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.openid.TransactionDataBase64Url
 import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
+import at.asitplus.openid.sha256
 import at.asitplus.signum.indispensable.cosef.CoseSigned
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
@@ -46,6 +47,9 @@ data class PresentationRequestParameters(
     /** mdocGeneratedNonce to be used for the presentation and [calcIsoDeviceSignature] (OpenID4VP with ISO/IEC 18013-7) */
     val mdocGeneratedNonce: String? = null,
 ) {
+
+    fun getTransactionDataHashes() =
+        transactionData?.second?.map { it.sha256() }
     /**
      * Used to differentiate between the OID4VP and the UC5 transaction data flows
      * since they are not compatible

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -6,7 +6,6 @@ import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
 import at.asitplus.openid.dcql.DCQLClaimsQueryResult
 import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult
-import at.asitplus.openid.sha256
 import at.asitplus.openid.third_party.at.asitplus.jsonpath.core.plus
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.signum.indispensable.josef.JwsSigned

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -6,6 +6,7 @@ import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
 import at.asitplus.openid.dcql.DCQLClaimsQueryResult
 import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult
+import at.asitplus.openid.sha256
 import at.asitplus.openid.third_party.at.asitplus.jsonpath.core.plus
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.signum.indispensable.josef.JwsSigned

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.lib.agent
 
+import at.asitplus.openid.TransactionDataBase64Url
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.signum.indispensable.josef.jwkId
@@ -26,6 +27,7 @@ interface Verifier {
     suspend fun verifyPresentationSdJwt(
         input: SdJwtSigned,
         challenge: String,
+        transactionData: Pair<PresentationRequestParameters.Flow, List<TransactionDataBase64Url>>? = null,
     ): VerifyPresentationResult
 
     /**

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifierAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifierAgent.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.lib.agent
 
+import at.asitplus.openid.TransactionDataBase64Url
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.wallet.lib.agent.Verifier.VerifyPresentationResult
 import at.asitplus.wallet.lib.data.VerifiablePresentationJws
@@ -24,8 +25,9 @@ class VerifierAgent(
     override suspend fun verifyPresentationSdJwt(
         input: SdJwtSigned,
         challenge: String,
+        transactionData: Pair<PresentationRequestParameters.Flow, List<TransactionDataBase64Url>>?,
     ): VerifyPresentationResult = runCatching {
-        validator.verifyVpSdJwt(input, challenge, identifier)
+        validator.verifyVpSdJwt(input, challenge, identifier, transactionData)
     }.getOrElse {
         VerifyPresentationResult.ValidationError(it)
     }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/Base64URLTransactionDataSerializer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/Base64URLTransactionDataSerializer.kt
@@ -1,6 +1,7 @@
 package at.asitplus.wallet.lib.data
 
 import at.asitplus.openid.TransactionData
+import at.asitplus.openid.TransactionDataBase64Url
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
@@ -12,6 +13,10 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonElement
+
+@Suppress("Unused")
+fun TransactionDataBase64Url.toDataclass() =
+    vckJsonSerializer.decodeFromJsonElement(DeprecatedBase64URLTransactionDataSerializer, this)
 
 /**
  * According to "Transaction Data entries as defined in D3.1: UC Specification WP3" the encoding
@@ -35,7 +40,10 @@ object Base64URLTransactionDataSerializer : KSerializer<TransactionData> {
     }
 }
 
-@Deprecated("Will be removed, only for backwards compatability", replaceWith = ReplaceWith("Base64URLTransactionDataSerializer"))
+@Deprecated(
+    "Will be removed, only for backwards compatability",
+    replaceWith = ReplaceWith("Base64URLTransactionDataSerializer")
+)
 object DeprecatedBase64URLTransactionDataSerializer : KSerializer<TransactionData> {
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("Base64URLTransactionDataSerializer", PrimitiveKind.STRING)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/Base64URLTransactionDataSerializer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/Base64URLTransactionDataSerializer.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonElement
 
 @Suppress("Unused")
-fun TransactionDataBase64Url.toDataclass() =
+fun TransactionDataBase64Url.toTransactionData() =
     vckJsonSerializer.decodeFromJsonElement(DeprecatedBase64URLTransactionDataSerializer, this)
 
 /**

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/KeyBindingJws.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/KeyBindingJws.kt
@@ -38,7 +38,7 @@ data class KeyBindingJws(
      */
     @Deprecated("Remove as soon as UC5 Specification catches up to OIDVP draft 23")
     @SerialName("transaction_data")
-    val transactionData: Collection<TransactionDataBase64Url>? = null,
+    val transactionData: List<TransactionDataBase64Url>? = null,
 
     /**
      * OID4VP: Array of hashes, where each hash is calculated using a hash function over the strings received in the

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/KeyBindingJws.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/KeyBindingJws.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.data
 
 import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.openid.TransactionData
+import at.asitplus.openid.TransactionDataBase64Url
 import at.asitplus.signum.indispensable.contentEqualsIfArray
 import at.asitplus.signum.indispensable.contentHashCodeIfArray
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
@@ -37,7 +38,7 @@ data class KeyBindingJws(
      */
     @Deprecated("Remove as soon as UC5 Specification catches up to OIDVP draft 23")
     @SerialName("transaction_data")
-    val transactionData: Collection<@Contextual TransactionData>? = null,
+    val transactionData: Collection<TransactionDataBase64Url>? = null,
 
     /**
      * OID4VP: Array of hashes, where each hash is calculated using a hash function over the strings received in the
@@ -45,7 +46,7 @@ data class KeyBindingJws(
      * of, and maps to, the respective transaction data object.
      */
     @SerialName("transaction_data_hashes")
-    val transactionDataHashes: Set<@Serializable(ByteArrayBase64UrlSerializer::class) ByteArray>? = null,
+    val transactionDataHashes: List<@Serializable(ByteArrayBase64UrlSerializer::class) ByteArray>? = null,
 
     /**
      * OID4VP: REQUIRED when this parameter was present in the `transaction_data` request parameter. String representing


### PR DESCRIPTION
Addresses the following bugs/shortcomings concerning verification of transaction data as in UC5 or OID4VP encountered during cross-border testing:
- Change transaction data and related data elements from set to list in order to impose a strict order (UC5 and OID4VP)
- Change transaction data elements from their class to JsonPrimitive as de-/encoding from and to Json is not perfectly stable (consider normal vs pretty-print, encoded default values or not etc) (UC5 and OID4VP)
- Add `TransactionDataBase64Uri` typealias for JsonPrimitive. We do not store the transaction data as string as otherwise this leads to escaped strings in nested structures.
- Add transaction data verification to `OpenID4VpVerifier.validateAuthnResponse`. If transaction data contains valid OID4VP transaction data instances then we only verify these. If none are present we assume all remaining entries are UC5 compliant and are verified as described in the relevant spec.

Test vectors have been extended to now contain two instead of one transaction data entry to check the order requirement and a modified test vector which uses different encoding for transaction data to make sure we do not reject valid requests based on representation.