### PR TITLE
Fix JWS cert encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 Release 5.8.0:
- - tbd
+ - Signum 3.16.3/Supreme 0.8.3 to fix certificate encoding in JWS header
+ - Remove okio dependency and use Supreme digest calculation instead
 
 Release 5.7.0:
  - Remote Qualified Electronic Signatures:

--- a/conventions-vclib/src/main/kotlin/VcLibConventions.kt
+++ b/conventions-vclib/src/main/kotlin/VcLibConventions.kt
@@ -28,7 +28,6 @@ inline fun Project.commonApiDependencies(): List<String> {
     project.AspVersions.versions["signum"] = VcLibVersions.signum
     project.AspVersions.versions["supreme"] = VcLibVersions.supreme
     project.AspVersions.versions["jsonpath"] = VcLibVersions.jsonpath
-    project.AspVersions.versions["okio"] = signumVersionCatalog.findVersion("okio").get().toString()
 
 
     return listOf(
@@ -36,7 +35,6 @@ inline fun Project.commonApiDependencies(): List<String> {
         addDependency("at.asitplus.signum:supreme", "supreme"),
         addDependency("at.asitplus.signum:indispensable-cosef", "signum"),
         addDependency("at.asitplus.signum:indispensable-josef", "signum"),
-        addDependency("com.squareup.okio:okio", "okio"),
         addDependency("at.asitplus:jsonpath4k", "jsonpath"),
     )
 }

--- a/conventions-vclib/src/main/resources/vcLibVersions.properties
+++ b/conventions-vclib/src/main/resources/vcLibVersions.properties
@@ -1,4 +1,4 @@
-signum=3.16.2
+signum=3.16.3
 supreme=0.8.3
 uuid=0.8.1
 jsonpath=2.4.1

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/cborSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/cborSerializer.kt
@@ -1,10 +1,11 @@
 package at.asitplus.iso
 
+import at.asitplus.signum.indispensable.Digest
+import at.asitplus.signum.supreme.hash.digest
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.CompositeDecoder
 import kotlinx.serialization.encoding.CompositeEncoder
-import okio.ByteString.Companion.toByteString
 
 object CborCredentialSerializer {
 
@@ -71,7 +72,7 @@ fun ByteArray.stripCborTag(tag: Byte): ByteArray {
 
 fun ByteArray.wrapInCborTag(tag: Byte) = byteArrayOf(0xd8.toByte()) + byteArrayOf(tag) + this
 
-fun ByteArray.sha256(): ByteArray = toByteString().sha256().toByteArray()
+fun ByteArray.sha256(): ByteArray = Digest.SHA256.digest(this)
 
 
 private typealias ItemValueEncoder

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TransactionData.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TransactionData.kt
@@ -1,14 +1,12 @@
 package at.asitplus.openid
 
-import at.asitplus.signum.indispensable.io.Base64UrlStrict
-import io.ktor.util.*
+import at.asitplus.signum.indispensable.Digest
+import at.asitplus.signum.supreme.hash.digest
 import io.ktor.utils.io.charsets.*
 import io.ktor.utils.io.core.*
-import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import kotlinx.serialization.ContextualSerializer
 import kotlinx.serialization.PolymorphicSerializer
 import kotlinx.serialization.json.JsonPrimitive
-import okio.ByteString.Companion.toByteString
 
 
 /**
@@ -21,8 +19,8 @@ import okio.ByteString.Companion.toByteString
 typealias TransactionDataBase64Url = JsonPrimitive
 
 fun TransactionDataBase64Url.sha256(): ByteArray =
-    this.content.toByteArray(Charsets.UTF_8).toByteString().sha256().toByteArray()
- 
+    Digest.SHA256.digest(this.content.toByteArray(Charsets.UTF_8))
+
 /**
  * OID4VP Draft 24: OPTIONAL. Array of strings, where each string is a base64url encoded JSON object that contains a typed parameter
  * set with details about the transaction that the Verifier is requesting the End-User to authorize.

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/cborSerializer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/cborSerializer.kt
@@ -1,12 +1,9 @@
 package at.asitplus.wallet.lib.iso
 
+import at.asitplus.signum.indispensable.Digest
+import at.asitplus.signum.supreme.hash.digest
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.cbor.Cbor
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.CompositeDecoder
-import kotlinx.serialization.encoding.CompositeEncoder
-import okio.ByteString.Companion.toByteString
 
 @OptIn(ExperimentalSerializationApi::class)
 @Deprecated("No added value", ReplaceWith("at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer"))
@@ -31,4 +28,4 @@ fun ByteArray.stripCborTag(tag: Byte): ByteArray {
 @Deprecated("Moved", ReplaceWith("at.asitplus.iso.cborSerializer.ByteArray.wrapInCborTag"))
 fun ByteArray.wrapInCborTag(tag: Byte) = byteArrayOf(0xd8.toByte()) + byteArrayOf(tag) + this
 
-fun ByteArray.sha256(): ByteArray = toByteString().sha256().toByteArray()
+fun ByteArray.sha256(): ByteArray = Digest.SHA256.digest(this)

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/JwsHeaderSerializationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/JwsHeaderSerializationTest.kt
@@ -14,7 +14,6 @@ import at.asitplus.signum.indispensable.pki.RelativeDistinguishedName
 import at.asitplus.signum.indispensable.pki.TbsCertificate
 import at.asitplus.signum.indispensable.pki.X509Certificate
 import at.asitplus.signum.ecmath.times
-import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import com.benasher44.uuid.uuid4
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.Sign
@@ -45,8 +44,8 @@ class JwsHeaderSerializationTest : FreeSpec({
 
         val serialized = header.serialize()
 
-        serialized shouldContain """"${first.encodeToDer().encodeToString(Base64UrlStrict)}""""
-        serialized shouldContain """"${second.encodeToDer().encodeToString(Base64UrlStrict)}""""
+        serialized shouldContain """"${first.encodeToDer().encodeToString(Base64Strict)}""""
+        serialized shouldContain """"${second.encodeToDer().encodeToString(Base64Strict)}""""
         serialized shouldContain """"$kid""""
     }
 


### PR DESCRIPTION
Fix erroneously url-encoding certificates in JWS headers.  
This should make it into a 5.7.1 release