### PR TITLE
Improvements from Vilnius Interop Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+Release 5.6.5:
+ - OpenID for Verifiable Presentations:
+   - Change JSON Path serialization for claims to dot notation (for EUDIW reference implementation)
+   - Change `vct` filter to contain `const` instead of `pattern` (for EUDIW reference implementation)
+
 Release 5.6.4:
  - OpenID for Verifiable Presentations:
    - Correctly handle requested attributes with nested paths, i.e. `address.formatted`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release 5.6.5:
  - OpenID for Verifiable Presentations:
    - Change JSON Path serialization for claims to dot notation (for EUDIW reference implementation)
    - Change `vct` filter to contain `const` instead of `pattern` (for EUDIW reference implementation)
+   - Treat requested attributes as optional, if not explicitly set as required
+   - Treat selected submission from the user as valid, let verifier decide if submission shall be accepted
 
 Release 5.6.4:
  - OpenID for Verifiable Presentations:

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
-artifactVersion = 5.6.4
+artifactVersion = 5.6.5-SNAPSHOT
 jdk.version=17
 org.jetbrains.dokka.experimental.tryK2=true
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -359,6 +359,7 @@ open class OpenId4VpVerifier(
      * Validates [AuthenticationResponseParameters] from the Wallet
      */
     suspend fun validateAuthnResponse(input: ResponseParametersFrom): AuthnResponseResult {
+        Napier.d("validateAuthnResponse: $input")
         val params = input.parameters
         val state = params.state
             ?: return AuthnResponseResult.ValidationError("state", params.state)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestOptions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestOptions.kt
@@ -3,6 +3,7 @@ package at.asitplus.wallet.lib.openid
 import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
 import at.asitplus.dif.*
 import at.asitplus.jsonpath.core.NormalizedJsonPath
+import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
 import at.asitplus.jsonpath.core.NormalizedJsonPathSegment.NameSegment
 import at.asitplus.openid.*
 import at.asitplus.openid.OpenIdConstants.SCOPE_OPENID
@@ -16,7 +17,7 @@ import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
 import at.asitplus.wallet.lib.data.ConstantIndex.supportsSdJwt
 import at.asitplus.wallet.lib.data.ConstantIndex.supportsVcJwt
 import com.benasher44.uuid.uuid4
-import io.ktor.http.*
+import kotlinx.serialization.json.JsonPrimitive
 
 // TODO Should be NormalizedJsonPath
 typealias RequestedAttributes = Set<String>
@@ -270,17 +271,28 @@ data class RequestOptionsCredential(
         scheme: ConstantIndex.CredentialScheme?,
         optional: Boolean,
     ): Collection<ConstraintField> = map {
-        if (isMdoc) it.toIsoMdocConstraintField(scheme) else it.toJwtConstraintField(optional)
+        if (isMdoc) it.toIsoMdocConstraintField(scheme, optional) else it.toJwtConstraintField(optional)
     }
 
-    private fun String.toIsoMdocConstraintField(scheme: ConstantIndex.CredentialScheme?) =
-        ConstraintField(path = listOf(scheme.prefixWithIsoNamespace(this)), intentToRetain = false)
+    private fun String.toIsoMdocConstraintField(scheme: ConstantIndex.CredentialScheme?, optional: Boolean) =
+        ConstraintField(path = listOf(scheme.prefixWithIsoNamespace(this)), intentToRetain = false, optional = optional)
 
     private fun String.toJwtConstraintField(optional: Boolean): ConstraintField =
         ConstraintField(path = listOf(splitByDotToJsonPath()), optional = optional)
 
+    // EUDIW Reference Implementation only supports dot notation for JSONPath
     private fun String.splitByDotToJsonPath(): String =
-        NormalizedJsonPath(split(".").map { NameSegment(it) }).toString()
+        NormalizedJsonPath(split(".").map { NameSegment(it) }).toDotNotation()
+
+    private fun NormalizedJsonPath.toDotNotation(): String =
+        "$" + segments.joinToString("") { it.toDotNotation() }
+
+    private fun NormalizedJsonPathSegment.toDotNotation(): CharSequence = when (this) {
+        is NormalizedJsonPathSegment.IndexSegment -> toString()
+        is NameSegment -> if (memberName.contains(".") || memberName.isDigitsOnly()) toString() else ".$memberName"
+    }
+
+    private fun String.isDigitsOnly() = all { it.isDigit() }
 
     private fun ConstantIndex.CredentialScheme?.prefixWithIsoNamespace(attribute: String): String = NormalizedJsonPath(
         NameSegment(this?.isoNamespace ?: "mdoc"),
@@ -292,7 +304,7 @@ data class RequestOptionsCredential(
             path = listOf("$.type"),
             filter = ConstraintFilter(
                 type = "string",
-                pattern = vcType,
+                const = JsonPrimitive(vcType),
             )
         ) else null
 
@@ -301,7 +313,7 @@ data class RequestOptionsCredential(
             path = listOf("$.vct"),
             filter = ConstraintFilter(
                 type = "string",
-                pattern = sdJwtType!!
+                const = JsonPrimitive(sdJwtType!!)
             )
         ) else null
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestOptions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestOptions.kt
@@ -4,6 +4,7 @@ import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
 import at.asitplus.dif.*
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
+import at.asitplus.jsonpath.core.NormalizedJsonPathSegment.IndexSegment
 import at.asitplus.jsonpath.core.NormalizedJsonPathSegment.NameSegment
 import at.asitplus.openid.*
 import at.asitplus.openid.OpenIdConstants.SCOPE_OPENID
@@ -288,11 +289,16 @@ data class RequestOptionsCredential(
         "$" + segments.joinToString("") { it.toDotNotation() }
 
     private fun NormalizedJsonPathSegment.toDotNotation(): CharSequence = when (this) {
-        is NormalizedJsonPathSegment.IndexSegment -> toString()
-        is NameSegment -> if (memberName.contains(".") || memberName.isDigitsOnly()) toString() else ".$memberName"
+        is IndexSegment -> toString()
+        is NameSegment -> if (memberName.isValidForDotNotation()) ".$memberName" else toString()
     }
 
-    private fun String.isDigitsOnly() = all { it.isDigit() }
+    private fun String.isValidForDotNotation(): Boolean =
+        firstOrNull().isLetterOrUnderscore() && all { it.isLetterOrDigit() || it.isUnderscore() }
+
+    private fun Char?.isLetterOrUnderscore(): Boolean = if (this == null) false else (isLetter() || this.isUnderscore())
+
+    private fun Char.isUnderscore(): Boolean = this == '_'
 
     private fun ConstantIndex.CredentialScheme?.prefixWithIsoNamespace(attribute: String): String = NormalizedJsonPath(
         NameSegment(this?.isoNamespace ?: "mdoc"),

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpComplexSdJwtProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpComplexSdJwtProtocolTest.kt
@@ -86,7 +86,7 @@ class OpenId4VpComplexSdJwtProtocolTest : FreeSpec({
                         it.path.shouldBeSingleton().first().apply {
                             JsonPath(this)
                             if (!this.contains("vct"))
-                                split("][").shouldHaveSize(2)
+                                split(".").shouldHaveSize(3) // "$", first segment, second segment
                         }
                     }
                 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -194,21 +194,6 @@ class HolderAgent(
         )
     }
 
-    private suspend fun createDefaultPresentationExchangePresentation(
-        request: PresentationRequestParameters,
-        presentationDefinition: PresentationDefinition,
-        fallbackFormatHolder: FormatHolder?,
-    ): KmmResult<PresentationResponseParameters.PresentationExchangeParameters> =
-        createPresentationExchangePresentation(
-            request = request,
-            credentialPresentation = CredentialPresentation.PresentationExchangePresentation(
-                CredentialPresentationRequest.PresentationExchangeRequest(
-                    presentationDefinition,
-                    fallbackFormatHolder,
-                ),
-            )
-        )
-
     private suspend fun createPresentationExchangePresentation(
         request: PresentationRequestParameters,
         credentialPresentation: CredentialPresentation.PresentationExchangePresentation,
@@ -376,17 +361,6 @@ class HolderAgent(
         )
     }
 
-    /** assume credential format to be supported by the verifier if no format holder is specified */
-    @Suppress("DEPRECATION")
-    private fun StoreEntry.isFormatSupported(supportedFormats: FormatHolder?): Boolean =
-        supportedFormats?.let { formatHolder ->
-            when (this) {
-                is StoreEntry.Vc -> formatHolder.jwtVp != null
-                is StoreEntry.SdJwt -> formatHolder.jwtSd != null || formatHolder.sdJwt != null
-                is StoreEntry.Iso -> formatHolder.msoMdoc != null
-            }
-        } ?: true
-
     private fun PresentationSubmission.Companion.fromMatches(
         presentationId: String?,
         matches: List<Pair<String, PresentationExchangeCredentialDisclosure>>,
@@ -457,7 +431,7 @@ class HolderAgent(
             // find a matching path for each constraint field
             constraintFieldMatches.filter {
                 // only need to validate non-optional constraint fields
-                it.key.optional != true
+                it.key.optional == true
             }.forEach { constraintField ->
                 val allowedPaths = constraintField.value.map {
                     it.normalizedJsonPath.toString()


### PR DESCRIPTION
Improves interop with partners tested against in Vilnius:

- Generate `vct` field constraints as `const`
- Use JSON Path dot notation where possible
- Treat all requested attributes as optional and let the user select them