### PR TITLE
fix(openId4VP): change input data for calculating transaction_data_ha…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Release 5.7.0:
  - OpenID for Verifiable Credential Issuance:
    - Expose `oauth2Client` in `WalletService`
    - Remove code elements deprecated in `5.6.3` in `OpenId4VciClient` 
+   - Update transaction_data_hashes according to result from https://github.com/openid/OpenID4VP/pull/621
  - Holder:
    - Replace `keyPair` with `keyMaterial`
  - Functions:

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TransactionData.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TransactionData.kt
@@ -2,6 +2,8 @@ package at.asitplus.openid
 
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import io.ktor.util.*
+import io.ktor.utils.io.charsets.*
+import io.ktor.utils.io.core.*
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import kotlinx.serialization.ContextualSerializer
 import kotlinx.serialization.PolymorphicSerializer
@@ -19,7 +21,7 @@ import okio.ByteString.Companion.toByteString
 typealias TransactionDataBase64Url = JsonPrimitive
 
 fun TransactionDataBase64Url.sha256(): ByteArray =
-    this.content.decodeToByteArray(Base64UrlStrict).toByteString().sha256().toByteArray()
+    this.content.toByteArray(Charsets.UTF_8).toByteString().sha256().toByteArray()
 
 /**
  * OID4VP Draft 24: OPTIONAL. Array of strings, where each string is a base64url encoded JSON object that contains a typed parameter

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TransactionData.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TransactionData.kt
@@ -22,7 +22,7 @@ typealias TransactionDataBase64Url = JsonPrimitive
 
 fun TransactionDataBase64Url.sha256(): ByteArray =
     this.content.toByteArray(Charsets.UTF_8).toByteString().sha256().toByteArray()
-
+ 
 /**
  * OID4VP Draft 24: OPTIONAL. Array of strings, where each string is a base64url encoded JSON object that contains a typed parameter
  * set with details about the transaction that the Verifier is requesting the End-User to authorize.


### PR DESCRIPTION
There was a discussion in openID4VP about how _transaction_data_hashes_ have to be calculated. 
Agreement to use text from v23, see https://github.com/openid/OpenID4VP/pull/621