### PR TITLE
Fun interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Release 5.7.0:
    - Replace `keyPair` with `keyMaterial`
  - Functions:
    - Replace type aliases with functional interfaces (providing named parameters in implementations)
+   - Make cryptographic verification functions suspending
  - Fully integrated crypto functionality based on Signum 3.16.1. This carries over breaking changes:
    - All debug-only kotlinx.serialization for cryptographic datatypes like certificates, public keys, etc. was removed
    - This finally cleans up the RSAorHMAC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Release 5.7.0:
    - Remove code elements deprecated in `5.6.0`
  - Holder:
    - Replace `keyPair` with `keyMaterial`
+ - Functions:
+   - Replace type aliases with functional interfaces (providing named parameters in implementations)
  - Fully integrated crypto functionality based on Signum 3.16.1. This carries over breaking changes:
    - All debug-only kotlinx.serialization for cryptographic datatypes like certificates, public keys, etc. was removed
    - This finally cleans up the RSAorHMAC

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialAuthorizationServiceStrategy.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialAuthorizationServiceStrategy.kt
@@ -1,6 +1,5 @@
 package at.asitplus.wallet.lib.oidvci
 
-import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.AuthorizationDetails
 import at.asitplus.openid.OpenIdAuthorizationDetails
 import at.asitplus.wallet.lib.data.ConstantIndex
@@ -79,6 +78,3 @@ fun OpenIdAuthorizationDetails.matches(other: OpenIdAuthorizationDetails): Boole
     else -> false
 }
 
