### PR TITLE
Simplify freshness api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Release 5.7.0:
        - `Verifier.VerifyPresentationResult.SuccessSdJwt`
        - `IsoDocumentParsed`
        - `AuthnResponseResult.SuccessSdJwt`
- - Remove `Validator.checkTimeliness` and `Validator.checkRevocationStatus` in favour of `Validator.checkCredentialFreshness`
+ - Remove `Validator.checkTimeliness` and `Validator.checkRevocationStatus` in favor of `Validator.checkCredentialFreshness`
  - Combine members `timelinessValidationSummary` and `tokenStatus` as `freshnessSummary` in:
    - `IsoDocumentParsed`
    - `Verifier.VerifyPresentationResult.SuccessSdJwt`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,37 +13,19 @@ Release 5.7.0:
      - `SignatureAlgorithm.RSAorHMAC` is now properly split into `SignatureAlgorithm` and `MessageAuthenticationCode`. Both implement `DataIntegrityAlgorithm`.
      - This split also affects `JwsAlgorithm`, which now has subtypes: `Signature` and `MAC`. Hence, `JwsAlgorithm.ES256` -> `JwsAlgorithm.Signature.ES256`
  - Separate credential timeliness validation from content semantics validation
-   - Change `Validator` constructor to include configuration of separate credential structure validators 
-   - Change `Validator` constructor to include configuration of credential timeliness validator 
+   - Change `Validator` constructor to include configuration of the credential timeliness validator
    - Change `Validator.verifyVcJws` to not perform timeliness validation
    - Change `Validator.verifySdJwt` to not perform timeliness validation
-   - Replace property`isRevoked` with properties `timelinessValidationSummary` and `tokenStatus` in:
+   - Replace property`isRevoked` with property `freshnessSummary` in:
      - `Verifier.VerifyPresentationResult.SuccessSdJwt` 
      - `IsoDocumentParsed`
      - `AuthnResponseResult.SuccessSdJwt`
-   - Rename `VerifiablePresentationParsed.verifiableCredentials` to `VerifiablePresentationParsed.timelyCredentials`
-   - Rename `VerifiablePresentationParsed.revokedVerifiableCredentials` to `VerifiablePresentationParsed.untimelyVerifiableCredentials`
-   - Change type of `VerifiablePresentationParsed.verifiableCredentials` and `revokedVerifiableCredentials` to `Collection<VcJwsVerificationResultWrapper`> 
-   - Add `Validator.checkTimeliness`
+   - Change type of `VerifiablePresentationParsed.verifiableCredentials` and `revokedVerifiableCredentials` to `Collection<VcJwsVerificationResultWrapper`>
+   - Rename `VerifiablePresentationParsed.verifiableCredentials` to `VerifiablePresentationParsed.freshVerifiableCredentials`
+   - Rename `VerifiablePresentationParsed.revokedVerifiableCredentials` to `VerifiablePresentationParsed.notVerifiablyFreshVerifiableCredentials`
+   - Add `Validator.checkCredentialFreshness`
    - Remove `Holder.StoredCredential.status`
- - Add class `TokenStatusValidationResult`
-   - Change type of property `tokenStatus` in:
-       - `Verifier.VerifyPresentationResult.SuccessSdJwt`
-       - `IsoDocumentParsed`
-       - `AuthnResponseResult.SuccessSdJwt`
  - Add constructor parameter `Validator.acceptedTokenStatuses` to allow library client to define token statuses deemed valid
- - Remove `Validator.checkTimeliness` and `Validator.checkRevocationStatus` in favor of `Validator.checkCredentialFreshness`
- - Combine members `timelinessValidationSummary` and `tokenStatus` as `freshnessSummary` in:
-   - `IsoDocumentParsed`
-   - `Verifier.VerifyPresentationResult.SuccessSdJwt`
-   - `AuthnResponseResult.SuccessSdJwt`
-   - `VcJwsVerificationResultWrapper`
- - Rename `isSuccess` to `isTimely` in:
-   - `CredentialTimelinessValidationSummary`
-   - `MdocTimelinessValidationDetails`
-   - `MobileSecurityObjectTimelinessValidationSummary`
-   - `SdJwtTimelinessValidationDetails`
-   - `VcJwsTimelinessValidationDetails`
  - Remove `Holder.StoredCredential` in favor of `SubjectCredentialStore.StoreEntry` 
 
 Release 5.6.1:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ Release 5.7.0:
    - Change type of `VerifiablePresentationParsed.verifiableCredentials` and `revokedVerifiableCredentials` to `Collection<VcJwsVerificationResultWrapper`>
    - Rename `VerifiablePresentationParsed.verifiableCredentials` to `VerifiablePresentationParsed.freshVerifiableCredentials`
    - Rename `VerifiablePresentationParsed.revokedVerifiableCredentials` to `VerifiablePresentationParsed.notVerifiablyFreshVerifiableCredentials`
-   - Add `Validator.checkCredentialFreshness`
+   - Remove `Validator.checkRevocationStatus` in favor of `Validator.checkCredentialFreshness`
    - Remove `Holder.StoredCredential.status`
+   - Remove `Verifier.VerifyCredentialResult.Revoked`
  - Add constructor parameter `Validator.acceptedTokenStatuses` to allow library client to define token statuses deemed valid
  - Remove `Holder.StoredCredential` in favor of `SubjectCredentialStore.StoreEntry` 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ Release 5.7.0:
        - `Verifier.VerifyPresentationResult.SuccessSdJwt`
        - `IsoDocumentParsed`
        - `AuthnResponseResult.SuccessSdJwt`
+ - Remove `Validator.checkTimeliness` and `Validator.checkRevocationStatus` in favour of `Validator.checkCredentialFreshness`
+ - Combine members `timelinessValidationSummary` and `tokenStatus` as `freshnessSummary` in:
+   - `IsoDocumentParsed`
+   - `Verifier.VerifyPresentationResult.SuccessSdJwt`
+   - `AuthnResponseResult.SuccessSdJwt`
+   - `VcJwsVerificationResultWrapper`
+ - Rename `isSuccess` to `isTimely` in:
+   - `CredentialTimelinessValidationSummary`
+   - `MdocTimelinessValidationDetails`
+   - `MobileSecurityObjectTimelinessValidationSummary`
+   - `SdJwtTimelinessValidationDetails`
+   - `VcJwsTimelinessValidationDetails`
  - Remove `Holder.StoredCredential` in favor of `SubjectCredentialStore.StoreEntry` 
 
 Release 5.6.1:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Release 5.7.0:
        - `Verifier.VerifyPresentationResult.SuccessSdJwt`
        - `IsoDocumentParsed`
        - `AuthnResponseResult.SuccessSdJwt`
+ - Add constructor parameter `Validator.acceptedTokenStatuses` to allow library client to define token statuses deemed valid
  - Remove `Validator.checkTimeliness` and `Validator.checkRevocationStatus` in favor of `Validator.checkCredentialFreshness`
  - Combine members `timelinessValidationSummary` and `tokenStatus` as `freshnessSummary` in:
    - `IsoDocumentParsed`

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
@@ -6,6 +6,7 @@ import at.asitplus.wallet.lib.data.IsoDocumentParsed
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
 import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import at.asitplus.wallet.lib.data.VerifiablePresentationParsed
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 import at.asitplus.wallet.lib.jws.SdJwtSigned
 import kotlinx.serialization.json.JsonObject
 