-private fun emptyDataProvider(): OAuth2DataProvider = object : OAuth2DataProvider {
-    override suspend fun loadUserInfo(request: AuthenticationRequestParameters, code: String) = null
-}

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -592,7 +592,7 @@ open class OpenId4VpVerifier(
         clientId: String?,
         responseUrl: String?,
         expectedNonce: String,
-    ): (MobileSecurityObject, Document) -> Boolean = { mso, document ->
+    ): suspend (MobileSecurityObject, Document) -> Boolean = { mso, document ->
         Napier.d("verifyDocument: mdocGeneratedNonce='$mdocGeneratedNonce', clientId='$clientId', responseUrl='$responseUrl', expectedNonce='$expectedNonce'")
         val deviceSignature = document.deviceSigned.deviceAuth.deviceSignature ?: run {
             Napier.w("DeviceSignature is null: ${document.deviceSigned.deviceAuth}")
@@ -694,7 +694,7 @@ private val PresentationSubmissionDescriptor.cumulativeJsonPath: String
 
 
 class JwsHeaderClientIdScheme(val clientIdScheme: ClientIdScheme) : JwsHeaderIdentifierFun {
-    override suspend fun invoke(
+    override suspend operator fun invoke(
         it: JwsHeader,
         keyMaterial: KeyMaterial,
     ) = run {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/PresentationFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/PresentationFactory.kt
@@ -20,6 +20,7 @@ import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.wallet.lib.agent.*
 import at.asitplus.wallet.lib.cbor.SignCoseFun
 import at.asitplus.wallet.lib.agent.PresentationRequestParameters.Flow
+import at.asitplus.wallet.lib.cbor.SignCoseDetachedFun
 import at.asitplus.wallet.lib.data.CredentialPresentation
 import at.asitplus.wallet.lib.data.DeprecatedBase64URLTransactionDataSerializer
 import at.asitplus.wallet.lib.data.dif.PresentationSubmissionValidator
@@ -43,7 +44,7 @@ import kotlin.time.Duration.Companion.seconds
 
 internal class PresentationFactory(
     private val supportedAlgorithms: Set<JwsAlgorithm>,
-    private val signDeviceAuthDetached: SignCoseFun<ByteArray>,
+    private val signDeviceAuthDetached: SignCoseDetachedFun<ByteArray>,
     private val signDeviceAuthFallback: SignCoseFun<ByteArray>,
     private val signIdToken: SignJwtFun<IdToken>,
 ) {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/PresentationFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/PresentationFactory.kt
@@ -119,13 +119,23 @@ internal class PresentationFactory(
                 .wrapInCborTag(24)
                 .also { Napier.d("Device authentication signature input is ${it.encodeToString(Base16())}") }
 
-            signDeviceAuthDetached(null, null, deviceAuthenticationBytes, ByteArraySerializer()).getOrElse {
+            signDeviceAuthDetached(
+                protectedHeader = null,
+                unprotectedHeader = null,
+                payload = deviceAuthenticationBytes,
+                serializer = ByteArraySerializer()
+            ).getOrElse {
                 Napier.w("Could not create DeviceAuth for presentation", it)
                 throw PresentationException(it)
             }
         }
     } else {
-        signDeviceAuthFallback(null, null, nonce.encodeToByteArray(), ByteArraySerializer()).getOrElse {
+        signDeviceAuthFallback(
+            protectedHeader = null,
+            unprotectedHeader = null,
+            payload = nonce.encodeToByteArray(),
+            serializer = ByteArraySerializer()
+        ).getOrElse {
             Napier.w("Could not create DeviceAuth for presentation", it)
             throw PresentationException(it)
         }
@@ -304,7 +314,7 @@ internal fun RequestParameters.parseTransactionData(): Pair<Flow, List<Transacti
         .ifEmpty { return null }
 
     //Do not change to map because keys are unordered!
-    val oid4vpTransactionData: List<Pair<JsonPrimitive,TransactionData>> = rawTransactionData.map {
+    val oid4vpTransactionData: List<Pair<JsonPrimitive, TransactionData>> = rawTransactionData.map {
         it to vckJsonSerializer.decodeFromJsonElement(DeprecatedBase64URLTransactionDataSerializer, it)
     }.filter { it.second.credentialIds != null }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CryptoService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CryptoService.kt
@@ -11,7 +11,7 @@ import at.asitplus.signum.supreme.sign.Verifier
 import at.asitplus.signum.supreme.sign.verifierFor
 
 fun interface VerifySignatureFun {
-    operator fun invoke(
+    suspend operator fun invoke(
         input: ByteArray,
         signature: CryptoSignature,
         algorithm: SignatureAlgorithm,
@@ -20,12 +20,12 @@ fun interface VerifySignatureFun {
 }
 
 class VerifySignature() : VerifySignatureFun {
-    override fun invoke(
+    override suspend operator fun invoke(
         input: ByteArray,
         signature: CryptoSignature,
         algorithm: SignatureAlgorithm,
-        publicKey: CryptoPublicKey,
-    ) = algorithm.verifierFor(publicKey).transform {
+        publicKey: CryptoPublicKey
+    ): KmmResult<Verifier.Success> = algorithm.verifierFor(publicKey).transform {
         it.verify(SignatureInput(input), signature)
     }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CryptoService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CryptoService.kt
@@ -10,17 +10,22 @@ import at.asitplus.signum.supreme.sign.SignatureInput
 import at.asitplus.signum.supreme.sign.Verifier
 import at.asitplus.signum.supreme.sign.verifierFor
 
-typealias VerifySignatureFun = (
-    input: ByteArray,
-    signature: CryptoSignature,
-    algorithm: SignatureAlgorithm,
-    publicKey: CryptoPublicKey,
-) -> KmmResult<Verifier.Success>
+fun interface VerifySignatureFun {
+    operator fun invoke(
+        input: ByteArray,
+        signature: CryptoSignature,
+        algorithm: SignatureAlgorithm,
+        publicKey: CryptoPublicKey,
+    ): KmmResult<Verifier.Success>
+}
 
-object VerifySignature {
-    operator fun invoke(): VerifySignatureFun = { input, signature, algorithm, publicKey ->
-        algorithm.verifierFor(publicKey).transform {
-            it.verify(SignatureInput(input), signature)
-        }
+class VerifySignature() : VerifySignatureFun {
+    override fun invoke(
+        input: ByteArray,
+        signature: CryptoSignature,
+        algorithm: SignatureAlgorithm,
+        publicKey: CryptoPublicKey,
+    ) = algorithm.verifierFor(publicKey).transform {
+        it.verify(SignatureInput(input), signature)
     }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
@@ -130,7 +130,10 @@ class IssuerAgent(
         val issuerSigned = IssuerSigned.fromIssuerSignedItems(
             namespacedItems = mapOf(credential.scheme.isoNamespace!! to credential.issuerSignedItems),
             issuerAuth = signMobileSecurityObject(
-                null, null, mso, MobileSecurityObject.serializer(),
+                protectedHeader = null,
+                unprotectedHeader = null,
+                payload = mso,
+                serializer = MobileSecurityObject.serializer(),
             ).getOrThrow(),
         )
         return Issuer.IssuedCredential.Iso(issuerSigned, credential.scheme)
@@ -369,10 +372,10 @@ class IssuerAgent(
 
     private suspend fun wrapStatusListTokenInCoseSigned(statusListTokenPayload: StatusListTokenPayload): CoseSigned<StatusListTokenPayload>? =
         signStatusListCwt(
-            CoseHeader(type = MediaTypes.Application.STATUSLIST_CWT),
-            null,
-            statusListTokenPayload,
-            StatusListTokenPayload.serializer(),
+            protectedHeader = CoseHeader(type = MediaTypes.Application.STATUSLIST_CWT),
+            unprotectedHeader = null,
+            payload = statusListTokenPayload,
+            serializer = StatusListTokenPayload.serializer(),
         ).getOrElse {
             Napier.w("Could not wrapStatusListInJws", it)
             return null

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListTokenIntegrityValidator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListTokenIntegrityValidator.kt
@@ -52,7 +52,7 @@ class StatusListTokenIntegrityValidator(
     /**
      * Validate the integrity of a status list cwt
      */
-    fun validateStatusListCwtIntegrity(statusListToken: StatusListToken.StatusListCwt): KmmResult<StatusListTokenPayload> =
+    suspend fun validateStatusListCwtIntegrity(statusListToken: StatusListToken.StatusListCwt): KmmResult<StatusListTokenPayload> =
         catching {
             val coseStatus = statusListToken.value
             verifyCoseSignature(coseStatus, byteArrayOf(), null).isSuccess.ifFalse {

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Validator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Validator.kt
@@ -278,7 +278,7 @@ class Validator(
     @Throws(IllegalArgumentException::class, CancellationException::class)
     suspend fun verifyDeviceResponse(
         deviceResponse: DeviceResponse,
-        verifyDocumentCallback: (MobileSecurityObject, Document) -> Boolean,
+        verifyDocumentCallback: suspend (MobileSecurityObject, Document) -> Boolean,
     ): VerifyPresentationResult {
         if (deviceResponse.status != 0U) {
             Napier.w("Status invalid: ${deviceResponse.status}")
@@ -301,7 +301,7 @@ class Validator(
     @Throws(IllegalArgumentException::class, CancellationException::class)
     suspend fun verifyDocument(
         doc: Document,
-        verifyDocumentCallback: (MobileSecurityObject, Document) -> Boolean,
+        verifyDocumentCallback: suspend (MobileSecurityObject, Document) -> Boolean,
     ): IsoDocumentParsed {
         if (doc.errors != null) {
             Napier.w("Document has errors: ${doc.errors}")
@@ -431,7 +431,7 @@ class Validator(
      *
      * @param it The [IssuerSigned] structure from ISO 18013-5
      */
-    fun verifyIsoCred(it: IssuerSigned, issuerKey: CoseKey?): VerifyCredentialResult {
+    suspend fun verifyIsoCred(it: IssuerSigned, issuerKey: CoseKey?): VerifyCredentialResult {
         Napier.d("Verifying ISO Cred $it")
         if (!mdocInputValidator(it, issuerKey).isSuccess) {
             return InvalidStructure(it.serialize().encodeToString(Base16(strict = true)))

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
@@ -48,7 +48,7 @@ interface Verifier {
     suspend fun verifyPresentationIsoMdoc(
         input: DeviceResponse,
         challenge: String,
-        verifyDocument: (MobileSecurityObject, Document) -> Boolean,
+        verifyDocument: suspend (MobileSecurityObject, Document) -> Boolean,
     ): VerifyPresentationResult
 
     sealed class VerifyPresentationResult {

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifierAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifierAgent.kt
@@ -44,7 +44,7 @@ class VerifierAgent(
     override suspend fun verifyPresentationIsoMdoc(
         input: DeviceResponse,
         challenge: String,
-        verifyDocument: (MobileSecurityObject, Document) -> Boolean,
+        verifyDocument: suspend (MobileSecurityObject, Document) -> Boolean,
     ): VerifyPresentationResult = runCatching {
         validator.verifyDeviceResponse(input, verifyDocument)
     }.getOrElse {

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/mdoc/MdocInputValidator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/mdoc/MdocInputValidator.kt
@@ -10,8 +10,8 @@ import io.github.aakira.napier.Napier
 class MdocInputValidator(
     private val verifyCoseSignatureWithKey: VerifyCoseSignatureWithKeyFun<MobileSecurityObject> = VerifyCoseSignatureWithKey(),
 ) {
-    operator fun invoke(it: IssuerSigned, issuerKey: CoseKey?) = MdocInputValidationSummary(
-        integrityValidationSummary = if(issuerKey == null) {
+    suspend operator fun invoke(it: IssuerSigned, issuerKey: CoseKey?) = MdocInputValidationSummary(
+        integrityValidationSummary = if (issuerKey == null) {
             Napier.w("ISO: No issuer key")
             MdocInputValidationSummary.IntegrityValidationSummary.IntegrityNotValidated
         } else {
@@ -23,7 +23,7 @@ class MdocInputValidator(
             )
         },
     ).also {
-        if(it.isSuccess) {
+        if (it.isSuccess) {
             Napier.d("Verifying ISO Cred $it")
         }
     }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/cbor/CoseService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/cbor/CoseService.kt
@@ -165,7 +165,7 @@ fun interface VerifyCoseSignatureFun<P> {
 class VerifyCoseSignature<P : Any>(
     val verifyCoseSignature: VerifyCoseSignatureWithKeyFun<P> = VerifyCoseSignatureWithKey<P>(),
     /** Need to implement if valid keys for CoseSigned are transported somehow out-of-band, e.g. provided by a trust store */
-    val publicKeyLookup: PublicCoseKeyLookup = nullPublicCoseKeyLookup(),
+    val publicKeyLookup: PublicCoseKeyLookup = PublicCoseKeyLookup { null }
 ) : VerifyCoseSignatureFun<P> {
     override suspend fun invoke(
         coseSigned: CoseSigned<P>,
@@ -182,10 +182,6 @@ class VerifyCoseSignature<P : Any>(
     suspend fun CoseSigned<*>.loadPublicKeys(): Set<CoseKey> =
         (protectedHeader.publicKey ?: unprotectedHeader?.publicKey)?.let { setOf(it) }
             ?: publicKeyLookup(this) ?: setOf()
-}
-
-private fun nullPublicCoseKeyLookup(): PublicCoseKeyLookup = object : PublicCoseKeyLookup {
-    override suspend fun invoke(coseSigned: CoseSigned<*>): Set<CoseKey>? = null
 }
 
 fun interface VerifyCoseSignatureWithKeyFun<P> {

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/cbor/CoseService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/cbor/CoseService.kt
@@ -35,7 +35,7 @@ class CoseHeaderNone : CoseHeaderIdentifierFun {
 
 /** Identify [KeyMaterial] with it's [KeyMaterial.identifier] in (protected) [CoseHeader.keyId]. */
 class CoseHeaderKeyId : CoseHeaderIdentifierFun {
-    override suspend fun invoke(
+    override suspend operator fun invoke(
         it: CoseHeader?,
         keyMaterial: KeyMaterial,
     ): CoseHeader? = it?.copy(kid = keyMaterial.identifier.encodeToByteArray())
@@ -43,7 +43,7 @@ class CoseHeaderKeyId : CoseHeaderIdentifierFun {
 
 /** Identify [KeyMaterial] with it's [KeyMaterial.getCertificate] in (unprotected) [CoseHeader.certificateChain]. */
 class CoseHeaderCertificate : CoseHeaderIdentifierFun {
-    override suspend fun invoke(
+    override suspend operator fun invoke(
         it: CoseHeader?,
         keyMaterial: KeyMaterial,
     ) = it?.copy(certificateChain = keyMaterial.getCertificate()?.let { listOf(it.encodeToDer()) })
@@ -64,7 +64,7 @@ class SignCose<P : Any>(
     val protectedHeaderModifier: CoseHeaderIdentifierFun? = null,
     val unprotectedHeaderModifier: CoseHeaderIdentifierFun? = null,
 ) : SignCoseFun<P> {
-    override suspend fun invoke(
+    override suspend operator fun invoke(
         protectedHeader: CoseHeader?,
         unprotectedHeader: CoseHeader?,
         payload: P?,
@@ -104,7 +104,7 @@ class SignCoseDetached<P : Any>(
     val protectedHeaderModifier: CoseHeaderIdentifierFun? = null,
     val unprotectedHeaderModifier: CoseHeaderIdentifierFun? = null,
 ) : SignCoseDetachedFun<P> {
-    override suspend fun invoke(
+    override suspend operator fun invoke(
         protectedHeader: CoseHeader?,
         unprotectedHeader: CoseHeader?,
         payload: P?,
@@ -167,7 +167,7 @@ class VerifyCoseSignature<P : Any>(
     /** Need to implement if valid keys for CoseSigned are transported somehow out-of-band, e.g. provided by a trust store */
     val publicKeyLookup: PublicCoseKeyLookup = PublicCoseKeyLookup { null }
 ) : VerifyCoseSignatureFun<P> {
-    override suspend fun invoke(
+    override suspend operator fun invoke(
         coseSigned: CoseSigned<P>,
         externalAad: ByteArray,
         detachedPayload: ByteArray?,
@@ -185,7 +185,7 @@ class VerifyCoseSignature<P : Any>(
 }
 
 fun interface VerifyCoseSignatureWithKeyFun<P> {
-    operator fun invoke(
+    suspend operator fun invoke(
         coseSigned: CoseSigned<P>,
         signer: CoseKey,
         externalAad: ByteArray,
@@ -196,7 +196,7 @@ fun interface VerifyCoseSignatureWithKeyFun<P> {
 class VerifyCoseSignatureWithKey<P : Any>(
     val verifySignature: VerifySignatureFun = VerifySignature(),
 ) : VerifyCoseSignatureWithKeyFun<P> {
-    override fun invoke(
+    override suspend operator fun invoke(
         coseSigned: CoseSigned<P>,
         signer: CoseKey,
         externalAad: ByteArray,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
@@ -247,7 +247,7 @@ class DecryptJwe(
  * Clients need to retrieve the URL passed in as the only argument, and parse the content to [JsonWebKeySet].
  */
 fun interface JwkSetRetrieverFunction {
-    operator fun invoke(url: String): JsonWebKeySet?
+    suspend operator fun invoke(url: String): JsonWebKeySet?
 }
 
 /**
@@ -260,7 +260,7 @@ fun interface PublicJsonWebKeyLookup {
 }
 
 fun interface VerifyJwsSignatureFun {
-    operator fun invoke(
+    suspend operator fun invoke(
         jwsObject: JwsSigned<*>,
         publicKey: CryptoPublicKey,
     ): Boolean
@@ -269,7 +269,7 @@ fun interface VerifyJwsSignatureFun {
 class VerifyJwsSignature(
     val verifySignature: VerifySignatureFun = VerifySignature(),
 ) : VerifyJwsSignatureFun {
-    override operator fun invoke(
+    override suspend operator fun invoke(
         jwsObject: JwsSigned<*>,
         publicKey: CryptoPublicKey,
     ) = catching {
@@ -290,7 +290,7 @@ class VerifyJwsSignature(
 }
 
 fun interface VerifyJwsSignatureWithKeyFun {
-    operator fun invoke(
+    suspend operator fun invoke(
         jwsObject: JwsSigned<*>,
         signer: JsonWebKey,
     ): Boolean
@@ -299,7 +299,7 @@ fun interface VerifyJwsSignatureWithKeyFun {
 class VerifyJwsSignatureWithKey(
     val verifyJwsSignature: VerifyJwsSignatureFun = VerifyJwsSignature(),
 ) : VerifyJwsSignatureWithKeyFun {
-    override operator fun invoke(
+    override suspend operator fun invoke(
         jwsObject: JwsSigned<*>,
         signer: JsonWebKey,
     ) = signer.toCryptoPublicKey().getOrNull()?.let {

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
@@ -23,52 +23,55 @@ import at.asitplus.wallet.lib.data.vckJsonSerializer
 import io.github.aakira.napier.Napier
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray
 import kotlinx.serialization.SerializationStrategy
-import kotlin.random.Random
 
 
 /** How to identify the key material in a [JwsHeader] */
-typealias JwsHeaderIdentifierFun = suspend (JwsHeader, KeyMaterial) -> JwsHeader
+fun interface JwsHeaderIdentifierFun {
+    suspend operator fun invoke(it: JwsHeader, keyMaterial: KeyMaterial): JwsHeader
+}
 
 /** Identify [KeyMaterial] with it's [KeyMaterial.identifier] in [JwsHeader.keyId]. */
-object JwsHeaderKeyId {
-    operator fun invoke(): JwsHeaderIdentifierFun = { it, keyMaterial ->
+class JwsHeaderKeyId : JwsHeaderIdentifierFun {
+    override suspend operator fun invoke(it: JwsHeader, keyMaterial: KeyMaterial) =
         it.copy(keyId = keyMaterial.identifier)
-    }
 }
 
 /**
  * Identify [KeyMaterial] with it's [KeyMaterial.getCertificate] in [JwsHeader.certificateChain] if it exists,
  * or [KeyMaterial.jsonWebKey] in [JwsHeader.jsonWebKey]. */
-object JwsHeaderCertOrJwk {
-    operator fun invoke(): JwsHeaderIdentifierFun = { it, keyMaterial ->
+class JwsHeaderCertOrJwk : JwsHeaderIdentifierFun {
+    override suspend operator fun invoke(it: JwsHeader, keyMaterial: KeyMaterial) =
         keyMaterial.getCertificate()?.let { x5c ->
             it.copy(certificateChain = listOf(x5c))
         } ?: it.copy(jsonWebKey = keyMaterial.jsonWebKey)
-    }
 }
 
 /** Identify [KeyMaterial] with it's [KeyMaterial.jsonWebKey] in [JwsHeader.jsonWebKey]. */
-object JwsHeaderJwk {
-    operator fun invoke(): JwsHeaderIdentifierFun = { it, keyMaterial ->
+class JwsHeaderJwk : JwsHeaderIdentifierFun {
+    override suspend operator fun invoke(it: JwsHeader, keyMaterial: KeyMaterial) =
         it.copy(jsonWebKey = keyMaterial.jsonWebKey)
-    }
 }
 
 /**
  * Identify [KeyMaterial] with it's [KeyMaterial.identifier] set in [JwsHeader.keyId],
  * and URL set in[JwsHeader.jsonWebKeySetUrl].
  */
-object JwsHeaderJwksUrl {
-    operator fun invoke(jsonWebKeySetUrl: String): JwsHeaderIdentifierFun = { it, keyMaterial ->
-        it.copy(keyId = keyMaterial.identifier, jsonWebKeySetUrl = jsonWebKeySetUrl)
-    }
+class JwsHeaderJwksUrl(val jsonWebKeySetUrl: String) : JwsHeaderIdentifierFun {
+    override suspend operator fun invoke(
+        it: JwsHeader,
+        keyMaterial: KeyMaterial,
+    ) = it.copy(keyId = keyMaterial.identifier, jsonWebKeySetUrl = jsonWebKeySetUrl)
 }
 
 /** Don't identify [KeyMaterial] at all in a [JwsHeader], used for SD-JWT KB-JWS. */
-object JwsHeaderNone {
-    operator fun invoke(): JwsHeaderIdentifierFun = { it, keyMaterial -> it }
+class JwsHeaderNone : JwsHeaderIdentifierFun {
+    override suspend operator fun invoke(
+        it: JwsHeader,
+        keyMaterial: KeyMaterial,
+    ) = it
 }
 
+/** Create a [JwsSigned], setting [JwsHeader.type] to the specified value */
 fun interface SignJwtFun<P : Any> {
     suspend operator fun invoke(
         type: String?,
@@ -77,7 +80,8 @@ fun interface SignJwtFun<P : Any> {
     ): KmmResult<JwsSigned<P>>
 }
 
-data class SignJwt<P : Any>(
+/** Create a [JwsSigned], setting [JwsHeader.type] to the specified value and applying [JwsHeaderIdentifierFun]. */
+class SignJwt<P : Any>(
     val keyMaterial: KeyMaterial,
     val headerModifier: JwsHeaderIdentifierFun,
 ) : SignJwtFun<P> {
@@ -85,47 +89,49 @@ data class SignJwt<P : Any>(
         type: String?,
         payload: P,
         serializer: SerializationStrategy<P>,
-    ) = catching {
+    ): KmmResult<JwsSigned<P>> = catching {
         val header = JwsHeader(
             algorithm = keyMaterial.signatureAlgorithm.toJwsAlgorithm().getOrThrow(),
             type = type,
-        ).let { headerModifier(it, keyMaterial) }
+        ).let {
+            headerModifier(it, keyMaterial)
+        }
         val plainSignatureInput = prepareJwsSignatureInput(header, payload, serializer, vckJsonSerializer)
         val signature = keyMaterial.sign(plainSignatureInput).asKmmResult().getOrThrow()
         JwsSigned(header, payload, signature, plainSignatureInput)
     }
 }
 
+/** Create a [JweEncrypted], setting values for [JweHeader]. */
+fun interface EncryptJweFun {
+    suspend operator fun invoke(
+        header: JweHeader,
+        payload: String,
+        recipientKey: JsonWebKey,
+    ): KmmResult<JweEncrypted>
+}
+
 
 /** Create a [JweEncrypted], setting values for [JweHeader]. */
-typealias EncryptJweFun = suspend (
-    header: JweHeader,
-    payload: String,
-    recipientKey: JsonWebKey,
-) -> KmmResult<JweEncrypted>
-
-/** Create a [JweEncrypted], setting values for [JweHeader]. */
-object EncryptJwe {
-    operator fun invoke(
-        keyMaterial: KeyMaterial,
-    ): EncryptJweFun = { header, payload, recipientKey ->
-        catching {
-
-            val cryptoPublicKey = recipientKey.toCryptoPublicKey().getOrThrow()
-            require(cryptoPublicKey is CryptoPublicKey.EC)
-            val crv = recipientKey.curve
-                ?: throw IllegalArgumentException("No curve in recipient key")
-            val ephemeralKeyPair = KeyAgreementPrivateValue.ECDH.Ephemeral(crv).getOrThrow()
-            val enc = header.encryption
-            require(enc != null)
-
-            val jweHeader = header.copy(
-                jsonWebKey = keyMaterial.jsonWebKey,
-                ephemeralKeyPair = ephemeralKeyPair.publicValue.asCryptoPublicKey().toJsonWebKey()
-            )
-
-            JweUtils.encryptJwe(ephemeralKeyPair, recipientKey, enc, jweHeader, payload)
-        }
+class EncryptJwe(
+    val keyMaterial: KeyMaterial,
+) : EncryptJweFun {
+    override suspend operator fun invoke(
+        header: JweHeader,
+        payload: String, recipientKey: JsonWebKey,
+    ) = catching {
+        val cryptoPublicKey = recipientKey.toCryptoPublicKey().getOrThrow()
+        require(cryptoPublicKey is CryptoPublicKey.EC)
+        val crv = recipientKey.curve
+            ?: throw IllegalArgumentException("No curve in recipient key")
+        val ephemeralKeyPair = KeyAgreementPrivateValue.ECDH.Ephemeral(crv).getOrThrow()
+        val jweEncryption = header.encryption
+            ?: throw IllegalArgumentException("No encryption in JWE header")
+        val jweHeader = header.copy(
+            jsonWebKey = keyMaterial.jsonWebKey,
+            ephemeralKeyPair = ephemeralKeyPair.publicValue.asCryptoPublicKey().toJsonWebKey()
+        )
+        JweUtils.encryptJwe(ephemeralKeyPair, recipientKey, jweEncryption, jweHeader, payload)
     }
 }
 
@@ -164,11 +170,8 @@ object JweUtils {
         jweHeader: JweHeader,
         payload: String,
     ): JweEncrypted {
-
         val cryptoPublicKey = recipientKey.toCryptoPublicKey().getOrThrow()
         require(cryptoPublicKey is CryptoPublicKey.EC)
-
-
         val z = ephemeralKeyPair.keyAgreement(cryptoPublicKey).getOrThrow()
         val intermediateKey = concatKdf(
             z,
@@ -176,7 +179,6 @@ object JweUtils {
             jweHeader.agreementPartyUInfo,
             jweHeader.agreementPartyVInfo,
         )
-
         val algorithm = jweEncryption.algorithm
         require(algorithm.requiresNonce())
         require(algorithm.isAuthenticated())
@@ -186,7 +188,7 @@ object JweUtils {
         val aad = headerSerialized.encodeToByteArray()
         val aadForCipher = aad.encodeToByteArray(Base64UrlStrict)
         val bytes = payload.encodeToByteArray()
-        val sealedBox =key.encrypt(data= bytes, authenticatedData = aadForCipher).getOrThrow()
+        val sealedBox = key.encrypt(data = bytes, authenticatedData = aadForCipher).getOrThrow()
 
         return JweEncrypted(jweHeader, aad, null, sealedBox.nonce, sealedBox.encryptedData, sealedBox.authTag)
     }
@@ -194,145 +196,150 @@ object JweUtils {
 }
 
 /** Decrypt a [JweEncrypted] object*/
-typealias DecryptJweFun = suspend (
-    jweObject: JweEncrypted,
-) -> KmmResult<JweDecrypted<String>>
-
-object DecryptJwe {
-    operator fun invoke(
-        keyMaterial: KeyMaterial,
-    ): DecryptJweFun = { jweObject ->
-        catching {
-            val header = jweObject.header
-            val alg = header.algorithm
-                ?: throw IllegalArgumentException("No algorithm in JWE header")
-            val enc = header.encryption
-                ?: throw IllegalArgumentException("No encryption in JWE header")
-            val epk = header.ephemeralKeyPair
-                ?: throw IllegalArgumentException("No epk in JWE header")
-            val z = (keyMaterial.getUnderLyingSigner() as Signer.ECDSA).keyAgreement(epk.toCryptoPublicKey().getOrThrow() as CryptoPublicKey.EC).getOrThrow()
-            val intermediateKey = JweUtils.concatKdf(
-                z,
-                enc,
-                header.agreementPartyUInfo,
-                header.agreementPartyVInfo
-            )
-            require(alg == JweAlgorithm.ECDH_ES)
-            val algorithm = enc.algorithm
-            require(algorithm.requiresNonce())
-            require(algorithm.isAuthenticated())
-            val key = algorithm.keyFromIntermediate(intermediateKey)
-            val iv = jweObject.iv
-            val aad = jweObject.headerAsParsed.encodeToByteArray(Base64UrlStrict)
-            val ciphertext = jweObject.ciphertext
-            val authTag = jweObject.authTag
-            val plaintext =  key.decrypt(iv, ciphertext, authTag, aad).getOrThrow()
-            val plainObject = plaintext.decodeToString()
-
-            JweDecrypted(header, plainObject)
-        }
-    }
-
-    internal suspend fun performKeyAgreement(
-        keyMaterial: KeyMaterial,
-        ephemeralKey: JsonWebKey,
-    ): KmmResult<ByteArray> = catching {
-        val publicKey = ephemeralKey.toCryptoPublicKey().getOrThrow() as CryptoPublicKey.EC
-        //this is temporary until we refactor the JWS service and both key agreement functions get merged
-        (keyMaterial.getUnderLyingSigner() as Signer.ECDSA).keyAgreement(publicKey).getOrThrow()
-    }
-
+fun interface DecryptJweFun {
+    suspend operator fun invoke(
+        jweObject: JweEncrypted,
+    ): KmmResult<JweDecrypted<String>>
 }
 
-interface VerifierJwsService {
+class DecryptJwe(
+    val keyMaterial: KeyMaterial,
+) : DecryptJweFun {
+    override suspend operator fun invoke(
+        jweObject: JweEncrypted,
+    ) = catching {
+        val header = jweObject.header
+        val alg = header.algorithm
+            ?: throw IllegalArgumentException("No algorithm in JWE header")
+        val enc = header.encryption
+            ?: throw IllegalArgumentException("No encryption in JWE header")
+        val epk = header.ephemeralKeyPair
+            ?: throw IllegalArgumentException("No epk in JWE header")
+        val z = (keyMaterial.getUnderLyingSigner() as Signer.ECDSA)
+            .keyAgreement(epk.toCryptoPublicKey().getOrThrow() as CryptoPublicKey.EC)
+            .getOrThrow()
+        val intermediateKey = JweUtils.concatKdf(
+            z,
+            enc,
+            header.agreementPartyUInfo,
+            header.agreementPartyVInfo
+        )
+        require(alg == JweAlgorithm.ECDH_ES)
+        val algorithm = enc.algorithm
+        require(algorithm.requiresNonce())
+        require(algorithm.isAuthenticated())
+        val key = algorithm.keyFromIntermediate(intermediateKey)
+        val iv = jweObject.iv
+        val aad = jweObject.headerAsParsed.encodeToByteArray(Base64UrlStrict)
+        val ciphertext = jweObject.ciphertext
+        val authTag = jweObject.authTag
+        val plaintext = key.decrypt(iv, ciphertext, authTag, aad).getOrThrow()
+        val plainObject = plaintext.decodeToString()
 
-    val supportedAlgorithms: List<JwsAlgorithm>
-
-    suspend fun verifyJwsObject(jwsObject: JwsSigned<*>): Boolean
-
-    suspend fun verifyJws(jwsObject: JwsSigned<*>, signer: JsonWebKey): Boolean
-
-    suspend fun verifyJws(jwsObject: JwsSigned<*>, cnf: ConfirmationClaim): Boolean
-
+        JweDecrypted(header, plainObject)
+    }
 }
+
 
 /**
  * Clients need to retrieve the URL passed in as the only argument, and parse the content to [JsonWebKeySet].
  */
-typealias JwkSetRetrieverFunction = suspend (String) -> JsonWebKeySet?
+fun interface JwkSetRetrieverFunction {
+    suspend operator fun invoke(
+        url: String,
+    ): JsonWebKeySet?
+}
 
 /**
  * Clients get the parsed [JwsSigned] and need to provide a set of keys, which will be used for verification one-by-one.
  */
-typealias PublicJsonWebKeyLookup = suspend (JwsSigned<*>) -> Set<JsonWebKey>?
-
-typealias VerifyJwsSignatureFun = suspend (jwsObject: JwsSigned<*>, publicKey: CryptoPublicKey) -> Boolean
-
-object VerifyJwsSignature {
-    operator fun invoke(
-        verifySignature: VerifySignatureFun = VerifySignature(),
-    ): VerifyJwsSignatureFun = { jwsObject, publicKey ->
-        catching {
-
-            val jwsAlgorithm = jwsObject.header.algorithm
-            require(jwsAlgorithm is JwsAlgorithm.Signature) { "Algorithm not supported: $jwsAlgorithm" }
-            verifySignature(
-                jwsObject.plainSignatureInput,
-                jwsObject.signature,
-                jwsAlgorithm.algorithm,
-                publicKey,
-            ).getOrThrow()
-        }.fold(
-            onSuccess = { true },
-            onFailure = {
-                Napier.w("No verification from native code", it)
-                false
-            })
-    }
+fun interface PublicJsonWebKeyLookup {
+    suspend operator fun invoke(
+        jwsObject: JwsSigned<*>,
+    ): Set<JsonWebKey>?
 }
 
-typealias VerifyJwsSignatureWithKeyFun = suspend (jwsObject: JwsSigned<*>, signer: JsonWebKey) -> Boolean
-
-object VerifyJwsSignatureWithKey {
+fun interface VerifyJwsSignatureFun {
     operator fun invoke(
-        verifyJwsSignature: VerifyJwsSignatureFun = VerifyJwsSignature(),
-    ): VerifyJwsSignatureWithKeyFun = { jwsObject, signer ->
-        signer.toCryptoPublicKey().getOrNull()?.let {
-            verifyJwsSignature(jwsObject, it)
-        } ?: false.also { Napier.w("Could not convert signer to public key: $signer") }
-    }
+        jwsObject: JwsSigned<*>,
+        publicKey: CryptoPublicKey,
+    ): Boolean
 }
 
-typealias VerifyJwsSignatureWithCnfFun = suspend (jwsObject: JwsSigned<*>, cnf: ConfirmationClaim) -> Boolean
+class VerifyJwsSignature(
+    val verifySignature: VerifySignatureFun = VerifySignature(),
+) : VerifyJwsSignatureFun {
+    override operator fun invoke(
+        jwsObject: JwsSigned<*>,
+        publicKey: CryptoPublicKey,
+    ) = catching {
+        val jwsAlgorithm = jwsObject.header.algorithm
+        require(jwsAlgorithm is JwsAlgorithm.Signature) { "Algorithm not supported: $jwsAlgorithm" }
+        verifySignature(
+            jwsObject.plainSignatureInput,
+            jwsObject.signature,
+            jwsAlgorithm.algorithm,
+            publicKey,
+        ).getOrThrow()
+    }.fold(
+        onSuccess = { true },
+        onFailure = {
+            Napier.w("No verification from native code", it)
+            false
+        })
+}
 
-object VerifyJwsSignatureWithCnf {
+fun interface VerifyJwsSignatureWithKeyFun {
     operator fun invoke(
-        verifyJwsSignature: VerifyJwsSignatureFun = VerifyJwsSignature(),
-        /**
-         * Need to implement if JSON web keys in JWS headers are referenced by a `kid`, and need to be retrieved from
-         * the `jku`.
-         */
-        jwkSetRetriever: JwkSetRetrieverFunction = { null },
-    ): VerifyJwsSignatureWithCnfFun = { jwsObject, cnf ->
-        cnf.loadPublicKeys(jwkSetRetriever).any { verifyJwsSignature(jwsObject, it) }
-    }
+        jwsObject: JwsSigned<*>,
+        signer: JsonWebKey,
+    ): Boolean
+}
+
+class VerifyJwsSignatureWithKey(
+    val verifyJwsSignature: VerifyJwsSignatureFun = VerifyJwsSignature(),
+) : VerifyJwsSignatureWithKeyFun {
+    override operator fun invoke(
+        jwsObject: JwsSigned<*>,
+        signer: JsonWebKey,
+    ) = signer.toCryptoPublicKey().getOrNull()?.let {
+        verifyJwsSignature(jwsObject, it)
+    } ?: false.also { Napier.w("Could not convert signer to public key: $signer") }
+}
+
+fun interface VerifyJwsSignatureWithCnfFun {
+    suspend operator fun invoke(
+        jwsObject: JwsSigned<*>,
+        cnf: ConfirmationClaim,
+    ): Boolean
+}
+
+class VerifyJwsSignatureWithCnf(
+    val verifyJwsSignature: VerifyJwsSignatureFun = VerifyJwsSignature(),
+    /**
+     * Need to implement if JSON web keys in JWS headers are referenced by a `kid`, and need to be retrieved from
+     * the `jku`.
+     */
+    val jwkSetRetriever: JwkSetRetrieverFunction = nullJwkSetRetrieverFunction(),
+) : VerifyJwsSignatureWithCnfFun {
+    override suspend operator fun invoke(
+        jwsObject: JwsSigned<*>,
+        cnf: ConfirmationClaim,
+    ) = cnf.loadPublicKeys().any { verifyJwsSignature(jwsObject, it) }
 
     /**
      * Loads all referenced [JsonWebKey]s, i.e. from [ConfirmationClaim.jsonWebKey] and [ConfirmationClaim.jsonWebKeySetUrl].
      */
-    private suspend fun ConfirmationClaim.loadPublicKeys(
-        jwkSetRetriever: JwkSetRetrieverFunction = { null },
-    ): Set<CryptoPublicKey> =
+    private suspend fun ConfirmationClaim.loadPublicKeys(): Set<CryptoPublicKey> =
         setOfNotNull(
             jsonWebKey?.toCryptoPublicKey()?.getOrNull(),
-            jsonWebKeySetUrl?.let { retrieveJwkFromKeySetUrl(jwkSetRetriever, it, keyId) }
+            jsonWebKeySetUrl?.let { retrieveJwkFromKeySetUrl(it, keyId) }
         )
 
     /**
      * Either take the single key from the JSON Web Key Set, or the one matching the keyId
      */
     private suspend fun retrieveJwkFromKeySetUrl(
-        jwkSetRetriever: JwkSetRetrieverFunction = { null },
         jku: String,
         keyId: String?,
     ): CryptoPublicKey? =
@@ -342,46 +349,47 @@ object VerifyJwsSignatureWithCnf {
 
 }
 
-typealias VerifyJwsObjectFun = suspend (jwsObject: JwsSigned<*>) -> Boolean
+private fun nullJwkSetRetrieverFunction(): JwkSetRetrieverFunction = object : JwkSetRetrieverFunction {
+    override suspend operator fun invoke(url: String): JsonWebKeySet? = null
+}
 
-object VerifyJwsObject {
-    operator fun invoke(
-        verifyJwsSignature: VerifyJwsSignatureFun = VerifyJwsSignature(),
-        /**
-         * Need to implement if JSON web keys in JWS headers are referenced by a `kid`, and need to be retrieved from
-         * the `jku`.
-         */
-        jwkSetRetriever: JwkSetRetrieverFunction = { null },
-        /** Need to implement if valid keys for JWS are transported somehow out-of-band, e.g. provided by a trust store */
-        publicKeyLookup: PublicJsonWebKeyLookup = { null },
-    ): VerifyJwsObjectFun = { jwsObject ->
-        jwsObject.loadPublicKeys(jwkSetRetriever, publicKeyLookup).any { verifyJwsSignature(jwsObject, it) }
-    }
+private fun nullPublicJsonWebKeyLookup(): PublicJsonWebKeyLookup = object : PublicJsonWebKeyLookup {
+    override suspend operator fun invoke(jwsObject: JwsSigned<*>) = null
+}
+
+fun interface VerifyJwsObjectFun {
+    suspend operator fun invoke(jwsObject: JwsSigned<*>): Boolean
+}
+
+class VerifyJwsObject(
+    val verifyJwsSignature: VerifyJwsSignatureFun = VerifyJwsSignature(),
+    /**
+     * Need to implement if JSON web keys in JWS headers are referenced by a `kid`, and need to be retrieved from
+     * the `jku`.
+     */
+    val jwkSetRetriever: JwkSetRetrieverFunction = nullJwkSetRetrieverFunction(),
+    /** Need to implement if valid keys for JWS are transported somehow out-of-band, e.g. provided by a trust store */
+    val publicKeyLookup: PublicJsonWebKeyLookup = nullPublicJsonWebKeyLookup(),
+) : VerifyJwsObjectFun {
+    override suspend operator fun invoke(jwsObject: JwsSigned<*>) =
+        jwsObject.loadPublicKeys().any { verifyJwsSignature(jwsObject, it) }
 
     /**
      * Returns a list of public keys that may have been used to sign this [JwsSigned]
      * by evaluating its header values (see [JwsHeader.jsonWebKey], [JwsHeader.jsonWebKeySetUrl])
      * as well as out-of-band transmitted keys from [publicKeyLookup].
      */
-    private suspend fun JwsSigned<*>.loadPublicKeys(
-        /**
-         * Need to implement if JSON web keys in JWS headers are referenced by a `kid`, and need to be retrieved from
-         * the `jku`.
-         */
-        jwkSetRetriever: JwkSetRetrieverFunction = { null },
-        /** Need to implement if valid keys for JWS are transported somehow out-of-band, e.g. provided by a trust store */
-        publicKeyLookup: PublicJsonWebKeyLookup = { null },
-    ): Set<CryptoPublicKey> =
+    private suspend fun JwsSigned<*>.loadPublicKeys(): Set<CryptoPublicKey> =
         header.publicKey?.let { setOf(it) }
             ?: header.jsonWebKeySetUrl?.let {
-                retrieveJwkFromKeySetUrl(jwkSetRetriever, it, header.keyId)?.let { setOf(it) }
-            } ?: publicKeyLookup(this)?.mapNotNull { jwk -> jwk.toCryptoPublicKey().getOrNull() }?.toSet() ?: setOf()
+                retrieveJwkFromKeySetUrl(it, header.keyId)?.let { setOf(it) }
+            } ?: publicKeyLookup(this)?.mapNotNull { jwk -> jwk.toCryptoPublicKey().getOrNull() }?.toSet()
+            ?: setOf()
 
     /**
      * Either take the single key from the JSON Web Key Set, or the one matching the keyId
      */
     private suspend fun retrieveJwkFromKeySetUrl(
-        jwkSetRetriever: JwkSetRetrieverFunction = { null },
         jku: String,
         keyId: String?,
     ): CryptoPublicKey? =
@@ -396,7 +404,7 @@ object VerifyJwsObject {
  * per [RFC 7518](https://datatracker.ietf.org/doc/html/rfc7518#section-5.2.2.1)
  */
 private inline fun SymmetricEncryptionAlgorithm<AuthCapability.Authenticated<*>, NonceTrait.Required, *>.keyFromIntermediate(
-    jweKeyBytes: ByteArray
+    jweKeyBytes: ByteArray,
 ): SymmetricKey<AuthCapability.Authenticated<*>, NonceTrait.Required, *> {
     return ((if (hasDedicatedMac())
         keyFrom(

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/CoseServiceTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/CoseServiceTest.kt
@@ -44,10 +44,10 @@ class CoseServiceTest : FreeSpec({
         val parameterSerializer = ByteArraySerializer()
         val payloadToUse = "This is the content: ".encodeToByteArray() + randomPayload
         val signed = signCose(
-            CoseHeader(algorithm = CoseAlgorithm.Signature.ES256),
-            null,
-            payloadToUse,
-            parameterSerializer
+            protectedHeader = CoseHeader(algorithm = CoseAlgorithm.Signature.ES256),
+            unprotectedHeader = null,
+            payload = payloadToUse,
+            serializer = parameterSerializer
         ).getOrThrow()
 
         signed.payload shouldBe payloadToUse
@@ -65,10 +65,10 @@ class CoseServiceTest : FreeSpec({
     "signed object with random bytes can be verified" {
         val parameterSerializer = ByteArraySerializer()
         val signed = signCose(
-            null,
-            CoseHeader(algorithm = CoseAlgorithm.Signature.ES256),
-            randomPayload,
-            parameterSerializer,
+            protectedHeader = null,
+            unprotectedHeader = CoseHeader(algorithm = CoseAlgorithm.Signature.ES256),
+            payload = randomPayload,
+            serializer = parameterSerializer,
         ).getOrThrow()
 
         signed.payload shouldBe randomPayload
@@ -100,10 +100,10 @@ class CoseServiceTest : FreeSpec({
             validityInfo = ValidityInfo(Clock.System.now(), Clock.System.now(), Clock.System.now())
         )
         val signed = signCoseMso(
-            CoseHeader(algorithm = CoseAlgorithm.Signature.ES256),
-            null,
-            mso,
-            parameterSerializer
+            protectedHeader = CoseHeader(algorithm = CoseAlgorithm.Signature.ES256),
+            unprotectedHeader = null,
+            payload = mso,
+            serializer = parameterSerializer
         ).getOrThrow()
 
         signed.payload shouldBe mso
@@ -117,12 +117,7 @@ class CoseServiceTest : FreeSpec({
 
     "signed object with null payload can be verified" {
         val parameterSerializer = NothingSerializer()
-        val signed = signCoseNothing(
-            null,
-            null,
-            null,
-            parameterSerializer
-        ).getOrThrow()
+        val signed = signCoseNothing(null, null, null, parameterSerializer).getOrThrow()
 
         signed.payload shouldBe null
         signed.signature.shouldNotBeNull()
@@ -141,7 +136,12 @@ class CoseServiceTest : FreeSpec({
 
     "signed object with random bytes, transported detached, can be verified" {
         val parameterSerializer = ByteArraySerializer()
-        val signed = signCoseDetached(null, null, randomPayload, parameterSerializer).getOrThrow()
+        val signed = signCoseDetached(
+            protectedHeader = null,
+            unprotectedHeader = null,
+            payload = randomPayload,
+            serializer = parameterSerializer
+        ).getOrThrow()
 
         signed.payload shouldBe null
         signed.signature.shouldNotBeNull()

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/IsoProcessTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/IsoProcessTest.kt
@@ -184,7 +184,7 @@ class Verifier {
         )
     )
 
-    fun verifyResponse(deviceResponse: DeviceResponse, issuerKey: CoseKey) {
+    suspend fun verifyResponse(deviceResponse: DeviceResponse, issuerKey: CoseKey) {
         val documents = deviceResponse.documents.shouldNotBeNull()
         val doc = documents.first()
         doc.docType shouldBe ConstantIndex.AtomicAttribute2023.isoDocType

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/IsoProcessTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/IsoProcessTest.kt
@@ -174,7 +174,12 @@ class Verifier {
                         )
                     )
                 ),
-                readerAuth = signCose(null, CoseHeader(), null, ByteArraySerializer()).getOrThrow()
+                readerAuth = signCose(
+                    protectedHeader = null,
+                    unprotectedHeader = CoseHeader(),
+                    payload = null,
+                    serializer = ByteArraySerializer()
+                ).getOrThrow()
             )
         )
     )

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceTest.kt
@@ -71,9 +71,7 @@ class JwsServiceTest : FreeSpec({
         val signer = SignJwt<String>(keyMaterial, JwsHeaderJwksUrl(jku))
         val signed = signer(null, randomPayload, String.serializer()).getOrThrow()
         val validKey = keyMaterial.jsonWebKey
-        val jwkSetRetriever: JwkSetRetrieverFunction = object : JwkSetRetrieverFunction {
-            override suspend fun invoke(url: String): JsonWebKeySet? = JsonWebKeySet(keys = listOf(validKey))
-        }
+        val jwkSetRetriever = JwkSetRetrieverFunction { JsonWebKeySet(keys = listOf(validKey)) }
         verifierJwsService = VerifyJwsObject(jwkSetRetriever = jwkSetRetriever)
         verifierJwsService(signed) shouldBe true
     }
@@ -83,9 +81,7 @@ class JwsServiceTest : FreeSpec({
         val signer = SignJwt<String>(keyMaterial, JwsHeaderJwksUrl(jku))
         val signed = signer(null, randomPayload, String.serializer()).getOrThrow()
         val invalidKey = EphemeralKeyWithoutCert().jsonWebKey
-        val jwkSetRetriever: JwkSetRetrieverFunction = object : JwkSetRetrieverFunction {
-            override suspend fun invoke(url: String): JsonWebKeySet? = JsonWebKeySet(keys = listOf(invalidKey))
-        }
+        val jwkSetRetriever = JwkSetRetrieverFunction { JsonWebKeySet(keys = listOf(invalidKey)) }
         verifierJwsService = VerifyJwsObject(jwkSetRetriever = jwkSetRetriever)
         verifierJwsService(signed) shouldBe false
     }
@@ -102,9 +98,7 @@ class JwsServiceTest : FreeSpec({
         val signer = SignJwt<String>(keyMaterial, JwsHeaderNone())
         val signed = signer(null, randomPayload, String.serializer()).getOrThrow()
 
-        val publicKeyLookup: PublicJsonWebKeyLookup = object : PublicJsonWebKeyLookup {
-            override suspend fun invoke(jwsObject: JwsSigned<*>): Set<JsonWebKey>? = setOf(keyMaterial.jsonWebKey)
-        }
+        val publicKeyLookup = PublicJsonWebKeyLookup { setOf(keyMaterial.jsonWebKey) }
         verifierJwsService = VerifyJwsObject(publicKeyLookup = publicKeyLookup)
         verifierJwsService(signed) shouldBe true
     }

--- a/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/cbor/CoseServiceJvmTest.kt
+++ b/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/cbor/CoseServiceJvmTest.kt
@@ -84,8 +84,12 @@ class CoseServiceJvmTest : FreeSpec({
             "$testIdentifier:" - {
 
                 "Signed object from int. library can be verified with int. library" {
-                    val signed = signCose(null, null, randomPayload.encodeToByteArray(), ByteArraySerializer())
-                        .getOrThrow()
+                    val signed = signCose(
+                        protectedHeader = null,
+                        unprotectedHeader = null,
+                        payload = randomPayload.encodeToByteArray(),
+                        serializer = ByteArraySerializer()
+                    ).getOrThrow()
 
                     withClue("$sigAlgo: Signature: ${signed.signature.encodeToTlv().toDerHexString()}") {
                         verifierCoseService(
@@ -126,10 +130,10 @@ class CoseServiceJvmTest : FreeSpec({
                     }
 
                     val signed = signCose(
-                        CoseHeader(algorithm = coseAlgorithm),
-                        null,
-                        randomPayload.encodeToByteArray(),
-                        ByteArraySerializer(),
+                        protectedHeader = CoseHeader(algorithm = coseAlgorithm),
+                        unprotectedHeader = null,
+                        payload = randomPayload.encodeToByteArray(),
+                        serializer = ByteArraySerializer(),
                     ).getOrThrow()
                     val signedSerialized = signed.serialize(ByteArraySerializer()).encodeToString(Base16())
                     val extLibSerialized = extLibCoseSign1.encode().encodeToString(Base16())
@@ -142,10 +146,10 @@ class CoseServiceJvmTest : FreeSpec({
 
                 "Signed object from int. library can be verified with ext. library" {
                     val coseSigned = signCose(
-                        CoseHeader(algorithm = coseAlgorithm),
-                        null,
-                        randomPayload.encodeToByteArray(),
-                        ByteArraySerializer(),
+                        protectedHeader = CoseHeader(algorithm = coseAlgorithm),
+                        unprotectedHeader = null,
+                        payload = randomPayload.encodeToByteArray(),
+                        serializer = ByteArraySerializer(),
                     ).getOrThrow()
 
                     val parsed =


### PR DESCRIPTION
As suggested by @acrusage-iaik, `fun interface` provides advantages over the previously used `typealias`, e.g. named parameters for invocation as well as strict type checking (i.e. passing a function with the same signature is not enough, as has happened with `SignCoseFun` and `SignCoseDetachedFun`).