@@ -53,7 +54,15 @@ sealed class AuthnResponseResult {
         val disclosures: Collection<SelectiveDisclosureItem>,
         val state: String?,
         val freshnessSummary: CredentialFreshnessSummary.SdJwt,
-    ) : AuthnResponseResult()
+    ) : AuthnResponseResult() {
+        @Deprecated("Replaced with more expressive freshness information", ReplaceWith("freshnessSummary.tokenStatusValidationResult is TokenStatusValidationResult.Invalid"))
+        val isRevoked: Boolean?
+            get() = if(freshnessSummary.tokenStatusValidationResult is TokenStatusValidationResult.Rejected) {
+                null
+            } else {
+                freshnessSummary.tokenStatusValidationResult is TokenStatusValidationResult.Invalid
+            }
+    }
 
     /**
      * Successfully decoded and validated the response from the Wallet (ISO credential)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
@@ -2,12 +2,10 @@ package at.asitplus.wallet.lib.openid
 
 import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
 import at.asitplus.wallet.lib.agent.validation.CredentialFreshnessSummary
-import at.asitplus.wallet.lib.agent.validation.CredentialTimelinessValidationSummary
 import at.asitplus.wallet.lib.data.IsoDocumentParsed
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
 import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import at.asitplus.wallet.lib.data.VerifiablePresentationParsed
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 import at.asitplus.wallet.lib.jws.SdJwtSigned
 import kotlinx.serialization.json.JsonObject
 
@@ -55,15 +53,7 @@ sealed class AuthnResponseResult {
         val disclosures: Collection<SelectiveDisclosureItem>,
         val state: String?,
         val freshnessSummary: CredentialFreshnessSummary.SdJwt,
-    ) : AuthnResponseResult() {
-        @Deprecated("Replaced with more expressive TokenStatusValidationResult, supporting token status values as defined by the library client.", ReplaceWith("freshnessSummary.tokenStatusValidationResult"))
-        val tokenStatus: TokenStatusValidationResult
-            get() = freshnessSummary.tokenStatusValidationResult
-
-        @Deprecated("", ReplaceWith("credentialFreshnessSummary.timelinessValidationSummary"))
-        val timelinessValidationSummary: CredentialTimelinessValidationSummary.SdJwt
-            get() = freshnessSummary.timelinessValidationSummary
-    }
+    ) : AuthnResponseResult()
 
     /**
      * Successfully decoded and validated the response from the Wallet (ISO credential)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
@@ -1,6 +1,7 @@
 package at.asitplus.wallet.lib.openid
 
 import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
+import at.asitplus.wallet.lib.agent.validation.CredentialFreshnessSummary
 import at.asitplus.wallet.lib.agent.validation.CredentialTimelinessValidationSummary
 import at.asitplus.wallet.lib.data.IsoDocumentParsed
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
@@ -53,9 +54,16 @@ sealed class AuthnResponseResult {
         val reconstructed: JsonObject,
         val disclosures: Collection<SelectiveDisclosureItem>,
         val state: String?,
-        val timelinessValidationSummary: CredentialTimelinessValidationSummary.SdJwt,
-        val tokenStatus: TokenStatusValidationResult,
-    ) : AuthnResponseResult()
+        val freshnessSummary: CredentialFreshnessSummary.SdJwt,
+    ) : AuthnResponseResult() {
+        @Deprecated("Replaced with more expressive TokenStatusValidationResult, supporting token status values as defined by the library client.", ReplaceWith("freshnessSummary.tokenStatusValidationResult"))
+        val tokenStatus: TokenStatusValidationResult
+            get() = freshnessSummary.tokenStatusValidationResult
+
+        @Deprecated("", ReplaceWith("credentialFreshnessSummary.timelinessValidationSummary"))
+        val timelinessValidationSummary: CredentialTimelinessValidationSummary.SdJwt
+            get() = freshnessSummary.timelinessValidationSummary
+    }
 
     /**
      * Successfully decoded and validated the response from the Wallet (ISO credential)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -675,8 +675,7 @@ open class OpenId4VpVerifier(
             reconstructed = reconstructedJsonObject,
             disclosures = disclosures,
             state = state,
-            timelinessValidationSummary = timelinessValidationSummary,
-            tokenStatus = tokenStatus,
+            freshnessSummary = freshnessSummary,
         ).also { Napier.i("VP success: $this") }
     }
 }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTest.kt
@@ -91,8 +91,8 @@ class OpenId4VpCombinedProtocolTest : FreeSpec({
 
                 val result = verifierOid4vp.validateAuthnResponse(authnResponse.url)
                     .shouldBeInstanceOf<AuthnResponseResult.Success>()
-                result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
-                result.vp.timelyVerifiableCredentials.map { it.vcJws }.forEach {
+                result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
+                result.vp.freshVerifiableCredentials.map { it.vcJws }.forEach {
                     it.vc.credentialSubject.shouldBeInstanceOf<AtomicAttribute2023>()
                 }
             }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
@@ -85,7 +85,7 @@ class PreRegisteredClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.url)
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
 
         verifierOid4vp.createAuthnRequest(
             defaultRequestOptions, OpenId4VpVerifier.CreationOptions.Query(walletUrl)
@@ -116,7 +116,7 @@ class PreRegisteredClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.url)
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
         result.state.shouldBe(expectedState)
     }
 
@@ -206,7 +206,7 @@ class PreRegisteredClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.params.formUrlEncode())
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
     }
 
     "test with direct_post_jwt" {
@@ -231,7 +231,7 @@ class PreRegisteredClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.params.formUrlEncode())
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
     }
 
     "test with deserializing" {
@@ -250,7 +250,7 @@ class PreRegisteredClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponseParams)
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
     }
 
     "test specific credential" {
@@ -264,8 +264,8 @@ class PreRegisteredClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.url)
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
-        result.vp.timelyVerifiableCredentials.map { it.vcJws }.forEach {
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.map { it.vcJws }.forEach {
             it.vc.credentialSubject.shouldBeInstanceOf<AtomicAttribute2023>()
         }
     }
@@ -280,8 +280,8 @@ class PreRegisteredClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.url)
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
-        result.vp.timelyVerifiableCredentials.map { it.vcJws }.forEach {
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.map { it.vcJws }.forEach {
             it.vc.credentialSubject.shouldBeInstanceOf<AtomicAttribute2023>()
         }
     }
@@ -312,8 +312,8 @@ class PreRegisteredClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.url)
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
-        result.vp.timelyVerifiableCredentials.map { it.vcJws }.forEach {
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.map { it.vcJws }.forEach {
             it.vc.credentialSubject.shouldBeInstanceOf<AtomicAttribute2023>()
         }
     }
@@ -338,8 +338,8 @@ class PreRegisteredClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.url)
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
-        result.vp.timelyVerifiableCredentials.map { it.vcJws }.forEach {
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.map { it.vcJws }.forEach {
             it.vc.credentialSubject.shouldBeInstanceOf<AtomicAttribute2023>()
         }
     }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RedirectUriClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RedirectUriClientTest.kt
@@ -74,7 +74,7 @@ class RedirectUriClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.url)
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
 
         verifySecondProtocolRun(verifierOid4vp, walletUrl, holderOid4vp)
     }
@@ -160,7 +160,7 @@ class RedirectUriClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.params.formUrlEncode())
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
     }
 
     "test with direct_post_jwt" {
@@ -185,7 +185,7 @@ class RedirectUriClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.params.formUrlEncode())
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
     }
 
     "test with Query" {
@@ -208,7 +208,7 @@ class RedirectUriClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.url)
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
         result.state.shouldBe(expectedState)
     }
 
@@ -228,7 +228,7 @@ class RedirectUriClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponseParams)
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
     }
 
     "test specific credential" {
@@ -242,8 +242,8 @@ class RedirectUriClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.url)
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
-        result.vp.timelyVerifiableCredentials.map { it.vcJws }.forEach {
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.map { it.vcJws }.forEach {
             it.vc.credentialSubject.shouldBeInstanceOf<AtomicAttribute2023>()
         }
     }
@@ -274,8 +274,8 @@ class RedirectUriClientTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.url)
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
-        result.vp.timelyVerifiableCredentials.map { it.vcJws }.forEach {
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.map { it.vcJws }.forEach {
             it.vc.credentialSubject.shouldBeInstanceOf<AtomicAttribute2023>()
         }
     }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/VerifierAttestationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/VerifierAttestationTest.kt
@@ -75,8 +75,8 @@ class VerifierAttestationTest : FreeSpec({
 
         val result = verifierOid4vp.validateAuthnResponse(authnResponse.url)
             .shouldBeInstanceOf<AuthnResponseResult.Success>()
-        result.vp.timelyVerifiableCredentials.shouldNotBeEmpty()
-        result.vp.timelyVerifiableCredentials.map { it.vcJws }.forEach {
+        result.vp.freshVerifiableCredentials.shouldNotBeEmpty()
+        result.vp.freshVerifiableCredentials.map { it.vcJws }.forEach {
             it.vc.credentialSubject.shouldBeInstanceOf<AtomicAttribute2023>()
         }
     }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -14,7 +14,6 @@ import at.asitplus.wallet.lib.agent.SubjectCredentialStore.StoreEntry
 import at.asitplus.wallet.lib.data.*
 import at.asitplus.wallet.lib.data.dif.PresentationExchangeInputEvaluator
 import at.asitplus.wallet.lib.data.dif.PresentationSubmissionValidator
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 import at.asitplus.wallet.lib.data.third_party.at.asitplus.oidc.dcql.toDefaultSubmission
 import at.asitplus.wallet.lib.jws.*
 import at.asitplus.wallet.lib.procedures.dcql.DCQLQueryAdapter
@@ -117,7 +116,7 @@ class HolderAgent(
         val withRevocationStatusQueryIssued = presortedCredentials.map {
             it to coroutineScope {
                 async {
-                    validator.checkRevocationStatus(it)
+                    validator.checkCredentialFreshness(it)
                 }
             }
         }
@@ -128,7 +127,7 @@ class HolderAgent(
             it.first to it.second.await()
         }
         return withRevocationStatusAvailable.sortedBy {
-            if (validator.checkTimeliness(it.first).isSuccess && it.second is TokenStatusValidationResult.Valid) {
+            if (it.second.isFresh) {
                 0
             } else {
                 1

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
@@ -6,7 +6,6 @@ import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.signum.indispensable.josef.jwkId
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.wallet.lib.agent.validation.CredentialFreshnessSummary
-import at.asitplus.wallet.lib.agent.validation.CredentialTimelinessValidationSummary
 import at.asitplus.wallet.lib.data.*
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 import at.asitplus.wallet.lib.iso.DeviceResponse
@@ -60,15 +59,7 @@ interface Verifier {
             val reconstructedJsonObject: JsonObject,
             val disclosures: Collection<SelectiveDisclosureItem>,
             val freshnessSummary: CredentialFreshnessSummary.SdJwt,
-        ) : VerifyPresentationResult() {
-            @Deprecated("Replaced with more expressive TokenStatusValidationResult, supporting token status values as defined by the library client.", ReplaceWith("freshnessSummary.tokenStatusValidationResult"))
-            val tokenStatus: TokenStatusValidationResult
-                get() = freshnessSummary.tokenStatusValidationResult
-
-            @Deprecated("", ReplaceWith("credentialFreshnessSummary.timelinessValidationSummary"))
-            val timelinessValidationSummary: CredentialTimelinessValidationSummary.SdJwt
-                get() = freshnessSummary.timelinessValidationSummary
-        }
+        ) : VerifyPresentationResult()
 
         data class SuccessIso(val documents: List<IsoDocumentParsed>) : VerifyPresentationResult()
         data class InvalidStructure(val input: String) : VerifyPresentationResult()

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
@@ -59,7 +59,19 @@ interface Verifier {
             val reconstructedJsonObject: JsonObject,
             val disclosures: Collection<SelectiveDisclosureItem>,
             val freshnessSummary: CredentialFreshnessSummary.SdJwt,
-        ) : VerifyPresentationResult()
+        ) : VerifyPresentationResult() {
+            @Deprecated("Replaced with more expressive freshness information", ReplaceWith("""freshnessSummary.let { when(it.tokenStatusValidationResult) {
+                is TokenStatusValidationResult.Rejected -> null
+                is TokenStatusValidationResult.Invalid -> true
+                is TokenStatusValidationResult.Valid -> false
+            }}"""))
+            val isRevoked: Boolean?
+                get() = when(freshnessSummary.tokenStatusValidationResult) {
+                    is TokenStatusValidationResult.Rejected -> null
+                    is TokenStatusValidationResult.Invalid -> true
+                    is TokenStatusValidationResult.Valid -> false
+                }
+        }
 
         data class SuccessIso(val documents: List<IsoDocumentParsed>) : VerifyPresentationResult()
         data class InvalidStructure(val input: String) : VerifyPresentationResult()

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
@@ -5,6 +5,7 @@ import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.signum.indispensable.josef.jwkId
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
+import at.asitplus.wallet.lib.agent.validation.CredentialFreshnessSummary
 import at.asitplus.wallet.lib.agent.validation.CredentialTimelinessValidationSummary
 import at.asitplus.wallet.lib.data.*
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
@@ -58,9 +59,16 @@ interface Verifier {
             val verifiableCredentialSdJwt: VerifiableCredentialSdJwt,
             val reconstructedJsonObject: JsonObject,
             val disclosures: Collection<SelectiveDisclosureItem>,
-            val timelinessValidationSummary: CredentialTimelinessValidationSummary.SdJwt,
-            val tokenStatus: TokenStatusValidationResult,
-        ) : VerifyPresentationResult()
+            val freshnessSummary: CredentialFreshnessSummary.SdJwt,
+        ) : VerifyPresentationResult() {
+            @Deprecated("Replaced with more expressive TokenStatusValidationResult, supporting token status values as defined by the library client.", ReplaceWith("freshnessSummary.tokenStatusValidationResult"))
+            val tokenStatus: TokenStatusValidationResult
+                get() = freshnessSummary.tokenStatusValidationResult
+
+            @Deprecated("", ReplaceWith("credentialFreshnessSummary.timelinessValidationSummary"))
+            val timelinessValidationSummary: CredentialTimelinessValidationSummary.SdJwt
+                get() = freshnessSummary.timelinessValidationSummary
+        }
 
         data class SuccessIso(val documents: List<IsoDocumentParsed>) : VerifyPresentationResult()
         data class InvalidStructure(val input: String) : VerifyPresentationResult()

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/CredentialFreshnessSummary.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/CredentialFreshnessSummary.kt
@@ -1,0 +1,26 @@
+package at.asitplus.wallet.lib.agent.validation
+
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
+
+sealed interface CredentialFreshnessSummary {
+    val isFresh: Boolean
+        get() = timelinessValidationSummary.isTimely && tokenStatusValidationResult is TokenStatusValidationResult.Valid
+
+    val timelinessValidationSummary: CredentialTimelinessValidationSummary
+    val tokenStatusValidationResult: TokenStatusValidationResult
+
+    data class Mdoc(
+        override val timelinessValidationSummary: CredentialTimelinessValidationSummary.Mdoc,
+        override val tokenStatusValidationResult: TokenStatusValidationResult
+    ) : CredentialFreshnessSummary
+
+    data class SdJwt(
+        override val timelinessValidationSummary: CredentialTimelinessValidationSummary.SdJwt,
+        override val tokenStatusValidationResult: TokenStatusValidationResult
+    ) : CredentialFreshnessSummary
+
+    data class VcJws(
+        override val timelinessValidationSummary: CredentialTimelinessValidationSummary.VcJws,
+        override val tokenStatusValidationResult: TokenStatusValidationResult
+    ) : CredentialFreshnessSummary
+}

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/CredentialTimelinessValidationSummary.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/CredentialTimelinessValidationSummary.kt
@@ -4,27 +4,16 @@ import at.asitplus.wallet.lib.agent.validation.mdoc.MdocTimelinessValidationDeta
 import at.asitplus.wallet.lib.agent.validation.sdJwt.SdJwtTimelinessValidationDetails
 import at.asitplus.wallet.lib.agent.validation.vcJws.VcJwsTimelinessValidationDetails
 
-sealed interface CredentialTimelinessValidationSummary {
-    val isSuccess: Boolean
-
+sealed interface CredentialTimelinessValidationSummary : TimelinessIndicator {
     data class VcJws(
         val details: VcJwsTimelinessValidationDetails,
-    ) : CredentialTimelinessValidationSummary {
-        override val isSuccess
-            get() = details.isSuccess
-    }
+    ) : CredentialTimelinessValidationSummary, TimelinessIndicator by details
 
     data class SdJwt(
         val details: SdJwtTimelinessValidationDetails,
-    ) : CredentialTimelinessValidationSummary {
-        override val isSuccess: Boolean
-            get() = details.isSuccess
-    }
+    ) : CredentialTimelinessValidationSummary, TimelinessIndicator by details
 
     data class Mdoc(
         val details: MdocTimelinessValidationDetails,
-    ) : CredentialTimelinessValidationSummary {
-        override val isSuccess: Boolean
-            get() = details.isSuccess
-    }
+    ) : CredentialTimelinessValidationSummary, TimelinessIndicator by details
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/CredentialTimelinessValidator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/CredentialTimelinessValidator.kt
@@ -14,29 +14,20 @@ import kotlin.time.Duration.Companion.seconds
 data class CredentialTimelinessValidator(
     private val timeLeeway: Duration = 300.seconds,
     private val clock: Clock = Clock.System,
-    val vcJwsTimelinessValidator: VcJwsTimelinessValidator = VcJwsTimelinessValidator(
-        timeLeeway = timeLeeway,
-        clock = clock
-    ),
-    val sdJwtTimelinessValidator: SdJwtTimelinessValidator = SdJwtTimelinessValidator(
-        timeLeeway = timeLeeway,
-        clock = clock
-    ),
-    val mdocTimelinessValidator: MdocTimelinessValidator = MdocTimelinessValidator(
-        timeLeeway = timeLeeway,
-        clock = clock
-    ),
+    val vcJwsTimelinessValidator: VcJwsTimelinessValidator = VcJwsTimelinessValidator(),
+    val sdJwtTimelinessValidator: SdJwtTimelinessValidator = SdJwtTimelinessValidator(),
+    val mdocTimelinessValidator: MdocTimelinessValidator = MdocTimelinessValidator(),
 ) {
     operator fun invoke(issuerSigned: IssuerSigned) = CredentialTimelinessValidationSummary.Mdoc(
-        mdocTimelinessValidator(issuerSigned),
+        mdocTimelinessValidator(issuerSigned, timeScope = TimeScope(clock.now(), timeLeeway)),
     )
 
     operator fun invoke(sdJwt: VerifiableCredentialSdJwt) = CredentialTimelinessValidationSummary.SdJwt(
-        sdJwtTimelinessValidator(sdJwt),
+        sdJwtTimelinessValidator(sdJwt, timeScope = TimeScope(clock.now(), timeLeeway)),
     )
 
     operator fun invoke(vcJws: VerifiableCredentialJws) = CredentialTimelinessValidationSummary.VcJws(
-        vcJwsTimelinessValidator(vcJws = vcJws),
+        vcJwsTimelinessValidator(vcJws, timeScope = TimeScope(clock.now(), timeLeeway)),
     )
 
     operator fun invoke(storeEntry: SubjectCredentialStore.StoreEntry) = when (storeEntry) {

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/StatusListTokenResolver.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/StatusListTokenResolver.kt
@@ -1,44 +1,8 @@
 package at.asitplus.wallet.lib.agent.validation
 
-import at.asitplus.KmmResult.Companion.wrap
-import at.asitplus.wallet.lib.DefaultZlibService
-import at.asitplus.wallet.lib.ZlibService
-import at.asitplus.wallet.lib.cbor.VerifyCoseSignature
-import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureFun
 import at.asitplus.wallet.lib.data.StatusListToken
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListTokenPayload
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListTokenValidator
 import at.asitplus.wallet.lib.data.rfc3986.UniformResourceIdentifier
-import at.asitplus.wallet.lib.jws.VerifyJwsObject
-import at.asitplus.wallet.lib.jws.VerifyJwsObjectFun
-import kotlinx.datetime.Clock
 
 fun interface StatusListTokenResolver {
     suspend operator fun invoke(statusListUrl: UniformResourceIdentifier): StatusListToken
-
-    fun toTokenStatusResolver(
-        clock: Clock = Clock.System,
-        zlibService: ZlibService = DefaultZlibService(),
-        verifyJwsObjectIntegrity: VerifyJwsObjectFun = VerifyJwsObject(),
-        verifyCoseSignature: VerifyCoseSignatureFun<StatusListTokenPayload> = VerifyCoseSignature(),
-    ) = TokenStatusResolver { status ->
-        runCatching {
-            val token = this(status.statusList.uri)
-
-            val payload = token.validate(
-                verifyJwsObject = verifyJwsObjectIntegrity,
-                verifyCoseSignature = verifyCoseSignature,
-                statusListInfo = status.statusList,
-                isInstantInThePast = {
-                    it < kotlinx.datetime.Instant.fromEpochMilliseconds(clock.now().toEpochMilliseconds())
-                },
-            ).getOrThrow()
-
-            StatusListTokenValidator.extractTokenStatus(
-                statusList = payload.statusList,
-                statusListInfo = status.statusList,
-                zlibService = zlibService,
-            ).getOrThrow()
-        }.wrap()
-    }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/TimeScope.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/TimeScope.kt
@@ -1,6 +1,5 @@
 package at.asitplus.wallet.lib.agent.validation
 
-import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.time.Duration
 
@@ -14,12 +13,5 @@ data class TimeScope(
     fun Instant.isTooEarly() = this < earliestTime
     fun Instant.isTooLate() = this > latestTime
 
-    companion object {
-        fun <T> timeScoped(clock: Clock, timeLeeway: Duration, block: TimeScope.() -> T) = block(
-            TimeScope(
-                now = clock.now(),
-                timeLeeway = timeLeeway,
-            ),
-        )
-    }
+    operator fun <T> invoke(block: TimeScope.() -> T) = block(this)
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/TimelinessIndicator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/TimelinessIndicator.kt
@@ -1,0 +1,14 @@
+package at.asitplus.wallet.lib.agent.validation
+
+import kotlinx.datetime.Instant
+
+interface TimelinessIndicator {
+    val evaluationTime: Instant
+
+    val isExpired: Boolean
+
+    val isNotYetValid: Boolean
+
+    val isTimely: Boolean
+        get() = !isNotYetValid && !isExpired
+}

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/TokenStatusResolver.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/TokenStatusResolver.kt
@@ -1,15 +1,51 @@
 package at.asitplus.wallet.lib.agent.validation
 
 import at.asitplus.KmmResult
+import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.wallet.lib.DefaultZlibService
+import at.asitplus.wallet.lib.ZlibService
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
+import at.asitplus.wallet.lib.cbor.VerifyCoseSignature
+import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureFun
 import at.asitplus.wallet.lib.data.Status
 import at.asitplus.wallet.lib.data.VerifiableCredentialJws
 import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListTokenPayload
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListTokenValidator
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
 import at.asitplus.wallet.lib.iso.IssuerSigned
+import at.asitplus.wallet.lib.jws.VerifyJwsObject
+import at.asitplus.wallet.lib.jws.VerifyJwsObjectFun
+import kotlinx.datetime.Clock
 
 fun interface TokenStatusResolver {
     suspend operator fun invoke(status: Status): KmmResult<TokenStatus>
+}
+
+fun StatusListTokenResolver.toTokenStatusResolver(
+    clock: Clock = Clock.System,
+    zlibService: ZlibService = DefaultZlibService(),
+    verifyJwsObjectIntegrity: VerifyJwsObjectFun = VerifyJwsObject(),
+    verifyCoseSignature: VerifyCoseSignatureFun<StatusListTokenPayload> = VerifyCoseSignature(),
+) = TokenStatusResolver { status ->
+    runCatching {
+        val token = this(status.statusList.uri)
+
+        val payload = token.validate(
+            verifyJwsObject = verifyJwsObjectIntegrity,
+            verifyCoseSignature = verifyCoseSignature,
+            statusListInfo = status.statusList,
+            isInstantInThePast = {
+                it < kotlinx.datetime.Instant.fromEpochMilliseconds(clock.now().toEpochMilliseconds())
+            },
+        ).getOrThrow()
+
+        StatusListTokenValidator.extractTokenStatus(
+            statusList = payload.statusList,
+            statusListInfo = status.statusList,
+            zlibService = zlibService,
+        ).getOrThrow()
+    }.wrap()
 }
 
 suspend operator fun TokenStatusResolver.invoke(issuerSigned: IssuerSigned) = invoke(CredentialWrapper.Mdoc(issuerSigned))

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/mdoc/MdocTimelinessValidationDetails.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/mdoc/MdocTimelinessValidationDetails.kt
@@ -1,8 +1,16 @@
 package at.asitplus.wallet.lib.agent.validation.mdoc
 
+import at.asitplus.wallet.lib.agent.validation.TimelinessIndicator
+import kotlinx.datetime.Instant
+
 data class MdocTimelinessValidationDetails(
+    override val evaluationTime: Instant,
     val msoTimelinessValidationSummary: MobileSecurityObjectTimelinessValidationSummary?,
-) {
-    val isSuccess: Boolean
-        get() = msoTimelinessValidationSummary?.isSuccess != false
+) : TimelinessIndicator {
+    override val isExpired: Boolean
+        get() = msoTimelinessValidationSummary?.isExpired ?: false
+
+    override val isNotYetValid: Boolean
+        get() = msoTimelinessValidationSummary?.isNotYetValid ?: false
 }
+

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/mdoc/MdocTimelinessValidator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/mdoc/MdocTimelinessValidator.kt
@@ -1,25 +1,25 @@
 package at.asitplus.wallet.lib.agent.validation.mdoc
 
+import at.asitplus.wallet.lib.agent.validation.TimeScope
 import at.asitplus.wallet.lib.iso.IssuerSigned
 import io.github.aakira.napier.Napier
-import kotlinx.datetime.Clock
-import kotlin.time.Duration
 
 class MdocTimelinessValidator(
-    clock: Clock,
-    timeLeeway: Duration,
-    private val mobileSecurityObjectTimelinessValidator: MobileSecurityObjectTimelinessValidator = MobileSecurityObjectTimelinessValidator(
-        clock = clock,
-        timeLeeway = timeLeeway,
-    ),
+    private val mobileSecurityObjectTimelinessValidator: MobileSecurityObjectTimelinessValidator = MobileSecurityObjectTimelinessValidator(),
 ) {
-    operator fun invoke(issuerSigned: IssuerSigned) = MdocTimelinessValidationDetails(
-        msoTimelinessValidationSummary = issuerSigned.issuerAuth.payload?.let {
-            mobileSecurityObjectTimelinessValidator(it)
-        }
-    ).also {
-        if(it.isSuccess) {
-            Napier.d("ISO Cred $it is timely")
+    operator fun invoke(
+        issuerSigned: IssuerSigned,
+        timeScope: TimeScope,
+    ) = timeScope {
+        MdocTimelinessValidationDetails(
+            evaluationTime = now,
+            msoTimelinessValidationSummary = issuerSigned.issuerAuth.payload?.let {
+                mobileSecurityObjectTimelinessValidator(it, timeScope)
+            }
+        ).also {
+            if(it.isTimely) {
+                Napier.d("ISO Cred $it is timely")
+            }
         }
     }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/mdoc/MobileSecurityObjectTimelinessValidationSummary.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/mdoc/MobileSecurityObjectTimelinessValidationSummary.kt
@@ -1,16 +1,18 @@
 package at.asitplus.wallet.lib.agent.validation.mdoc
 
+import at.asitplus.wallet.lib.agent.validation.TimelinessIndicator
 import at.asitplus.wallet.lib.agent.validation.common.EntityExpiredError
 import at.asitplus.wallet.lib.agent.validation.common.EntityNotYetValidError
 import kotlinx.datetime.Instant
 
 data class MobileSecurityObjectTimelinessValidationSummary(
-    val evaluationTime: Instant,
+    override val evaluationTime: Instant,
     val mdocExpiredError: EntityExpiredError?,
     val mdocNotYetValidError: EntityNotYetValidError?,
-) {
-    val isSuccess = listOf(
-        mdocExpiredError,
-        mdocNotYetValidError,
-    ).all { it == null }
+) : TimelinessIndicator {
+    override val isExpired: Boolean
+        get() = mdocExpiredError != null
+
+    override val isNotYetValid: Boolean
+        get() = mdocNotYetValidError != null
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/mdoc/MobileSecurityObjectTimelinessValidator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/mdoc/MobileSecurityObjectTimelinessValidator.kt
@@ -1,19 +1,16 @@
 package at.asitplus.wallet.lib.agent.validation.mdoc
 
-import at.asitplus.wallet.lib.agent.validation.TimeScope.Companion.timeScoped
+import at.asitplus.wallet.lib.agent.validation.TimeScope
 import at.asitplus.wallet.lib.agent.validation.common.EntityExpiredError
 import at.asitplus.wallet.lib.agent.validation.common.EntityNotYetValidError
 import at.asitplus.wallet.lib.iso.MobileSecurityObject
 import io.github.aakira.napier.Napier
-import kotlinx.datetime.Clock
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
-data class MobileSecurityObjectTimelinessValidator(
-    val timeLeeway: Duration = 300.seconds,
-    private val clock: Clock = Clock.System,
-) {
-    operator fun invoke(mobileSecurityObject: MobileSecurityObject) = timeScoped(clock, timeLeeway) {
+class MobileSecurityObjectTimelinessValidator {
+    operator fun invoke(
+        mobileSecurityObject: MobileSecurityObject,
+        timeScope: TimeScope,
+    ) = timeScope {
         MobileSecurityObjectTimelinessValidationSummary(
             evaluationTime = now,
             mdocExpiredError = if (mobileSecurityObject.validityInfo.validUntil.isTooEarly()) {
@@ -31,7 +28,7 @@ data class MobileSecurityObjectTimelinessValidator(
                 )
             } else null,
         ).also {
-            if (it.isSuccess) {
+            if (it.isTimely) {
                 Napier.d("MSO is timely")
             }
         }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/sdJwt/SdJwtTimelinessValidationDetails.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/sdJwt/SdJwtTimelinessValidationDetails.kt
@@ -1,17 +1,18 @@
 package at.asitplus.wallet.lib.agent.validation.sdJwt
 
+import at.asitplus.wallet.lib.agent.validation.TimelinessIndicator
 import at.asitplus.wallet.lib.agent.validation.common.EntityExpiredError
 import at.asitplus.wallet.lib.agent.validation.common.EntityNotYetValidError
 import kotlinx.datetime.Instant
 
 data class SdJwtTimelinessValidationDetails(
-    val evaluationTime: Instant,
+    override val evaluationTime: Instant,
     val jwsExpiredError: EntityExpiredError?,
     val jwsNotYetValidError: EntityNotYetValidError?,
-) {
-    val isSuccess: Boolean
-        get() = listOf(
-            jwsExpiredError,
-            jwsNotYetValidError,
-        ).all { it == null }
+): TimelinessIndicator {
+    override val isExpired: Boolean
+        get() = jwsExpiredError != null
+
+    override val isNotYetValid: Boolean
+        get() = jwsNotYetValidError != null
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/sdJwt/SdJwtTimelinessValidator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/sdJwt/SdJwtTimelinessValidator.kt
@@ -1,19 +1,16 @@
 package at.asitplus.wallet.lib.agent.validation.sdJwt
 
-import at.asitplus.wallet.lib.agent.validation.TimeScope.Companion.timeScoped
+import at.asitplus.wallet.lib.agent.validation.TimeScope
 import at.asitplus.wallet.lib.agent.validation.common.EntityExpiredError
 import at.asitplus.wallet.lib.agent.validation.common.EntityNotYetValidError
 import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import io.github.aakira.napier.Napier
-import kotlinx.datetime.Clock
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
-data class SdJwtTimelinessValidator(
-    val timeLeeway: Duration = 300.seconds,
-    private val clock: Clock = Clock.System,
-) {
-    operator fun invoke(sdJwt: VerifiableCredentialSdJwt)  = timeScoped(clock, timeLeeway) {
+class SdJwtTimelinessValidator {
+    operator fun invoke(
+        sdJwt: VerifiableCredentialSdJwt,
+        timeScope: TimeScope,
+    )  = timeScope {
         SdJwtTimelinessValidationDetails(
             evaluationTime = now,
             jwsExpiredError = if (sdJwt.expiration != null && sdJwt.expiration.isTooEarly()) {
@@ -31,7 +28,7 @@ data class SdJwtTimelinessValidator(
                 )
             } else null,
         ).also {
-            if (it.isSuccess) {
+            if (it.isTimely) {
                 Napier.d("SD-JWT is timely")
             }
         }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/vcJws/VcJwsTimelinessValidationDetails.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/vcJws/VcJwsTimelinessValidationDetails.kt
@@ -1,21 +1,21 @@
 package at.asitplus.wallet.lib.agent.validation.vcJws
 
+import at.asitplus.wallet.lib.agent.validation.TimelinessIndicator
 import at.asitplus.wallet.lib.agent.validation.common.EntityExpiredError
 import at.asitplus.wallet.lib.agent.validation.common.EntityNotYetValidError
 import kotlinx.datetime.Instant
 
 data class VcJwsTimelinessValidationDetails(
-    val evaluationTime: Instant,
+    override val evaluationTime: Instant,
     val jwsExpiredError: EntityExpiredError?,
     val credentialExpiredError: EntityExpiredError?,
     val jwsNotYetValidError: EntityNotYetValidError?,
     val credentialNotYetValidError: EntityNotYetValidError?,
-) {
-    val isSuccess = listOf(
-        jwsExpiredError,
-        credentialExpiredError,
-        jwsNotYetValidError,
-        credentialNotYetValidError,
-    ).all { it == null }
+): TimelinessIndicator {
+    override val isExpired: Boolean
+        get() = jwsExpiredError != null || credentialExpiredError != null
+
+    override val isNotYetValid: Boolean
+        get() = jwsNotYetValidError != null || credentialNotYetValidError != null
 }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/vcJws/VcJwsTimelinessValidator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/vcJws/VcJwsTimelinessValidator.kt
@@ -1,20 +1,16 @@
 package at.asitplus.wallet.lib.agent.validation.vcJws
 
-import at.asitplus.wallet.lib.agent.validation.TimeScope.Companion.timeScoped
+import at.asitplus.wallet.lib.agent.validation.TimeScope
 import at.asitplus.wallet.lib.agent.validation.common.EntityExpiredError
 import at.asitplus.wallet.lib.agent.validation.common.EntityNotYetValidError
 import at.asitplus.wallet.lib.data.VerifiableCredentialJws
 import io.github.aakira.napier.Napier
-import kotlinx.datetime.Clock
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
-data class VcJwsTimelinessValidator(
-    val timeLeeway: Duration = 300.seconds,
-    private val clock: Clock = Clock.System,
-) {
-
-    operator fun invoke(vcJws: VerifiableCredentialJws) = timeScoped(clock, timeLeeway) {
+class VcJwsTimelinessValidator {
+    operator fun invoke(
+        vcJws: VerifiableCredentialJws,
+        timeScope: TimeScope,
+    ) = timeScope {
         VcJwsTimelinessValidationDetails(
             evaluationTime = now,
             jwsExpiredError = if (vcJws.expiration != null && vcJws.expiration.isTooEarly()) {
@@ -46,7 +42,7 @@ data class VcJwsTimelinessValidator(
                 )
             } else null,
         ).also {
-            if (it.isSuccess) {
+            if (it.isTimely) {
                 Napier.d("VC is timely")
             }
         }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/IsoDocumentParsed.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/IsoDocumentParsed.kt
@@ -1,9 +1,6 @@
 package at.asitplus.wallet.lib.data
 
-import at.asitplus.KmmResult
 import at.asitplus.wallet.lib.agent.validation.CredentialFreshnessSummary
-import at.asitplus.wallet.lib.agent.validation.CredentialTimelinessValidationSummary
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 import at.asitplus.wallet.lib.iso.IssuerSignedItem
 import at.asitplus.wallet.lib.iso.MobileSecurityObject
@@ -18,15 +15,7 @@ data class IsoDocumentParsed(
     val invalidItems: List<IssuerSignedItem> = listOf(),
     val freshnessSummary: CredentialFreshnessSummary.Mdoc,
 ) {
-    @Deprecated("Replaced with more expressive TokenStatusValidationResult, supporting token status values as defined by the library client.", ReplaceWith("freshnessSummary.tokenStatusValidationResult"))
-    val tokenStatus: KmmResult<TokenStatus>?
-        get() = when(val it = freshnessSummary.tokenStatusValidationResult) {
-            is TokenStatusValidationResult.Invalid -> KmmResult.success(it.tokenStatus)
-            is TokenStatusValidationResult.Rejected -> KmmResult.failure(it.throwable)
-            is TokenStatusValidationResult.Valid -> it.tokenStatus?.let { KmmResult.success(it) }
-        }
-
-    @Deprecated("", ReplaceWith("freshnessSummary.timelinessValidationSummary"))
-    val timelinessValidationSummary: CredentialTimelinessValidationSummary.Mdoc
-        get() = freshnessSummary.timelinessValidationSummary
+    @Deprecated("Replaced with more expressive freshness information", ReplaceWith("freshnessSummary.tokenStatusValidationResult is TokenStatusValidationResult.Invalid"))
+    val isRevoked: Boolean
+        get() = freshnessSummary.tokenStatusValidationResult is TokenStatusValidationResult.Invalid
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/IsoDocumentParsed.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/IsoDocumentParsed.kt
@@ -15,7 +15,15 @@ data class IsoDocumentParsed(
     val invalidItems: List<IssuerSignedItem> = listOf(),
     val freshnessSummary: CredentialFreshnessSummary.Mdoc,
 ) {
-    @Deprecated("Replaced with more expressive freshness information", ReplaceWith("freshnessSummary.tokenStatusValidationResult is TokenStatusValidationResult.Invalid"))
-    val isRevoked: Boolean
-        get() = freshnessSummary.tokenStatusValidationResult is TokenStatusValidationResult.Invalid
+    @Deprecated("Replaced with more expressive freshness information", ReplaceWith("""freshnessSummary.let { when(it.tokenStatusValidationResult) {
+            is TokenStatusValidationResult.Rejected -> null
+            is TokenStatusValidationResult.Invalid -> true
+            is TokenStatusValidationResult.Valid -> false
+        }}"""))
+    val isRevoked: Boolean?
+        get() = when(freshnessSummary.tokenStatusValidationResult) {
+            is TokenStatusValidationResult.Rejected -> null
+            is TokenStatusValidationResult.Invalid -> true
+            is TokenStatusValidationResult.Valid -> false
+        }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/IsoDocumentParsed.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/IsoDocumentParsed.kt
@@ -1,6 +1,9 @@
 package at.asitplus.wallet.lib.data
 
+import at.asitplus.KmmResult
+import at.asitplus.wallet.lib.agent.validation.CredentialFreshnessSummary
 import at.asitplus.wallet.lib.agent.validation.CredentialTimelinessValidationSummary
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 import at.asitplus.wallet.lib.iso.IssuerSignedItem
 import at.asitplus.wallet.lib.iso.MobileSecurityObject
@@ -13,6 +16,17 @@ data class IsoDocumentParsed(
     val mso: MobileSecurityObject,
     val validItems: List<IssuerSignedItem> = listOf(),
     val invalidItems: List<IssuerSignedItem> = listOf(),
-    val tokenStatus: TokenStatusValidationResult,
-    val timelinessValidationSummary: CredentialTimelinessValidationSummary.Mdoc,
-)
+    val freshnessSummary: CredentialFreshnessSummary.Mdoc,
+) {
+    @Deprecated("Replaced with more expressive TokenStatusValidationResult, supporting token status values as defined by the library client.", ReplaceWith("freshnessSummary.tokenStatusValidationResult"))
+    val tokenStatus: KmmResult<TokenStatus>?
+        get() = when(val it = freshnessSummary.tokenStatusValidationResult) {
+            is TokenStatusValidationResult.Invalid -> KmmResult.success(it.tokenStatus)
+            is TokenStatusValidationResult.Rejected -> KmmResult.failure(it.throwable)
+            is TokenStatusValidationResult.Valid -> it.tokenStatus?.let { KmmResult.success(it) }
+        }
+
+    @Deprecated("", ReplaceWith("freshnessSummary.timelinessValidationSummary"))
+    val timelinessValidationSummary: CredentialTimelinessValidationSummary.Mdoc
+        get() = freshnessSummary.timelinessValidationSummary
+}

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VcJwsVerificationResultWrapper.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VcJwsVerificationResultWrapper.kt
@@ -1,10 +1,26 @@
 package at.asitplus.wallet.lib.data
 
+import at.asitplus.KmmResult
+import at.asitplus.wallet.lib.agent.validation.CredentialFreshnessSummary
 import at.asitplus.wallet.lib.agent.validation.CredentialTimelinessValidationSummary
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 
 data class VcJwsVerificationResultWrapper(
     val vcJws: VerifiableCredentialJws,
-    val tokenStatus: TokenStatusValidationResult,
-    val timelinessValidationSummary: CredentialTimelinessValidationSummary.VcJws,
-)
+    val freshnessSummary: CredentialFreshnessSummary.VcJws,
+) {
+    @Suppress("unused")
+    @Deprecated("Replaced with more expressive TokenStatusValidationResult, supporting token status values as defined by the library client.", ReplaceWith("freshnessSummary.tokenStatusValidationResult"))
+    val tokenStatus: KmmResult<TokenStatus>?
+        get() = when(val it = freshnessSummary.tokenStatusValidationResult) {
+            is TokenStatusValidationResult.Invalid -> KmmResult.success(it.tokenStatus)
+            is TokenStatusValidationResult.Rejected -> KmmResult.failure(it.throwable)
+            is TokenStatusValidationResult.Valid -> it.tokenStatus?.let { KmmResult.success(it) }
+        }
+
+    @Suppress("unused")
+    @Deprecated("Moved to content of other member.", ReplaceWith("freshnessSummary.timelinessValidationSummary"))
+    val timelinessValidationSummary: CredentialTimelinessValidationSummary.VcJws
+        get() = freshnessSummary.timelinessValidationSummary
+}

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VcJwsVerificationResultWrapper.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VcJwsVerificationResultWrapper.kt
@@ -1,26 +1,8 @@
 package at.asitplus.wallet.lib.data
 
-import at.asitplus.KmmResult
 import at.asitplus.wallet.lib.agent.validation.CredentialFreshnessSummary
-import at.asitplus.wallet.lib.agent.validation.CredentialTimelinessValidationSummary
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 
 data class VcJwsVerificationResultWrapper(
     val vcJws: VerifiableCredentialJws,
     val freshnessSummary: CredentialFreshnessSummary.VcJws,
-) {
-    @Suppress("unused")
-    @Deprecated("Replaced with more expressive TokenStatusValidationResult, supporting token status values as defined by the library client.", ReplaceWith("freshnessSummary.tokenStatusValidationResult"))
-    val tokenStatus: KmmResult<TokenStatus>?
-        get() = when(val it = freshnessSummary.tokenStatusValidationResult) {
-            is TokenStatusValidationResult.Invalid -> KmmResult.success(it.tokenStatus)
-            is TokenStatusValidationResult.Rejected -> KmmResult.failure(it.throwable)
-            is TokenStatusValidationResult.Valid -> it.tokenStatus?.let { KmmResult.success(it) }
-        }
-
-    @Suppress("unused")
-    @Deprecated("Moved to content of other member.", ReplaceWith("freshnessSummary.timelinessValidationSummary"))
-    val timelinessValidationSummary: CredentialTimelinessValidationSummary.VcJws
-        get() = freshnessSummary.timelinessValidationSummary
-}
+)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiablePresentationParsed.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiablePresentationParsed.kt
@@ -15,15 +15,15 @@ data class VerifiablePresentationParsed(
     val invalidVerifiableCredentials: Collection<String> = listOf(),
 ) {
     @Suppress("UNUSED")
-    @Deprecated("Renamed to represent new validation semantics.", ReplaceWith("notVerifiablyFreshVerifiableCredentials"))
-    val revokedVerifiableCredentials
-        get() = notVerifiablyFreshVerifiableCredentials
-
-    @Suppress("UNUSED")
     @Deprecated("Renamed to represent new validation semantics.", ReplaceWith("freshVerifiableCredentials.map { it.vcJws }"))
     val verifiableCredentials
         get() = freshVerifiableCredentials.map {
             it.vcJws
         }
+
+    @Suppress("UNUSED")
+    @Deprecated("Renamed to represent new validation semantics.", ReplaceWith("notVerifiablyFreshVerifiableCredentials"))
+    val revokedVerifiableCredentials
+        get() = notVerifiablyFreshVerifiableCredentials
 }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiablePresentationParsed.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiablePresentationParsed.kt
@@ -15,25 +15,15 @@ data class VerifiablePresentationParsed(
     val invalidVerifiableCredentials: Collection<String> = listOf(),
 ) {
     @Suppress("UNUSED")
-    @Deprecated("Renamed to represent new validation semantics.", ReplaceWith("untimelyVerifiableCredentials"))
+    @Deprecated("Renamed to represent new validation semantics.", ReplaceWith("notVerifiablyFreshVerifiableCredentials"))
     val revokedVerifiableCredentials
         get() = notVerifiablyFreshVerifiableCredentials
 
     @Suppress("UNUSED")
-    @Deprecated("Renamed to represent new validation semantics.", ReplaceWith("timelyVerifiableCredentials.map { it.vcJws }"))
+    @Deprecated("Renamed to represent new validation semantics.", ReplaceWith("freshVerifiableCredentials.map { it.vcJws }"))
     val verifiableCredentials
         get() = freshVerifiableCredentials.map {
             it.vcJws
         }
-
-    @Suppress("UNUSED")
-    @Deprecated("Renamed to represent new validation semantics.", ReplaceWith("freshVerifiableCredentials"))
-    val timelyVerifiableCredentials
-        get() = freshVerifiableCredentials
-
-    @Suppress("UNUSED")
-    @Deprecated("Renamed to better represent validation semantics.", ReplaceWith("notVerifiablyFreshVerifiableCredentials"))
-    val untimelyVerifiableCredentials
-        get() = notVerifiablyFreshVerifiableCredentials
 }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiablePresentationParsed.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiablePresentationParsed.kt
@@ -7,20 +7,33 @@ package at.asitplus.wallet.lib.data
 data class VerifiablePresentationParsed(
     val id: String,
     val type: String,
-    val timelyVerifiableCredentials: Collection<VcJwsVerificationResultWrapper> = listOf(),
-    val untimelyVerifiableCredentials: Collection<VcJwsVerificationResultWrapper> = listOf(),
+    val freshVerifiableCredentials: Collection<VcJwsVerificationResultWrapper> = listOf(),
+    /**
+     * This list may contain credentials where evaluation of the token status failed.
+     */
+    val notVerifiablyFreshVerifiableCredentials: Collection<VcJwsVerificationResultWrapper> = listOf(),
     val invalidVerifiableCredentials: Collection<String> = listOf(),
 ) {
     @Suppress("UNUSED")
     @Deprecated("Renamed to represent new validation semantics.", ReplaceWith("untimelyVerifiableCredentials"))
     val revokedVerifiableCredentials
-        get() = untimelyVerifiableCredentials
+        get() = notVerifiablyFreshVerifiableCredentials
 
     @Suppress("UNUSED")
     @Deprecated("Renamed to represent new validation semantics.", ReplaceWith("timelyVerifiableCredentials.map { it.vcJws }"))
     val verifiableCredentials
-        get() = timelyVerifiableCredentials.map {
+        get() = freshVerifiableCredentials.map {
             it.vcJws
         }
+
+    @Suppress("UNUSED")
+    @Deprecated("Renamed to represent new validation semantics.", ReplaceWith("freshVerifiableCredentials"))
+    val timelyVerifiableCredentials
+        get() = freshVerifiableCredentials
+
+    @Suppress("UNUSED")
+    @Deprecated("Renamed to better represent validation semantics.", ReplaceWith("notVerifiablyFreshVerifiableCredentials"))
+    val untimelyVerifiableCredentials
+        get() = notVerifiablyFreshVerifiableCredentials
 }
 

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
@@ -6,11 +6,11 @@ import at.asitplus.dif.PresentationDefinition
 import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.openid.dcql.*
 import at.asitplus.signum.indispensable.josef.JwsSigned
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 import at.asitplus.wallet.lib.data.*
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_DATE_OF_BIRTH
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
 import at.asitplus.wallet.lib.data.CredentialPresentation.PresentationExchangePresentation
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 import at.asitplus.wallet.lib.iso.sha256
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.jws.SdJwtSigned
@@ -99,7 +99,7 @@ class AgentSdJwtTest : FreeSpec({
             .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
 
         verified.reconstructedJsonObject.keys shouldContain CLAIM_GIVEN_NAME
-        verified.tokenStatus.shouldNotBeInstanceOf<TokenStatusValidationResult.Invalid>()
+        verified.freshnessSummary.tokenStatusValidationResult.shouldNotBeInstanceOf<TokenStatusValidationResult.Invalid>()
     }
 
     "when using presentation exchange" - {
@@ -117,7 +117,7 @@ class AgentSdJwtTest : FreeSpec({
 
             verified.reconstructedJsonObject[CLAIM_GIVEN_NAME]?.jsonPrimitive?.content shouldBe "Susanne"
             verified.reconstructedJsonObject[CLAIM_DATE_OF_BIRTH]?.jsonPrimitive?.content shouldBe "1990-01-01"
-            verified.tokenStatus.shouldNotBeInstanceOf<TokenStatusValidationResult.Invalid>()
+            verified.freshnessSummary.tokenStatusValidationResult.shouldNotBeInstanceOf<TokenStatusValidationResult.Invalid>()
         }
 
         "wrong key binding jwt" {
@@ -165,7 +165,7 @@ class AgentSdJwtTest : FreeSpec({
             issuer.revokeCredentialsWithId(listOfJwtId) shouldBe true
             val verified = verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
-            verified.tokenStatus.shouldBeInstanceOf<TokenStatusValidationResult.Invalid>()
+            verified.freshnessSummary.tokenStatusValidationResult.shouldBeInstanceOf<TokenStatusValidationResult.Invalid>()
         }
     }
 
@@ -193,7 +193,7 @@ class AgentSdJwtTest : FreeSpec({
 
             verified.reconstructedJsonObject[CLAIM_GIVEN_NAME]?.jsonPrimitive?.content shouldBe "Susanne"
             verified.reconstructedJsonObject[CLAIM_DATE_OF_BIRTH]?.jsonPrimitive?.content shouldBe "1990-01-01"
-            verified.tokenStatus.shouldNotBeInstanceOf<TokenStatusValidationResult.Invalid>()
+            verified.freshnessSummary.tokenStatusValidationResult.shouldNotBeInstanceOf<TokenStatusValidationResult.Invalid>()
         }
 
         "wrong key binding jwt" {
@@ -263,7 +263,7 @@ class AgentSdJwtTest : FreeSpec({
             issuer.revokeCredentialsWithId(listOfJwtId) shouldBe true
             val verified = verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
-            verified.tokenStatus.shouldBeInstanceOf<TokenStatusValidationResult.Invalid>()
+            verified.freshnessSummary.tokenStatusValidationResult.shouldBeInstanceOf<TokenStatusValidationResult.Invalid>()
         }
     }
 })

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentTest.kt
@@ -215,9 +215,9 @@ class AgentTest : FreeSpec({
 
             verifier.verifyPresentationVcJwt(vp.jwsSigned.getOrThrow(), challenge).also {
                 it.shouldBeInstanceOf<Verifier.VerifyPresentationResult.Success>()
-                it.vp.untimelyVerifiableCredentials.shouldBeEmpty()
+                it.vp.notVerifiablyFreshVerifiableCredentials.shouldBeEmpty()
                 it.vp.invalidVerifiableCredentials.shouldBeEmpty()
-                it.vp.timelyVerifiableCredentials shouldHaveSize 1
+                it.vp.freshVerifiableCredentials shouldHaveSize 1
             }
         }
 
@@ -341,8 +341,8 @@ class AgentTest : FreeSpec({
 
             verifier.verifyPresentationVcJwt(vp.jwsSigned.getOrThrow(), challenge).also {
                 it.shouldBeInstanceOf<Verifier.VerifyPresentationResult.Success>()
-                it.vp.untimelyVerifiableCredentials.shouldBeEmpty()
-                it.vp.timelyVerifiableCredentials shouldHaveSize 1
+                it.vp.notVerifiablyFreshVerifiableCredentials.shouldBeEmpty()
+                it.vp.freshVerifiableCredentials shouldHaveSize 1
             }
         }
 

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcTest.kt
@@ -6,10 +6,10 @@ import at.asitplus.signum.indispensable.josef.JwsHeader
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.signum.supreme.signature
 import at.asitplus.wallet.lib.agent.Verifier.VerifyCredentialResult
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 import at.asitplus.wallet.lib.data.*
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListInfo
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 import at.asitplus.wallet.lib.data.rfc3986.UniformResourceIdentifier
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.jws.JwsHeaderKeyId
@@ -313,7 +313,7 @@ class ValidatorVcTest : FreeSpec() {
                         val validationResult = validator.verifyVcJws(it, verifierKeyMaterial.publicKey)
                             .shouldBeInstanceOf<VerifyCredentialResult.SuccessJwt>()
 
-                        validator.checkTimeliness(validationResult.jws).isSuccess shouldBe false
+                        validator.checkCredentialTimeliness(validationResult.jws).isTimely shouldBe false
                     }
             }
         }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVpTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVpTest.kt
@@ -118,8 +118,8 @@ class ValidatorVpTest : FreeSpec({
 
         verifier.verifyPresentationVcJwt(vp.jwsSigned.getOrThrow(), challenge).also {
             it.shouldBeInstanceOf<VerifyPresentationResult.Success>()
-            it.vp.timelyVerifiableCredentials.shouldBeEmpty()
-            it.vp.untimelyVerifiableCredentials.shouldBeEmpty()
+            it.vp.freshVerifiableCredentials.shouldBeEmpty()
+            it.vp.notVerifiablyFreshVerifiableCredentials.shouldBeEmpty()
             it.vp.invalidVerifiableCredentials.shouldBe(holderVcSerialized)
         }
     }
@@ -169,7 +169,7 @@ class ValidatorVpTest : FreeSpec({
 
         verifier.verifyPresentationVcJwt(vp.jwsSigned.getOrThrow(), challenge).also {
             it.shouldBeInstanceOf<VerifyPresentationResult.Success>()
-            it.vp.timelyVerifiableCredentials.shouldBeEmpty()
+            it.vp.freshVerifiableCredentials.shouldBeEmpty()
         }
         holderCredentialStore.getCredentials().getOrThrow()
             .shouldHaveSize(1)


### PR DESCRIPTION
Merges results for timeliness and status validation into one, thereby introducing a "freshness" semantic.
Credentials are `fresh` if they are both timely (`nbf` < `now` < `exp`) and the corresponding status is resolvable and accepted by the library client. 
