### PR TITLE
Credential issuer functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Release 5.8.0:
    - Extract interface `StatusListIssuer` out of `Issuer` to separate credential issuing and status list management
    - Extract interface `IssueCredentialFun` to be used in `CredentialIssuer` for OID4VCI
    - Rework interface `IssuerCredentialStore`, deprecating methods `storeGetNewIndex` and class `IssuerCredentialStore.Credential`
+   - In `Issuer.IssuedCredential` add the typed credentials as properties
+   - In `StatusListIssuer` deprecate methods `revokeCredentials()` and `revokeCredentialsWithId()`, callers should use `revokeCredential()`
 
 Release 5.7.1:
  - Signum 3.16.3/Supreme 0.8.3 to fix certificate encoding in JWS header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Release 5.8.0:
  - Code organization:
    - Extract interface `StatusListIssuer` out of `Issuer` to separate credential issuing and status list management
    - Extract interface `IssueCredentialFun` to be used in `CredentialIssuer` for OID4VCI
+   - Rework interface `IssuerCredentialStore`, deprecating methods `storeGetNewIndex` and class `IssuerCredentialStore.Credential`
 
 Release 5.7.1:
  - Signum 3.16.3/Supreme 0.8.3 to fix certificate encoding in JWS header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Release 5.8.0:
    - Remove `AuthorizationDetail` matching and validation from class to interface function
  - Code organization:
    - Extract interface `StatusListIssuer` out of `Issuer` to separate credential issuing and status list management
+   - Extract interface `IssueCredentialFun` to be used in `CredentialIssuer` for OID4VCI
 
 Release 5.7.1:
  - Signum 3.16.3/Supreme 0.8.3 to fix certificate encoding in JWS header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Release 5.8.0:
    - Rework interface `IssuerCredentialStore`, deprecating methods `storeGetNewIndex` and class `IssuerCredentialStore.Credential`
    - In `Issuer.IssuedCredential` add the typed credentials as properties
    - In `StatusListIssuer` deprecate methods `revokeCredentials()` and `revokeCredentialsWithId()`, callers should use `revokeCredential()`
+   - In `CredentialIssuer` deprecate constructor parameter `credentialProvider`, replace with `credentialDataProvider`
 
 Release 5.7.1:
  - Signum 3.16.3/Supreme 0.8.3 to fix certificate encoding in JWS header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Release 5.8.0:
    - In `Issuer.IssuedCredential` add the typed credentials as properties
    - In `StatusListIssuer` deprecate methods `revokeCredentials()` and `revokeCredentialsWithId()`, callers should use `revokeCredential()`
    - In `CredentialIssuer` deprecate constructor parameter `credentialProvider`, replace with `credentialDataProvider`
+   - Extend `CredentialToBeIssued` to contain properties `expiration`, `scheme`, `subjectPublicKey`
 
 Release 5.7.1:
  - Signum 3.16.3/Supreme 0.8.3 to fix certificate encoding in JWS header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ Release 5.8.0:
    - Extract interface `StatusListIssuer` out of `Issuer` to separate credential issuing and status list management
    - Extract interface `IssueCredentialFun` to be used in `CredentialIssuer` for OID4VCI
    - Rework interface `IssuerCredentialStore`, deprecating methods `storeGetNewIndex` and class `IssuerCredentialStore.Credential`
-   - In `Issuer.IssuedCredential` add the typed credentials as properties
+   - In `Issuer.IssuedCredential` add the typed credentials as properties, add property `userInfo`
    - In `StatusListIssuer` deprecate methods `revokeCredentials()` and `revokeCredentialsWithId()`, callers should use `revokeCredential()`
    - In `CredentialIssuer` deprecate constructor parameter `credentialProvider`, replace with `credentialDataProvider`
-   - Extend `CredentialToBeIssued` to contain properties `expiration`, `scheme`, `subjectPublicKey`
+   - Extend `CredentialToBeIssued` to contain properties `expiration`, `scheme`, `subjectPublicKey`, `userInfo`
 
 Release 5.7.1:
  - Signum 3.16.3/Supreme 0.8.3 to fix certificate encoding in JWS header

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
@@ -34,6 +34,7 @@ import at.asitplus.wallet.lib.oauth2.RequestInfo
 import at.asitplus.wallet.lib.oauth2.TokenService
 import at.asitplus.wallet.lib.oidvci.BuildClientAttestationJwt
 import at.asitplus.wallet.lib.oidvci.CredentialAuthorizationServiceStrategy
+import at.asitplus.wallet.lib.oidvci.CredentialDataProviderFun
 import at.asitplus.wallet.lib.oidvci.CredentialIssuer
 import at.asitplus.wallet.lib.oidvci.CredentialIssuerDataProvider
 import at.asitplus.wallet.lib.oidvci.DefaultNonceService
@@ -195,8 +196,8 @@ class OpenId4VciClientTest : FunSpec() {
         attributes: Map<String, String>,
     ) {
         val dataProvider = OAuth2DataProvider { _, _ -> dummyUser() }
-        val credentialProvider =
-            CredentialIssuerDataProvider { _, subjectPublicKey: CryptoPublicKey, credentialScheme, representation, _ ->
+        val credentialDataProvider =
+            CredentialDataProviderFun { _, subjectPublicKey: CryptoPublicKey, credentialScheme, representation ->
                 catching {
                     require(credentialScheme == scheme)
                     require(representation == representation)
@@ -253,7 +254,7 @@ class OpenId4VciClientTest : FunSpec() {
             authorizationService = authorizationService,
             issuer = IssuerAgent(EphemeralKeyWithSelfSignedCert()),
             credentialSchemes = credentialSchemes,
-            credentialProvider = credentialProvider,
+            credentialDataProvider = credentialDataProvider,
             publicContext = publicContext,
             credentialEndpointPath = credentialEndpointPath,
             nonceEndpointPath = nonceEndpointPath,

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
@@ -208,21 +208,18 @@ class OpenId4VciClientTest : FunSpec() {
                             attributes.map { ClaimToBeIssued(it.key, it.value) },
                             Clock.System.now(),
                             credentialScheme,
-                            subjectPublicKey
+                            subjectPublicKey,
+                            OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
                         )
 
                         ISO_MDOC -> Iso(
                             attributes.map {
-                                IssuerSignedItem(
-                                    digestId++,
-                                    Random.nextBytes(32),
-                                    it.key,
-                                    it.value
-                                )
+                                IssuerSignedItem(digestId++, Random.nextBytes(32), it.key, it.value)
                             },
                             Clock.System.now(),
                             credentialScheme,
-                            subjectPublicKey
+                            subjectPublicKey,
+                            OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
                         )
                     }
                 }

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
@@ -26,6 +26,8 @@ import at.asitplus.wallet.lib.data.CredentialPresentation.DCQLPresentation
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
 import at.asitplus.iso.IssuerSignedItem
+import at.asitplus.openid.OidcUserInfo
+import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.wallet.lib.openid.*
 import at.asitplus.wallet.lib.openid.AuthnResponseResult.SuccessIso
 import at.asitplus.wallet.lib.openid.AuthnResponseResult.SuccessSdJwt
@@ -277,14 +279,16 @@ class OpenId4VpWalletTest : FunSpec() {
             claims = attributes.map { it.toClaimToBeIssued() },
             expiration = Clock.System.now().plus(1.minutes),
             scheme = scheme,
-            subjectPublicKey = keyMaterial.publicKey
+            subjectPublicKey = keyMaterial.publicKey,
+            userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
         )
 
         ISO_MDOC -> CredentialToBeIssued.Iso(
             issuerSignedItems = attributes.map { it.toIssuerSignedItem() },
             expiration = Clock.System.now().plus(1.minutes),
             scheme = scheme,
-            subjectPublicKey = keyMaterial.publicKey
+            subjectPublicKey = keyMaterial.publicKey,
+            userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
         )
 
         else -> TODO()

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialDataProviderFun.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialDataProviderFun.kt
@@ -1,0 +1,37 @@
+package at.asitplus.wallet.lib.oidvci
+
+import at.asitplus.KmmResult
+import at.asitplus.openid.OidcUserInfoExtended
+import at.asitplus.signum.indispensable.CryptoPublicKey
+import at.asitplus.wallet.lib.agent.CredentialToBeIssued
+import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialScheme
+
+
+fun interface CredentialDataProviderFun {
+    /**
+     * Gets called with the user authorized in [userInfo],
+     * a resolved [credentialScheme],
+     * the holder key in [subjectPublicKey],
+     * and the requested credential's representation in [representation].
+     */
+    suspend operator fun invoke(
+        userInfo: OidcUserInfoExtended,
+        subjectPublicKey: CryptoPublicKey,
+        credentialScheme: CredentialScheme,
+        representation: ConstantIndex.CredentialRepresentation,
+    ): KmmResult<CredentialToBeIssued>
+}
+
+class CredentialIssuerDataProviderAdapter(
+    val credentialDataProvider: CredentialIssuerDataProvider,
+) : CredentialDataProviderFun {
+    override suspend fun invoke(
+        userInfo: OidcUserInfoExtended,
+        subjectPublicKey: CryptoPublicKey,
+        credentialScheme: CredentialScheme,
+        representation: ConstantIndex.CredentialRepresentation,
+    ): KmmResult<CredentialToBeIssued> =
+        credentialDataProvider.getCredential(userInfo, subjectPublicKey, credentialScheme, representation, null)
+
+}

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/Extensions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/Extensions.kt
@@ -209,8 +209,8 @@ suspend fun Issuer.IssuedCredential.toCredentialResponseSingleCredential(
 ): CredentialResponseSingleCredential = CredentialResponseSingleCredential(
     when (this) {
         is Issuer.IssuedCredential.Iso -> JsonPrimitive(transformer(toBase64UrlStrict()))
-        is Issuer.IssuedCredential.VcJwt -> JsonPrimitive(transformer(vcJws))
-        is Issuer.IssuedCredential.VcSdJwt -> JsonPrimitive(transformer(vcSdJwt))
+        is Issuer.IssuedCredential.VcJwt -> JsonPrimitive(transformer(signedVcJws.serialize()))
+        is Issuer.IssuedCredential.VcSdJwt -> JsonPrimitive(transformer(signedSdJwtVc.serialize()))
     }
 )
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/IssueCredentialFun.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/IssueCredentialFun.kt
@@ -1,0 +1,22 @@
+package at.asitplus.wallet.lib.oidvci
+
+import at.asitplus.KmmResult
+import at.asitplus.wallet.lib.agent.CredentialToBeIssued
+import at.asitplus.wallet.lib.agent.Issuer
+import at.asitplus.wallet.lib.agent.Issuer.IssuedCredential
+
+fun interface IssueCredentialFun {
+
+    /**
+     * Wraps the credential-to-be-issued in [credential] into a single instance of [IssuedCredential],
+     * according to the representation, i.e. it essentially signs the credential with the issuer key.
+     */
+    suspend operator fun invoke(credential: CredentialToBeIssued): KmmResult<IssuedCredential>
+
+}
+
+class IssueCredential(val issuer: Issuer) : IssueCredentialFun {
+    override suspend fun invoke(
+        credential: CredentialToBeIssued,
+    ): KmmResult<IssuedCredential> = issuer.issueCredential(credential)
+}

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciAttestationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciAttestationTest.kt
@@ -66,7 +66,7 @@ class OidvciAttestationTest : FunSpec({
             authorizationService = authorizationService,
             issuer = IssuerAgent(),
             credentialSchemes = setOf(ConstantIndex.AtomicAttribute2023, MobileDrivingLicenceScheme),
-            credentialProvider = DummyOAuth2IssuerCredentialDataProvider,
+            credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
             verifyAttestationProof = { true },
             requireKeyAttestation = true, // this is important, to require key attestation
         )
@@ -103,7 +103,7 @@ class OidvciAttestationTest : FunSpec({
             authorizationService = authorizationService,
             issuer = IssuerAgent(),
             credentialSchemes = setOf(ConstantIndex.AtomicAttribute2023, MobileDrivingLicenceScheme),
-            credentialProvider = DummyOAuth2IssuerCredentialDataProvider,
+            credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
             verifyAttestationProof = { false }, // do not accept key attestation
             requireKeyAttestation = true, // this is important, to require key attestation
         )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciCodeFlowTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciCodeFlowTest.kt
@@ -47,7 +47,7 @@ class OidvciCodeFlowTest : FreeSpec({
             authorizationService = authorizationService,
             issuer = IssuerAgent(),
             credentialSchemes = setOf(AtomicAttribute2023, MobileDrivingLicenceScheme),
-            credentialProvider = DummyOAuth2IssuerCredentialDataProvider,
+            credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
         )
         client = WalletService()
         state = uuid4().toString()
@@ -191,7 +191,7 @@ class OidvciCodeFlowTest : FreeSpec({
             authorizationService = authorizationService,
             issuer = IssuerAgent(),
             credentialSchemes = setOf(AtomicAttribute2023),
-            credentialProvider = DummyOAuth2IssuerCredentialDataProvider
+            credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider
         )
         val requestOptions = RequestOptions(AtomicAttribute2023, PLAIN_JWT)
         val scope = client.selectSupportedCredentialFormat(requestOptions, issuer.metadata)?.scope.shouldNotBeNull()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciEncryptionTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciEncryptionTest.kt
@@ -58,7 +58,7 @@ class OidvciEncryptionTest : FunSpec({
             authorizationService = authorizationService,
             issuer = IssuerAgent(),
             credentialSchemes = setOf(ConstantIndex.AtomicAttribute2023),
-            credentialProvider = DummyOAuth2IssuerCredentialDataProvider,
+            credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
             requireEncryption = true, // this is important, to require encryption
         )
         state = uuid4().toString()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciInteropTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciInteropTest.kt
@@ -35,7 +35,7 @@ class OidvciInteropTest : FunSpec({
             authorizationService = authorizationService,
             issuer = IssuerAgent(),
             credentialSchemes = setOf(AtomicAttribute2023, MobileDrivingLicenceScheme),
-            credentialProvider = DummyOAuth2IssuerCredentialDataProvider
+            credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider
         )
         client = WalletService()
         state = uuid4().toString()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciOfferCodeTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciOfferCodeTest.kt
@@ -34,7 +34,7 @@ class OidvciOfferCodeTest : FreeSpec({
             authorizationService = authorizationService,
             issuer = IssuerAgent(),
             credentialSchemes = setOf(AtomicAttribute2023, MobileDrivingLicenceScheme),
-            credentialProvider = DummyOAuth2IssuerCredentialDataProvider
+            credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider
         )
         client = WalletService()
         state = uuid4().toString()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciPreAuthTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciPreAuthTest.kt
@@ -35,7 +35,7 @@ class OidvciPreAuthTest : FreeSpec({
             authorizationService = authorizationService,
             issuer = IssuerAgent(),
             credentialSchemes = setOf(AtomicAttribute2023, MobileDrivingLicenceScheme),
-            credentialProvider = DummyOAuth2IssuerCredentialDataProvider
+            credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider
         )
         client = WalletService()
         state = uuid4().toString()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/CredentialJsonInteropTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/CredentialJsonInteropTest.kt
@@ -4,6 +4,9 @@ import at.asitplus.jsonpath.JsonPath
 import at.asitplus.wallet.lib.agent.*
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.PLAIN_JWT
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.CredentialToJsonConverter
 import at.asitplus.wallet.lib.openid.DummyCredentialDataProvider
 import com.benasher44.uuid.uuid4
@@ -34,7 +37,7 @@ class CredentialJsonInteropTest : FreeSpec({
                 DummyCredentialDataProvider.getCredential(
                     holderKeyMaterial.publicKey,
                     AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                    PLAIN_JWT
                 ).getOrThrow(),
             ).getOrThrow().toStoreCredentialInput()
         )
@@ -56,17 +59,16 @@ class CredentialJsonInteropTest : FreeSpec({
                 DummyCredentialDataProvider.getCredential(
                     holderKeyMaterial.publicKey,
                     AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.SD_JWT,
-                    AtomicAttribute2023.claimNames
+                    SD_JWT,
                 ).getOrThrow(),
             ).getOrThrow().toStoreCredentialInput()
         )
 
         val credential =
             CredentialToJsonConverter.toJsonElement(subjectCredentialStore.getCredentials().getOrThrow()[0])
-        credential.getByJsonPath("\$['given_name']").content shouldNotBe null
-        credential.getByJsonPath("\$['family_name']").content shouldNotBe null
-        credential.getByJsonPath("\$['date_of_birth']").content shouldNotBe null
+        credential.getByJsonPath("\$['${AtomicAttribute2023.CLAIM_GIVEN_NAME}']").content shouldNotBe null
+        credential.getByJsonPath("\$['${AtomicAttribute2023.CLAIM_FAMILY_NAME}']").content shouldNotBe null
+        credential.getByJsonPath("\$['${AtomicAttribute2023.CLAIM_DATE_OF_BIRTH}']").content shouldNotBe null
     }
 
     "ISO credential path resolving" {
@@ -75,17 +77,16 @@ class CredentialJsonInteropTest : FreeSpec({
                 DummyCredentialDataProvider.getCredential(
                     holderKeyMaterial.publicKey,
                     AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.ISO_MDOC,
-                    AtomicAttribute2023.claimNames
+                    ISO_MDOC,
                 ).getOrThrow()
             ).getOrThrow().toStoreCredentialInput()
         )
 
         val credential =
             CredentialToJsonConverter.toJsonElement(subjectCredentialStore.getCredentials().getOrThrow()[0])
-        credential.getByJsonPath("\$['${AtomicAttribute2023.isoNamespace}']['given_name']").content shouldNotBe null
-        credential.getByJsonPath("\$['${AtomicAttribute2023.isoNamespace}']['family_name']").content shouldNotBe null
-        credential.getByJsonPath("\$['${AtomicAttribute2023.isoNamespace}']['date_of_birth']").content shouldNotBe null
+        credential.getByJsonPath("\$['${AtomicAttribute2023.isoNamespace}']['${AtomicAttribute2023.CLAIM_GIVEN_NAME}']").content shouldNotBe null
+        credential.getByJsonPath("\$['${AtomicAttribute2023.isoNamespace}']['${AtomicAttribute2023.CLAIM_FAMILY_NAME}']").content shouldNotBe null
+        credential.getByJsonPath("\$['${AtomicAttribute2023.isoNamespace}']['${AtomicAttribute2023.CLAIM_DATE_OF_BIRTH}']").content shouldNotBe null
     }
 
     "Simple JSONPaths" {

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/DummyCredentialDataProvider.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/DummyCredentialDataProvider.kt
@@ -50,6 +50,7 @@ object DummyCredentialDataProvider {
                     expiration = expiration,
                     scheme = credentialScheme,
                     subjectPublicKey = subjectPublicKey,
+                    userInfo = DummyOAuth2DataProvider.user,
                 )
 
                 PLAIN_JWT -> CredentialToBeIssued.VcJwt(
@@ -61,6 +62,7 @@ object DummyCredentialDataProvider {
                     expiration = expiration,
                     scheme = credentialScheme,
                     subjectPublicKey = subjectPublicKey,
+                    userInfo = DummyOAuth2DataProvider.user,
                 )
 
                 ISO_MDOC -> CredentialToBeIssued.Iso(
@@ -70,6 +72,7 @@ object DummyCredentialDataProvider {
                     expiration = expiration,
                     scheme = credentialScheme,
                     subjectPublicKey = subjectPublicKey,
+                    userInfo = DummyOAuth2DataProvider.user,
                 )
             }
         } else if (credentialScheme == MobileDrivingLicenceScheme) {
@@ -102,6 +105,7 @@ object DummyCredentialDataProvider {
                 expiration = expiration,
                 scheme = credentialScheme,
                 subjectPublicKey = subjectPublicKey,
+                userInfo = DummyOAuth2DataProvider.user,
             )
         } else if (credentialScheme == EuPidScheme) {
             val subjectId = subjectPublicKey.didEncoded
@@ -155,6 +159,7 @@ object DummyCredentialDataProvider {
                         expiration = expiration,
                         scheme = credentialScheme,
                         subjectPublicKey = subjectPublicKey,
+                        userInfo = DummyOAuth2DataProvider.user,
                     )
 
                 PLAIN_JWT -> CredentialToBeIssued.VcJwt(
@@ -172,6 +177,7 @@ object DummyCredentialDataProvider {
                     expiration = expiration,
                     scheme = credentialScheme,
                     subjectPublicKey = subjectPublicKey,
+                    userInfo = DummyOAuth2DataProvider.user,
                 )
 
                 ISO_MDOC -> CredentialToBeIssued.Iso(
@@ -181,6 +187,7 @@ object DummyCredentialDataProvider {
                     expiration = expiration,
                     scheme = credentialScheme,
                     subjectPublicKey = subjectPublicKey,
+                    userInfo = DummyOAuth2DataProvider.user,
                 )
             }
         } else {

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/DummyCredentialDataProvider.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/DummyCredentialDataProvider.kt
@@ -33,17 +33,16 @@ object DummyCredentialDataProvider {
         subjectPublicKey: CryptoPublicKey,
         credentialScheme: ConstantIndex.CredentialScheme,
         representation: ConstantIndex.CredentialRepresentation,
-        claimNames: Collection<String>? = null,
     ): KmmResult<CredentialToBeIssued> = catching {
         val issuance = Clock.System.now()
         val expiration = issuance + defaultLifetime
         if (credentialScheme == ConstantIndex.AtomicAttribute2023) {
             val subjectId = subjectPublicKey.didEncoded
             val claims = listOfNotNull(
-                optionalClaim(claimNames, CLAIM_GIVEN_NAME, "Susanne"),
-                optionalClaim(claimNames, CLAIM_FAMILY_NAME, "Meier"),
-                optionalClaim(claimNames, CLAIM_DATE_OF_BIRTH, LocalDate.parse("1990-01-01")),
-                optionalClaim(claimNames, CLAIM_PORTRAIT, Random.Default.nextBytes(32)),
+                ClaimToBeIssued(ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME, "Susanne"),
+                ClaimToBeIssued(ConstantIndex.AtomicAttribute2023.CLAIM_FAMILY_NAME, "Meier"),
+                ClaimToBeIssued(ConstantIndex.AtomicAttribute2023.CLAIM_DATE_OF_BIRTH, LocalDate.parse("1990-01-01")),
+                ClaimToBeIssued(ConstantIndex.AtomicAttribute2023.CLAIM_PORTRAIT, Random.Default.nextBytes(32)),
             )
             when (representation) {
                 SD_JWT -> CredentialToBeIssued.VcSd(
@@ -83,30 +82,18 @@ object DummyCredentialDataProvider {
             var digestId = 0U
             val issuerSignedItems = with(MobileDrivingLicenceDataElements) {
                 listOfNotNull(
-                    if (claimNames.isNullOrContains(FAMILY_NAME))
-                        issuerSignedItem(FAMILY_NAME, "Mustermann", digestId++) else null,
-                    if (claimNames.isNullOrContains(GIVEN_NAME))
-                        issuerSignedItem(GIVEN_NAME, "Max", digestId++) else null,
-                    if (claimNames.isNullOrContains(BIRTH_DATE))
-                        issuerSignedItem(BIRTH_DATE, LocalDate.parse("1970-01-01"), digestId++) else null,
-                    if (claimNames.isNullOrContains(DOCUMENT_NUMBER))
-                        issuerSignedItem(DOCUMENT_NUMBER, "123456789", digestId++) else null,
-                    if (claimNames.isNullOrContains(ISSUE_DATE))
-                        issuerSignedItem(ISSUE_DATE, LocalDate.parse("2023-01-01"), digestId++) else null,
-                    if (claimNames.isNullOrContains(EXPIRY_DATE))
-                        issuerSignedItem(EXPIRY_DATE, LocalDate.parse("2033-01-01"), digestId++) else null,
-                    if (claimNames.isNullOrContains(ISSUING_COUNTRY))
-                        issuerSignedItem(ISSUING_COUNTRY, "AT", digestId++) else null,
-                    if (claimNames.isNullOrContains(ISSUING_AUTHORITY))
-                        issuerSignedItem(ISSUING_AUTHORITY, "AT", digestId++) else null,
-                    if (claimNames.isNullOrContains(PORTRAIT))
-                        issuerSignedItem(PORTRAIT, Random.Default.nextBytes(32), digestId++) else null,
-                    if (claimNames.isNullOrContains(UN_DISTINGUISHING_SIGN))
-                        issuerSignedItem(UN_DISTINGUISHING_SIGN, "AT", digestId++) else null,
-                    if (claimNames.isNullOrContains(DRIVING_PRIVILEGES))
-                        issuerSignedItem(DRIVING_PRIVILEGES, arrayOf(drivingPrivilege), digestId++) else null,
-                    if (claimNames.isNullOrContains(AGE_OVER_18))
-                        issuerSignedItem(AGE_OVER_18, true, digestId++) else null,
+                    issuerSignedItem(FAMILY_NAME, "Mustermann", digestId++),
+                    issuerSignedItem(GIVEN_NAME, "Max", digestId++),
+                    issuerSignedItem(BIRTH_DATE, LocalDate.parse("1970-01-01"), digestId++),
+                    issuerSignedItem(DOCUMENT_NUMBER, "123456789", digestId++),
+                    issuerSignedItem(ISSUE_DATE, LocalDate.parse("2023-01-01"), digestId++),
+                    issuerSignedItem(EXPIRY_DATE, LocalDate.parse("2033-01-01"), digestId++),
+                    issuerSignedItem(ISSUING_COUNTRY, "AT", digestId++),
+                    issuerSignedItem(ISSUING_AUTHORITY, "AT", digestId++),
+                    issuerSignedItem(PORTRAIT, Random.Default.nextBytes(32), digestId++),
+                    issuerSignedItem(UN_DISTINGUISHING_SIGN, "AT", digestId++),
+                    issuerSignedItem(DRIVING_PRIVILEGES, arrayOf(drivingPrivilege), digestId++),
+                    issuerSignedItem(AGE_OVER_18, true, digestId++),
                 )
             }
 
@@ -129,33 +116,33 @@ object DummyCredentialDataProvider {
 
                 SD_JWT -> with(EuPidScheme.SdJwtAttributes) {
                     listOfNotNull(
-                        optionalClaim(claimNames, FAMILY_NAME, familyName),
-                        optionalClaim(claimNames, FAMILY_NAME_BIRTH, familyName),
-                        optionalClaim(claimNames, GIVEN_NAME, givenName),
-                        optionalClaim(claimNames, GIVEN_NAME_BIRTH, givenName),
-                        optionalClaim(claimNames, BIRTH_DATE, birthDate),
-                        optionalClaim(claimNames, AGE_EQUAL_OR_OVER_18, true),
-                        optionalClaim(claimNames, NATIONALITIES, listOf(nationality)),
-                        optionalClaim(claimNames, ISSUANCE_DATE, issuanceDate),
-                        optionalClaim(claimNames, EXPIRY_DATE, expirationDate),
-                        optionalClaim(claimNames, ISSUING_COUNTRY, issuingCountry),
-                        optionalClaim(claimNames, ISSUING_AUTHORITY, issuingCountry),
+                        ClaimToBeIssued(FAMILY_NAME, familyName),
+                        ClaimToBeIssued(FAMILY_NAME_BIRTH, familyName),
+                        ClaimToBeIssued(GIVEN_NAME, givenName),
+                        ClaimToBeIssued(GIVEN_NAME_BIRTH, givenName),
+                        ClaimToBeIssued(BIRTH_DATE, birthDate),
+                        ClaimToBeIssued(AGE_EQUAL_OR_OVER_18, true),
+                        ClaimToBeIssued(NATIONALITIES, listOf(nationality)),
+                        ClaimToBeIssued(ISSUANCE_DATE, issuanceDate),
+                        ClaimToBeIssued(EXPIRY_DATE, expirationDate),
+                        ClaimToBeIssued(ISSUING_COUNTRY, issuingCountry),
+                        ClaimToBeIssued(ISSUING_AUTHORITY, issuingCountry),
                     )
                 }
 
                 ISO_MDOC -> with(EuPidScheme.Attributes) {
                     listOfNotNull(
-                        optionalClaim(claimNames, FAMILY_NAME, familyName),
-                        optionalClaim(claimNames, FAMILY_NAME_BIRTH, familyName),
-                        optionalClaim(claimNames, GIVEN_NAME, givenName),
-                        optionalClaim(claimNames, GIVEN_NAME_BIRTH, givenName),
-                        optionalClaim(claimNames, BIRTH_DATE, birthDate),
-                        optionalClaim(claimNames, AGE_OVER_18, true),
-                        optionalClaim(claimNames, NATIONALITY, nationality),
-                        optionalClaim(claimNames, ISSUANCE_DATE, issuanceDate),
-                        optionalClaim(claimNames, EXPIRY_DATE, expirationDate),
-                        optionalClaim(claimNames, ISSUING_COUNTRY, issuingCountry),
-                        optionalClaim(claimNames, ISSUING_AUTHORITY, issuingCountry),
+                        ClaimToBeIssued(FAMILY_NAME, familyName),
+                        ClaimToBeIssued(FAMILY_NAME_BIRTH, familyName),
+                        ClaimToBeIssued(GIVEN_NAME, givenName),
+                        ClaimToBeIssued(GIVEN_NAME_BIRTH, givenName),
+                        ClaimToBeIssued(BIRTH_DATE, birthDate),
+                        ClaimToBeIssued(AGE_OVER_18, true),
+                        ClaimToBeIssued(NATIONALITY, nationality),
+                        ClaimToBeIssued(ISSUANCE_DATE, issuanceDate),
+                        ClaimToBeIssued(EXPIRY_DATE, expirationDate),
+                        ClaimToBeIssued(ISSUING_COUNTRY, issuingCountry),
+                        ClaimToBeIssued(ISSUING_AUTHORITY, issuingCountry),
                     )
                 }
 
@@ -200,12 +187,6 @@ object DummyCredentialDataProvider {
             throw NotImplementedError()
         }
     }
-
-    private fun Collection<String>?.isNullOrContains(s: String) =
-        this == null || contains(s)
-
-    private fun optionalClaim(claimNames: Collection<String>?, name: String, value: Any) =
-        if (claimNames.isNullOrContains(name)) ClaimToBeIssued(name, value) else null
 
     private fun issuerSignedItem(name: String, value: Any, digestId: UInt) =
         IssuerSignedItem(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/DummyOAuth2IssuerCredentialDataProvider.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/DummyOAuth2IssuerCredentialDataProvider.kt
@@ -87,14 +87,16 @@ object DummyOAuth2IssuerCredentialDataProvider : CredentialDataProviderFun {
                 claims,
                 expiration,
                 ConstantIndex.AtomicAttribute2023,
-                subjectPublicKey
+                subjectPublicKey,
+                DummyOAuth2DataProvider.user,
             )
 
             PLAIN_JWT -> CredentialToBeIssued.VcJwt(
                 AtomicAttribute2023(subjectId, GIVEN_NAME, givenName ?: "no value"),
                 expiration,
                 ConstantIndex.AtomicAttribute2023,
-                subjectPublicKey
+                subjectPublicKey,
+                DummyOAuth2DataProvider.user,
             )
 
             ISO_MDOC -> CredentialToBeIssued.Iso(
@@ -103,7 +105,8 @@ object DummyOAuth2IssuerCredentialDataProvider : CredentialDataProviderFun {
                 },
                 expiration,
                 ConstantIndex.AtomicAttribute2023,
-                subjectPublicKey
+                subjectPublicKey,
+                DummyOAuth2DataProvider.user,
             )
         }
     }
@@ -124,7 +127,13 @@ object DummyOAuth2IssuerCredentialDataProvider : CredentialDataProviderFun {
             issuerSignedItem(ISSUE_DATE, "2023-01-01", digestId++),
             issuerSignedItem(EXPIRY_DATE, "2033-01-01", digestId++),
         )
-        return CredentialToBeIssued.Iso(issuerSignedItems, expiration, MobileDrivingLicenceScheme, subjectPublicKey)
+        return CredentialToBeIssued.Iso(
+            issuerSignedItems,
+            expiration,
+            MobileDrivingLicenceScheme,
+            subjectPublicKey,
+            DummyOAuth2DataProvider.user,
+        )
     }
 
     private fun getEuPid(
@@ -156,6 +165,7 @@ object DummyOAuth2IssuerCredentialDataProvider : CredentialDataProviderFun {
                 expiration,
                 EuPidScheme,
                 subjectPublicKey,
+                DummyOAuth2DataProvider.user,
             )
 
             PLAIN_JWT -> CredentialToBeIssued.VcJwt(
@@ -172,6 +182,7 @@ object DummyOAuth2IssuerCredentialDataProvider : CredentialDataProviderFun {
                 expiration,
                 EuPidScheme,
                 subjectPublicKey,
+                DummyOAuth2DataProvider.user,
             )
 
             ISO_MDOC -> CredentialToBeIssued.Iso(
@@ -181,6 +192,7 @@ object DummyOAuth2IssuerCredentialDataProvider : CredentialDataProviderFun {
                 expiration,
                 EuPidScheme,
                 subjectPublicKey,
+                DummyOAuth2DataProvider.user,
             )
         }
     }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/DummyOAuth2IssuerCredentialDataProvider.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/DummyOAuth2IssuerCredentialDataProvider.kt
@@ -185,12 +185,6 @@ object DummyOAuth2IssuerCredentialDataProvider : CredentialDataProviderFun {
         }
     }
 
-    private fun Collection<String>?.isNullOrContains(s: String) =
-        this == null || contains(s)
-
-    private fun optionalClaim(claimNames: Collection<String>?, name: String, value: Any) =
-        if (claimNames.isNullOrContains(name)) ClaimToBeIssued(name, value) else null
-
     private fun issuerSignedItem(name: String, value: Any, digestId: UInt) = IssuerSignedItem(
         digestId = digestId,
         random = Random.nextBytes(16),

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTest.kt
@@ -4,6 +4,9 @@ import at.asitplus.wallet.eupid.EuPidScheme
 import at.asitplus.wallet.lib.agent.*
 import at.asitplus.wallet.lib.data.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.PLAIN_JWT
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 import at.asitplus.wallet.mdl.MobileDrivingLicenceScheme
 import com.benasher44.uuid.uuid4
@@ -56,7 +59,7 @@ class OpenId4VpCombinedProtocolTest : FreeSpec({
                         credentials = setOf(
                             RequestOptionsCredential(
                                 ConstantIndex.AtomicAttribute2023,
-                                ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                                PLAIN_JWT
                             )
                         )
                     )
@@ -79,7 +82,7 @@ class OpenId4VpCombinedProtocolTest : FreeSpec({
                         credentials = setOf(
                             RequestOptionsCredential(
                                 ConstantIndex.AtomicAttribute2023,
-                                ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                                PLAIN_JWT,
                             )
                         )
                     )
@@ -116,7 +119,7 @@ class OpenId4VpCombinedProtocolTest : FreeSpec({
                             credentials = setOf(
                                 RequestOptionsCredential(
                                     ConstantIndex.AtomicAttribute2023,
-                                    ConstantIndex.CredentialRepresentation.SD_JWT
+                                    SD_JWT
                                 )
                             )
                         )
@@ -146,7 +149,7 @@ class OpenId4VpCombinedProtocolTest : FreeSpec({
                             credentials = setOf(
                                 RequestOptionsCredential(
                                     ConstantIndex.AtomicAttribute2023,
-                                    ConstantIndex.CredentialRepresentation.SD_JWT
+                                    SD_JWT
                                 )
                             )
                         ),
@@ -177,7 +180,7 @@ class OpenId4VpCombinedProtocolTest : FreeSpec({
                             credentials = setOf(
                                 RequestOptionsCredential(
                                     ConstantIndex.AtomicAttribute2023,
-                                    ConstantIndex.CredentialRepresentation.SD_JWT
+                                    SD_JWT
                                 )
                             ),
                             presentationMechanism = PresentationMechanismEnum.DCQL,
@@ -210,7 +213,7 @@ class OpenId4VpCombinedProtocolTest : FreeSpec({
                             credentials = setOf(
                                 RequestOptionsCredential(
                                     ConstantIndex.AtomicAttribute2023,
-                                    ConstantIndex.CredentialRepresentation.SD_JWT
+                                    SD_JWT
                                 )
                             ),
                             presentationMechanism = PresentationMechanismEnum.DCQL
@@ -248,7 +251,7 @@ class OpenId4VpCombinedProtocolTest : FreeSpec({
                             credentials = setOf(
                                 RequestOptionsCredential(
                                     ConstantIndex.AtomicAttribute2023,
-                                    ConstantIndex.CredentialRepresentation.ISO_MDOC
+                                    ISO_MDOC
                                 )
                             )
                         ),
@@ -278,7 +281,7 @@ class OpenId4VpCombinedProtocolTest : FreeSpec({
                         credentials = setOf(
                             RequestOptionsCredential(
                                 ConstantIndex.AtomicAttribute2023,
-                                ConstantIndex.CredentialRepresentation.ISO_MDOC
+                                ISO_MDOC
                             )
                         )
                     ),
@@ -307,7 +310,7 @@ class OpenId4VpCombinedProtocolTest : FreeSpec({
                             credentials = setOf(
                                 RequestOptionsCredential(
                                     ConstantIndex.AtomicAttribute2023,
-                                    ConstantIndex.CredentialRepresentation.ISO_MDOC
+                                    ISO_MDOC
                                 )
                             ),
                             presentationMechanism = PresentationMechanismEnum.DCQL,
@@ -339,7 +342,7 @@ class OpenId4VpCombinedProtocolTest : FreeSpec({
                             credentials = setOf(
                                 RequestOptionsCredential(
                                     ConstantIndex.AtomicAttribute2023,
-                                    ConstantIndex.CredentialRepresentation.ISO_MDOC
+                                    ISO_MDOC
                                 )
                             ),
                             presentationMechanism = PresentationMechanismEnum.DCQL
@@ -367,10 +370,10 @@ class OpenId4VpCombinedProtocolTest : FreeSpec({
                 credentials = setOf(
                     RequestOptionsCredential(
                         ConstantIndex.AtomicAttribute2023,
-                        ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                        PLAIN_JWT
                     ),
                     RequestOptionsCredential(
-                        MobileDrivingLicenceScheme, ConstantIndex.CredentialRepresentation.ISO_MDOC
+                        MobileDrivingLicenceScheme, ISO_MDOC
                     )
                 )
             ),
@@ -391,12 +394,12 @@ class OpenId4VpCombinedProtocolTest : FreeSpec({
             credentials = setOf(
                 RequestOptionsCredential(
                     credentialScheme = ConstantIndex.AtomicAttribute2023,
-                    representation = ConstantIndex.CredentialRepresentation.SD_JWT,
+                    representation = SD_JWT,
                     requestedAttributes = setOf(ConstantIndex.AtomicAttribute2023.CLAIM_DATE_OF_BIRTH),
                 ),
                 RequestOptionsCredential(
                     credentialScheme = EuPidScheme,
-                    representation = ConstantIndex.CredentialRepresentation.SD_JWT,
+                    representation = SD_JWT,
                     requestedAttributes = setOf(
                         EuPidScheme.Attributes.FAMILY_NAME,
                         EuPidScheme.Attributes.GIVEN_NAME
@@ -442,7 +445,7 @@ private suspend fun Holder.storeJwtCredential(
             DummyCredentialDataProvider.getCredential(
                 holderKeyMaterial.publicKey,
                 credentialScheme,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                PLAIN_JWT,
             ).getOrThrow()
         ).getOrThrow().toStoreCredentialInput()
     )
@@ -457,7 +460,7 @@ private suspend fun Holder.storeSdJwtCredential(
             DummyCredentialDataProvider.getCredential(
                 holderKeyMaterial.publicKey,
                 credentialScheme,
-                ConstantIndex.CredentialRepresentation.SD_JWT,
+                SD_JWT,
             ).getOrThrow()
         ).getOrThrow().toStoreCredentialInput()
     )
@@ -471,7 +474,7 @@ private suspend fun Holder.storeIsoCredential(
         DummyCredentialDataProvider.getCredential(
             holderKeyMaterial.publicKey,
             credentialScheme,
-            ConstantIndex.CredentialRepresentation.ISO_MDOC,
+            ISO_MDOC,
         ).getOrThrow()
     ).getOrThrow().toStoreCredentialInput()
 )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpComplexSdJwtProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpComplexSdJwtProtocolTest.kt
@@ -3,7 +3,6 @@ package at.asitplus.wallet.lib.openid
 import at.asitplus.dif.FormatContainerJwt
 import at.asitplus.dif.FormatContainerSdJwt
 import at.asitplus.jsonpath.JsonPath
-import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.wallet.lib.agent.*
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
@@ -54,7 +53,8 @@ class OpenId4VpComplexSdJwtProtocolTest : FreeSpec({
                     ),
                     Clock.System.now().plus(5.minutes),
                     AtomicAttribute2023,
-                    holderKeyMaterial.publicKey
+                    holderKeyMaterial.publicKey,
+                    DummyOAuth2DataProvider.user,
                 )
             ).getOrThrow().toStoreCredentialInput()
         )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEuRefInteropTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEuRefInteropTest.kt
@@ -53,7 +53,6 @@ class OpenId4VpEuRefInteropTest : FreeSpec({
                     holderKeyMaterial.publicKey,
                     EuPidScheme,
                     ConstantIndex.CredentialRepresentation.SD_JWT,
-                    EuPidScheme.requiredClaimNames
                 ).getOrThrow()
             ).getOrThrow().toStoreCredentialInput()
         )
@@ -63,10 +62,6 @@ class OpenId4VpEuRefInteropTest : FreeSpec({
                     holderKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
                     ConstantIndex.CredentialRepresentation.SD_JWT,
-                    listOf(
-                        CLAIM_FAMILY_NAME,
-                        CLAIM_GIVEN_NAME
-                    )
                 ).getOrThrow()
             ).getOrThrow().toStoreCredentialInput()
         )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpInteropTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpInteropTest.kt
@@ -63,7 +63,6 @@ class OpenId4VpInteropTest : FreeSpec({
                     holderKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
                     ConstantIndex.CredentialRepresentation.SD_JWT,
-                    listOf(CLAIM_FAMILY_NAME, CLAIM_GIVEN_NAME)
                 ).getOrThrow()
             ).getOrThrow().toStoreCredentialInput()
         )

--- a/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/KeyBindingTests.kt
+++ b/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/KeyBindingTests.kt
@@ -43,18 +43,13 @@ class KeyBindingTests : FreeSpec({
     beforeEach {
         holderKeyMaterial = EphemeralKeyWithoutCert()
         holderAgent = HolderAgent(holderKeyMaterial)
-
         holderAgent.storeCredential(
             IssuerAgent().issueCredential(
                 DummyCredentialDataProvider.getCredential(holderKeyMaterial.publicKey, EuPidScheme, SD_JWT)
                     .getOrThrow()
             ).getOrThrow().toStoreCredentialInput()
         )
-
-        holderOid4vp = OpenId4VpHolder(
-            holder = holderAgent,
-        )
-
+        holderOid4vp = OpenId4VpHolder(holder = holderAgent)
     }
 
     "Rqes Request with EU PID credential" - {
@@ -71,7 +66,101 @@ class KeyBindingTests : FreeSpec({
                 """.trimIndent()
 
         val cibaWalletTestVector = """
-                {"response_type":"vp_token","client_id":"redirect_uri:$clientId","scope":"","state":"iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg","nonce":"f90d0982-52f4-4a1c-8525-bdf1d33c232b","client_metadata":{"jwks_uri":"https://cibawallet.local-ip.medicmobile.org/wallet/jarm/iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg/jwks.json","id_token_signed_response_alg":"RS256","authorization_encrypted_response_alg":"ECDH-ES","authorization_encrypted_response_enc":"A128CBC-HS256","id_token_encrypted_response_alg":"RSA-OAEP-256","id_token_encrypted_response_enc":"A128CBC-HS256","subject_syntax_types_supported":["urn:ietf:params:oauth:jwk-thumbprint"],"vp_formats":{"vc+sd-jwt":{"sd-jwt_alg_values":["ES256"],"kb-jwt_alg_values":["ES256"]},"dc+sd-jwt":{"sd-jwt_alg_values":["ES256"],"kb-jwt_alg_values":["ES256"]},"mso_mdoc":{"alg":["ES256"]}}},"presentation_definition":{"id":"4c7038cf-bd1e-47c0-8f70-eaf9d62c6fae","name":"Cibazmaj","purpose":"where su pare","input_descriptors":[{"id":"607510a9-c957-4095-906d-f99fd006c4ae","name":"niko kao","purpose":"hajduk iz splita","format":{"vc+sd-jwt":{"sd-jwt_alg_values":["ES256"],"kb-jwt_alg_values":["ES256"]}},"constraints":{"fields":[{"path":["${'$'}.family_name"]},{"path":["${'$'}.given_name"]},{"path":["${'$'}.birth_date"]},{"path":["${'$'}.vct"],"filter":{"type":"string","enum":["urn:eu.europa.ec.eudi:pid:1"]}}]}}]},"response_mode":"direct_post","response_uri":"https://cibawallet.local-ip.medicmobile.org/wallet/direct_post/iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg","aud":"https://self-issued.me/v2","iat":1744198186,"transaction_data":["eyJ0eXBlIjoicWNlcnRfY3JlYXRpb25fYWNjZXB0YW5jZSIsImNyZWRlbnRpYWxfaWRzIjpbIjYwNzUxMGE5LWM5NTctNDA5NS05MDZkLWY5OWZkMDA2YzRhZSJdLCJRQ190ZXJtc19jb25kaXRpb25zX3VyaSI6Imh0dHBzOi8vd3d3LmQtdHJ1c3QubmV0L2RlL2FnYiIsIlFDX2hhc2giOiI3UXptNUVqdXpYS1NIRmxjME9IOVBQOXFVYUgtVkJsMmFHTmJ3WWoxb09BIiwiUUNfaGFzaEFsZ29yaXRobU9JRCI6IjIuMTYuODQwLjEuMTAxLjMuNC4yLjEiLCJ0cmFuc2FjdGlvbl9kYXRhX2hhc2hlc19hbGciOlsic2hhLTI1NiJdfQ"]}
+                {
+                    "response_type": "vp_token",
+                    "client_id": "redirect_uri:$clientId",
+                    "scope": "",
+                    "state": "iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg",
+                    "nonce": "f90d0982-52f4-4a1c-8525-bdf1d33c232b",
+                    "client_metadata": {
+                        "jwks_uri": "https://cibawallet.local-ip.medicmobile.org/wallet/jarm/iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg/jwks.json",
+                        "id_token_signed_response_alg": "RS256",
+                        "authorization_encrypted_response_alg": "ECDH-ES",
+                        "authorization_encrypted_response_enc": "A128CBC-HS256",
+                        "id_token_encrypted_response_alg": "RSA-OAEP-256",
+                        "id_token_encrypted_response_enc": "A128CBC-HS256",
+                        "subject_syntax_types_supported": [
+                            "urn:ietf:params:oauth:jwk-thumbprint"
+                        ],
+                        "vp_formats": {
+                            "vc+sd-jwt": {
+                                "sd-jwt_alg_values": [
+                                    "ES256"
+                                ],
+                                "kb-jwt_alg_values": [
+                                    "ES256"
+                                ]
+                            },
+                            "dc+sd-jwt": {
+                                "sd-jwt_alg_values": [
+                                    "ES256"
+                                ],
+                                "kb-jwt_alg_values": [
+                                    "ES256"
+                                ]
+                            },
+                            "mso_mdoc": {
+                                "alg": [
+                                    "ES256"
+                                ]
+                            }
+                        }
+                    },
+                    "presentation_definition": {
+                        "id": "4c7038cf-bd1e-47c0-8f70-eaf9d62c6fae",
+                        "name": "Cibazmaj",
+                        "purpose": "where su pare",
+                        "input_descriptors": [
+                            {
+                                "id": "607510a9-c957-4095-906d-f99fd006c4ae",
+                                "name": "niko kao",
+                                "purpose": "hajduk iz splita",
+                                "format": {
+                                    "vc+sd-jwt": {
+                                        "sd-jwt_alg_values": [
+                                            "ES256"
+                                        ],
+                                        "kb-jwt_alg_values": [
+                                            "ES256"
+                                        ]
+                                    }
+                                },
+                                "constraints": {
+                                    "fields": [
+                                        {
+                                            "path": [
+                                                "${'$'}.family_name"
+                                            ]
+                                        },
+                                        {
+                                            "path": [
+                                                "${'$'}.given_name"
+                                            ]
+                                        },
+                                        {
+                                            "path": [
+                                                "${'$'}.vct"
+                                            ],
+                                            "filter": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "urn:eu.europa.ec.eudi:pid:1"
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "response_mode": "direct_post",
+                    "response_uri": "https://cibawallet.local-ip.medicmobile.org/wallet/direct_post/iTGlKl-AJxmncWPbXHp2xy58bNy18wqZ4TR9EzhBl2R4ulxeTEO0VyWYR2qMDpCDV5JWeOxecTqcEJ61bFKrUg",
+                    "aud": "https://self-issued.me/v2",
+                    "iat": 1744198186,
+                    "transaction_data": [
+                        "eyJ0eXBlIjoicWNlcnRfY3JlYXRpb25fYWNjZXB0YW5jZSIsImNyZWRlbnRpYWxfaWRzIjpbIjYwNzUxMGE5LWM5NTctNDA5NS05MDZkLWY5OWZkMDA2YzRhZSJdLCJRQ190ZXJtc19jb25kaXRpb25zX3VyaSI6Imh0dHBzOi8vd3d3LmQtdHJ1c3QubmV0L2RlL2FnYiIsIlFDX2hhc2giOiI3UXptNUVqdXpYS1NIRmxjME9IOVBQOXFVYUgtVkJsMmFHTmJ3WWoxb09BIiwiUUNfaGFzaEFsZ29yaXRobU9JRCI6IjIuMTYuODQwLjEuMTAxLjMuNC4yLjEiLCJ0cmFuc2FjdGlvbl9kYXRhX2hhc2hlc19hbGciOlsic2hhLTI1NiJdfQ"
+                    ]
+                }
             """.trimIndent()
 
         "KB-JWT contains transaction data" - {
@@ -82,8 +171,9 @@ class KeyBindingTests : FreeSpec({
                 val newInputDescriptors = rawRequest.presentationDefinition!!.inputDescriptors.map {
                     (it as QesInputDescriptor).copy(transactionData = null)
                 }
-                val authnRequest =
-                    rawRequest.copy(presentationDefinition = rawRequest.presentationDefinition!!.copy(inputDescriptors = newInputDescriptors))
+                val authnRequest = rawRequest.copy(
+                    presentationDefinition = rawRequest.presentationDefinition!!.copy(inputDescriptors = newInputDescriptors)
+                )
 
                 val authnRequestUrl = URLBuilder(walletUrl).apply {
                     authnRequest.encodeToParameters()
@@ -161,21 +251,20 @@ class KeyBindingTests : FreeSpec({
             val requestOptions = buildRqesRequestOptions(null, OpenIdConstants.ResponseMode.DirectPost)
             val authnRequest = rqesVerifier.createAuthnRequest(requestOptions)
 
-            val malignResponse =
-                holderOid4vp.createAuthnResponse(
-                    vckJsonSerializer.encodeToString(
-                        authnRequest.copy(
-                            transactionData = listOf(
-                                QCertCreationAcceptance(
-                                    qcTermsConditionsUri = uuid4().toString(),
-                                    qcHash = uuid4().bytes,
-                                    qcHashAlgorithmOid = Digest.SHA256.oid,
-                                ).toBase64UrlJsonString()
-                            )
+            val malignResponse = holderOid4vp.createAuthnResponse(
+                vckJsonSerializer.encodeToString(
+                    authnRequest.copy(
+                        transactionData = listOf(
+                            QCertCreationAcceptance(
+                                qcTermsConditionsUri = uuid4().toString(),
+                                qcHash = uuid4().bytes,
+                                qcHashAlgorithmOid = Digest.SHA256.oid,
+                            ).toBase64UrlJsonString()
                         )
                     )
-                ).getOrThrow()
-                    .shouldBeInstanceOf<AuthenticationResponseResult.Post>()
+                )
+            ).getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Post>()
 
             val result = rqesVerifier.validateAuthnResponse(malignResponse.params)
             result.shouldBeInstanceOf<AuthnResponseResult.ValidationError>()
@@ -187,27 +276,29 @@ class KeyBindingTests : FreeSpec({
                 keyMaterial = EphemeralKeyWithoutCert(),
                 clientIdScheme = clientIdScheme,
                 stateToAuthnRequestStore = externalMapStore,
-                verifier = VerifierAgent(identifier = clientIdScheme.clientId, validator = Validator(verifyTransactionData = false))
+                verifier = VerifierAgent(
+                    identifier = clientIdScheme.clientId,
+                    validator = Validator(verifyTransactionData = false)
+                )
             )
 
             val requestOptions = buildRqesRequestOptions(null, OpenIdConstants.ResponseMode.DirectPost)
             val authnRequest = lenientVerifier.createAuthnRequest(requestOptions)
 
-            val malignResponse =
-                holderOid4vp.createAuthnResponse(
-                    vckJsonSerializer.encodeToString(
-                        authnRequest.copy(
-                            transactionData = listOf(
-                                QCertCreationAcceptance(
-                                    qcTermsConditionsUri = uuid4().toString(),
-                                    qcHash = uuid4().bytes,
-                                    qcHashAlgorithmOid = Digest.SHA256.oid,
-                                ).toBase64UrlJsonString()
-                            )
+            val malignResponse = holderOid4vp.createAuthnResponse(
+                vckJsonSerializer.encodeToString(
+                    authnRequest.copy(
+                        transactionData = listOf(
+                            QCertCreationAcceptance(
+                                qcTermsConditionsUri = uuid4().toString(),
+                                qcHash = uuid4().bytes,
+                                qcHashAlgorithmOid = Digest.SHA256.oid,
+                            ).toBase64UrlJsonString()
                         )
                     )
-                ).getOrThrow()
-                    .shouldBeInstanceOf<AuthenticationResponseResult.Post>()
+                )
+            ).getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Post>()
 
             val result = lenientVerifier.validateAuthnResponse(malignResponse.params)
             result.shouldBeInstanceOf<AuthnResponseResult.SuccessSdJwt>()

--- a/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/helper/DummyCredentialDataProvider.kt
+++ b/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/helper/DummyCredentialDataProvider.kt
@@ -2,6 +2,8 @@ package at.asitplus.wallet.lib.rqes.helper
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
+import at.asitplus.openid.OidcUserInfo
+import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.wallet.eupid.EuPidScheme
 import at.asitplus.wallet.lib.agent.ClaimToBeIssued
@@ -55,6 +57,7 @@ object DummyCredentialDataProvider {
                         expiration = expiration,
                         scheme = credentialScheme,
                         subjectPublicKey = subjectPublicKey,
+                        userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
                     )
                 else -> throw NotImplementedError()
             }

--- a/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/helper/DummyCredentialDataProvider.kt
+++ b/vck-rqes/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/helper/DummyCredentialDataProvider.kt
@@ -19,12 +19,10 @@ object DummyCredentialDataProvider {
         subjectPublicKey: CryptoPublicKey,
         credentialScheme: ConstantIndex.CredentialScheme,
         representation: ConstantIndex.CredentialRepresentation,
-        claimNames: Collection<String>? = null,
     ): KmmResult<CredentialToBeIssued> = catching {
         val issuance = Clock.System.now()
         val expiration = issuance + defaultLifetime
         if (credentialScheme == EuPidScheme) {
-            val subjectId = subjectPublicKey.didEncoded
             val familyName = "Musterfrau"
             val givenName = "Maria"
             val birthDate = LocalDate.parse("1970-01-01")
@@ -34,18 +32,17 @@ object DummyCredentialDataProvider {
 
                 ConstantIndex.CredentialRepresentation.SD_JWT -> with(EuPidScheme.SdJwtAttributes) {
                     listOfNotNull(
-                        optionalClaim(claimNames, FAMILY_NAME, familyName),
-                        optionalClaim(claimNames, FAMILY_NAME_BIRTH, familyName),
-                        optionalClaim(claimNames, GIVEN_NAME, givenName),
-                        optionalClaim(claimNames, GIVEN_NAME_BIRTH, givenName),
-                        optionalClaim(claimNames, BIRTH_DATE, birthDate),
-                        optionalClaim(claimNames, EuPidScheme.Attributes.BIRTH_DATE, birthDate), //incorrect encoding in german test vector?
-                        optionalClaim(claimNames, AGE_EQUAL_OR_OVER_18, true),
-                        optionalClaim(claimNames, NATIONALITIES, listOf(nationality)),
-                        optionalClaim(claimNames, ISSUANCE_DATE, issuance),
-                        optionalClaim(claimNames, EXPIRY_DATE, expiration),
-                        optionalClaim(claimNames, ISSUING_COUNTRY, issuingCountry),
-                        optionalClaim(claimNames, ISSUING_AUTHORITY, issuingCountry),
+                        ClaimToBeIssued(FAMILY_NAME, familyName),
+                        ClaimToBeIssued(FAMILY_NAME_BIRTH, familyName),
+                        ClaimToBeIssued(GIVEN_NAME, givenName),
+                        ClaimToBeIssued(GIVEN_NAME_BIRTH, givenName),
+                        ClaimToBeIssued(BIRTH_DATE, birthDate),
+                        ClaimToBeIssued(AGE_EQUAL_OR_OVER_18, true),
+                        ClaimToBeIssued(NATIONALITIES, listOf(nationality)),
+                        ClaimToBeIssued(ISSUANCE_DATE, issuance),
+                        ClaimToBeIssued(EXPIRY_DATE, expiration),
+                        ClaimToBeIssued(ISSUING_COUNTRY, issuingCountry),
+                        ClaimToBeIssued(ISSUING_AUTHORITY, issuingCountry),
                     )
                 }
 
@@ -65,11 +62,5 @@ object DummyCredentialDataProvider {
             throw NotImplementedError()
         }
     }
-
-    private fun Collection<String>?.isNullOrContains(s: String) =
-        this == null || contains(s)
-
-    private fun optionalClaim(claimNames: Collection<String>?, name: String, value: Any) =
-        if (claimNames.isNullOrContains(name)) ClaimToBeIssued(name, value) else null
 
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CredentialToBeIssued.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CredentialToBeIssued.kt
@@ -4,18 +4,21 @@ import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.CredentialSubject
 import at.asitplus.iso.IssuerSignedItem
+import at.asitplus.openid.OidcUserInfoExtended
 import kotlinx.datetime.Instant
 
 sealed class CredentialToBeIssued {
     abstract val expiration: Instant
     abstract val scheme: ConstantIndex.CredentialScheme
     abstract val subjectPublicKey: CryptoPublicKey
+    abstract val userInfo: OidcUserInfoExtended
 
     data class VcJwt(
         val subject: CredentialSubject,
         override val expiration: Instant,
         override val scheme: ConstantIndex.CredentialScheme,
         override val subjectPublicKey: CryptoPublicKey,
+        override val userInfo: OidcUserInfoExtended,
     ) : CredentialToBeIssued()
 
     data class VcSd(
@@ -23,6 +26,7 @@ sealed class CredentialToBeIssued {
         override val expiration: Instant,
         override val scheme: ConstantIndex.CredentialScheme,
         override val subjectPublicKey: CryptoPublicKey,
+        override val userInfo: OidcUserInfoExtended,
     ) : CredentialToBeIssued()
 
     data class Iso(
@@ -30,6 +34,7 @@ sealed class CredentialToBeIssued {
         override val expiration: Instant,
         override val scheme: ConstantIndex.CredentialScheme,
         override val subjectPublicKey: CryptoPublicKey,
+        override val userInfo: OidcUserInfoExtended,
     ) : CredentialToBeIssued()
 }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CredentialToBeIssued.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CredentialToBeIssued.kt
@@ -7,25 +7,29 @@ import at.asitplus.iso.IssuerSignedItem
 import kotlinx.datetime.Instant
 
 sealed class CredentialToBeIssued {
+    abstract val expiration: Instant
+    abstract val scheme: ConstantIndex.CredentialScheme
+    abstract val subjectPublicKey: CryptoPublicKey
+
     data class VcJwt(
         val subject: CredentialSubject,
-        val expiration: Instant,
-        val scheme: ConstantIndex.CredentialScheme,
-        val subjectPublicKey: CryptoPublicKey,
+        override val expiration: Instant,
+        override val scheme: ConstantIndex.CredentialScheme,
+        override val subjectPublicKey: CryptoPublicKey,
     ) : CredentialToBeIssued()
 
     data class VcSd(
         val claims: Collection<ClaimToBeIssued>,
-        val expiration: Instant,
-        val scheme: ConstantIndex.CredentialScheme,
-        val subjectPublicKey: CryptoPublicKey,
+        override val expiration: Instant,
+        override val scheme: ConstantIndex.CredentialScheme,
+        override val subjectPublicKey: CryptoPublicKey,
     ) : CredentialToBeIssued()
 
     data class Iso(
         val issuerSignedItems: List<IssuerSignedItem>,
-        val expiration: Instant,
-        val scheme: ConstantIndex.CredentialScheme,
-        val subjectPublicKey: CryptoPublicKey,
+        override val expiration: Instant,
+        override val scheme: ConstantIndex.CredentialScheme,
+        override val subjectPublicKey: CryptoPublicKey,
     ) : CredentialToBeIssued()
 }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
@@ -8,10 +8,13 @@ import at.asitplus.jsonpath.core.NodeList
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.openid.dcql.DCQLQuery
 import at.asitplus.openid.dcql.DCQLQueryResult
+import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.CredentialPresentation
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest
+import at.asitplus.wallet.lib.data.VerifiableCredentialJws
 import at.asitplus.wallet.lib.iso.IssuerSigned
+import at.asitplus.wallet.lib.jws.SdJwtSigned
 
 /**
  * Summarizes operations for a Holder in the sense of the [W3C VC Data Model](https://w3c.github.io/vc-data-model/).
@@ -25,17 +28,17 @@ interface Holder {
      */
     val keyMaterial: KeyMaterial
 
-    @Deprecated("Use keyMaterial instead", ReplaceWith("keyMaterial"))
-    val keyPair: KeyMaterial
-        get() = keyMaterial
-
     sealed class StoreCredentialInput {
         data class Vc(
+            val signedVcJws: JwsSigned<VerifiableCredentialJws>,
+            @Deprecated("Use signedVcJws instead", ReplaceWith("signedVcJws"))
             val vcJws: String,
             val scheme: ConstantIndex.CredentialScheme,
         ) : StoreCredentialInput()
 
         data class SdJwt(
+            val signedSdJwtVc: SdJwtSigned,
+            @Deprecated("Use signedSdJwtVc instead", ReplaceWith("signedSdJwtVc"))
             val vcSdJwt: String,
             val scheme: ConstantIndex.CredentialScheme,
         ) : StoreCredentialInput()

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -48,7 +48,7 @@ class HolderAgent(
     override suspend fun storeCredential(credential: Holder.StoreCredentialInput) = catching {
         when (credential) {
             is Holder.StoreCredentialInput.Vc -> {
-                val validated = validator.verifyVcJws(credential.vcJws, keyMaterial.publicKey)
+                val validated = validator.verifyVcJws(credential.signedVcJws, keyMaterial.publicKey)
                 if (validated !is Verifier.VerifyCredentialResult.SuccessJwt) {
                     val error = (validated as? Verifier.VerifyCredentialResult.ValidationError)?.cause
                         ?: Throwable("Invalid VC JWS")
@@ -62,7 +62,7 @@ class HolderAgent(
             }
 
             is Holder.StoreCredentialInput.SdJwt -> {
-                val validated = validator.verifySdJwt(SdJwtSigned.parse(credential.vcSdJwt)!!, keyMaterial.publicKey)
+                val validated = validator.verifySdJwt(credential.signedSdJwtVc, keyMaterial.publicKey)
                 if (validated !is Verifier.VerifyCredentialResult.SuccessSdJwt) {
                     val error = (validated as? Verifier.VerifyCredentialResult.ValidationError)?.cause
                         ?: Throwable("Invalid SD-JWT")

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
@@ -1,11 +1,15 @@
 package at.asitplus.wallet.lib.agent
 
+import at.asitplus.KmmResult
+import at.asitplus.catching
 import at.asitplus.signum.indispensable.CryptoPublicKey
+import at.asitplus.wallet.lib.agent.IssuerCredentialStore.Credential.*
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListView
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusBitSize
 import at.asitplus.wallet.lib.iso.sha256
+import com.benasher44.uuid.uuid4
 import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.coroutines.sync.Mutex
@@ -19,12 +23,13 @@ class InMemoryIssuerCredentialStore(
 
     data class Credential(
         val vcId: String,
-        val statusListIndex: Long,
+        val statusListIndex: ULong,
         var status: TokenStatus,
         val expirationDate: Instant,
         val scheme: ConstantIndex.CredentialScheme,
     )
 
+    /** Maps timePeriod to credentials */
     private val credentialMap = mutableMapOf<Int, MutableList<Credential>>()
 
     override suspend fun storeGetNextIndex(
@@ -34,50 +39,74 @@ class InMemoryIssuerCredentialStore(
         expirationDate: Instant,
         timePeriod: Int
     ): Long = indexMutex.withLock {
-        val list = credentialMap.getOrPut(timePeriod) {
-            mutableListOf()
-        }
-
-        val newIndex = (list.maxOfOrNull { it.statusListIndex } ?: 0) + 1
+        val list = credentialMap.getOrPut(timePeriod) { mutableListOf() }
+        val newIndex: ULong = (list.maxOfOrNull { it.statusListIndex } ?: 0U) + 1U
         val vcId = when (credential) {
-            is IssuerCredentialStore.Credential.Iso -> credential.issuerSignedItemList.sortedBy {
-                it.digestId
-            }.toString().encodeToByteArray().sha256().encodeToString(Base16(strict = true))
+            is Iso -> credential.issuerSignedItemList
+                .sortedBy { it.digestId }
+                .toString()
+                .encodeToByteArray().sha256()
+                .encodeToString(Base16(strict = true))
 
-            is IssuerCredentialStore.Credential.VcJwt -> credential.vcId
-            is IssuerCredentialStore.Credential.VcSd -> credential.vcId
-        }
-        val scheme = when (credential) {
-            is IssuerCredentialStore.Credential.Iso -> credential.scheme
-            is IssuerCredentialStore.Credential.VcJwt -> credential.scheme
-            is IssuerCredentialStore.Credential.VcSd -> credential.scheme
+            is VcJwt -> credential.vcId
+            is VcSd -> credential.vcId
         }
         list += Credential(
             vcId = vcId,
             statusListIndex = newIndex,
             status = TokenStatus.Valid,
             expirationDate = expirationDate,
-            scheme = scheme,
+            scheme = credential.scheme,
         )
-        newIndex
+        newIndex.toLong()
+    }
+
+    override suspend fun createStatusListIndex(
+        credential: CredentialToBeIssued,
+        timePeriod: Int,
+    ): KmmResult<IssuerCredentialStore.StoredCredentialReference> = catching {
+        val list = credentialMap.getOrPut(timePeriod) { mutableListOf() }
+        val newIndex: ULong = (list.maxOfOrNull { it.statusListIndex } ?: 0U) + 1U
+        val vcId = uuid4().toString()
+        list += Credential(
+            vcId = vcId,
+            statusListIndex = newIndex,
+            status = TokenStatus.Valid,
+            expirationDate = credential.expiration,
+            scheme = credential.scheme,
+        )
+        IssuerCredentialStore.StoredCredentialReference(vcId, timePeriod, newIndex)
+    }
+
+    override suspend fun updateStoredCredential(
+        reference: IssuerCredentialStore.StoredCredentialReference,
+        credential: Issuer.IssuedCredential,
+    ): KmmResult<IssuerCredentialStore.StoredCredentialReference> = catching {
+        val list = credentialMap.getOrPut(reference.timePeriod) { mutableListOf() }
+        if (list.find { it.vcId == reference.id } == null) {
+            list += Credential(
+                vcId = reference.id,
+                statusListIndex = reference.statusListIndex,
+                status = TokenStatus.Valid,
+                expirationDate = credential.validUntil,
+                scheme = credential.scheme
+            )
+        }
+        reference
     }
 
     override fun getStatusListView(timePeriod: Int): StatusListView {
-        val timePeriodStatusCollection = credentialMap[timePeriod] ?: return StatusListView(
-            ByteArray(0),
-            statusBitSize = tokenStatusBitSize,
-        )
+        val timePeriodStatusCollection = credentialMap[timePeriod]
+            ?: return StatusListView(ByteArray(0), tokenStatusBitSize)
 
         val timePeriodStatusMap = timePeriodStatusCollection.associate {
             it.statusListIndex to it.status
         }
-        val highestIndex = timePeriodStatusMap.keys.maxOrNull() ?: return StatusListView(
-            ByteArray(0),
-            statusBitSize = tokenStatusBitSize,
-        )
+        val highestIndex = timePeriodStatusMap.keys.maxOrNull()
+            ?: return StatusListView(ByteArray(0), tokenStatusBitSize)
 
-        val tokenStatusList = (0..highestIndex).map {
-            timePeriodStatusMap[it] ?: TokenStatus.Valid
+        val tokenStatusList = (0U..highestIndex.toUInt()).map {
+            timePeriodStatusMap[it.toULong()] ?: TokenStatus.Valid
         }
 
         return StatusListView.fromTokenStatuses(
@@ -99,4 +128,29 @@ class InMemoryIssuerCredentialStore(
         entry.status = status
         return true
     }
+
+    override fun setStatus(
+        timePeriod: Int,
+        index: ULong,
+        status: TokenStatus,
+    ): Boolean {
+        if (status.value > tokenStatusBitSize.maxValue) {
+            throw IllegalStateException("Credential store only accepts token statuses of bitlength `${tokenStatusBitSize.value}`.")
+        }
+        val entry = credentialMap.getOrPut(timePeriod) {
+            mutableListOf()
+        }.find {
+            it.statusListIndex == index
+        } ?: return false
+
+        entry.status = status
+        return true
+    }
 }
+
+private val Issuer.IssuedCredential.validUntil: Instant
+    get() = when (this) {
+        is Issuer.IssuedCredential.Iso -> this.issuerSigned.issuerAuth.payload?.validityInfo?.validUntil ?: Instant.DISTANT_PAST
+        is Issuer.IssuedCredential.VcJwt -> this.vc.expirationDate?: Instant.DISTANT_PAST
+        is Issuer.IssuedCredential.VcSdJwt -> this.sdJwtVc.expiration ?: Instant.DISTANT_PAST
+    }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Issuer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Issuer.kt
@@ -3,6 +3,8 @@ package at.asitplus.wallet.lib.agent
 import at.asitplus.KmmResult
 import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.VerifiableCredential
+import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents.ReferencedTokenIssuer
 import at.asitplus.wallet.lib.iso.IssuerSigned
 
@@ -18,13 +20,14 @@ interface Issuer : ReferencedTokenIssuer<CredentialToBeIssued, KmmResult<Issuer.
      * A credential issued by an [Issuer], in a specific format
      */
     sealed class IssuedCredential {
-        // TODO add the typed credential and the userInfo
+        // TODO add the userInfo
         abstract val scheme: ConstantIndex.CredentialScheme
 
         /**
          * Issued credential in W3C Verifiable Credentials JWT representation
          */
         data class VcJwt(
+            val vc: VerifiableCredential,
             val vcJws: String,
             override val scheme: ConstantIndex.CredentialScheme,
         ) : IssuedCredential()
@@ -33,6 +36,7 @@ interface Issuer : ReferencedTokenIssuer<CredentialToBeIssued, KmmResult<Issuer.
          * Issued credential in SD-JWT representation
          */
         data class VcSdJwt(
+            val sdJwt: VerifiableCredentialSdJwt,
             val vcSdJwt: String,
             override val scheme: ConstantIndex.CredentialScheme,
         ) : IssuedCredential()

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Issuer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Issuer.kt
@@ -2,11 +2,14 @@ package at.asitplus.wallet.lib.agent
 
 import at.asitplus.KmmResult
 import at.asitplus.signum.indispensable.SignatureAlgorithm
+import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.VerifiableCredential
+import at.asitplus.wallet.lib.data.VerifiableCredentialJws
 import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents.ReferencedTokenIssuer
 import at.asitplus.wallet.lib.iso.IssuerSigned
+import at.asitplus.wallet.lib.jws.SdJwtSigned
 
 
 /**
@@ -28,6 +31,8 @@ interface Issuer : ReferencedTokenIssuer<CredentialToBeIssued, KmmResult<Issuer.
          */
         data class VcJwt(
             val vc: VerifiableCredential,
+            val signedVcJws: JwsSigned<VerifiableCredentialJws>,
+            @Deprecated("Use signedVcJws instead", ReplaceWith("signedVcJws"))
             val vcJws: String,
             override val scheme: ConstantIndex.CredentialScheme,
         ) : IssuedCredential()
@@ -36,7 +41,9 @@ interface Issuer : ReferencedTokenIssuer<CredentialToBeIssued, KmmResult<Issuer.
          * Issued credential in SD-JWT representation
          */
         data class VcSdJwt(
-            val sdJwt: VerifiableCredentialSdJwt,
+            val sdJwtVc: VerifiableCredentialSdJwt,
+            val signedSdJwtVc: SdJwtSigned,
+            @Deprecated("Use signedSdJwtVc instead", ReplaceWith("signedSdJwtVc"))
             val vcSdJwt: String,
             override val scheme: ConstantIndex.CredentialScheme,
         ) : IssuedCredential()
@@ -74,6 +81,6 @@ interface Issuer : ReferencedTokenIssuer<CredentialToBeIssued, KmmResult<Issuer.
 
 fun Issuer.IssuedCredential.toStoreCredentialInput() = when (this) {
     is Issuer.IssuedCredential.Iso -> Holder.StoreCredentialInput.Iso(issuerSigned, scheme)
-    is Issuer.IssuedCredential.VcSdJwt -> Holder.StoreCredentialInput.SdJwt(vcSdJwt, scheme)
-    is Issuer.IssuedCredential.VcJwt -> Holder.StoreCredentialInput.Vc(vcJws, scheme)
+    is Issuer.IssuedCredential.VcSdJwt -> Holder.StoreCredentialInput.SdJwt(signedSdJwtVc, signedSdJwtVc.serialize(), scheme)
+    is Issuer.IssuedCredential.VcJwt -> Holder.StoreCredentialInput.Vc(signedVcJws, signedVcJws.serialize(), scheme)
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Issuer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Issuer.kt
@@ -1,6 +1,8 @@
 package at.asitplus.wallet.lib.agent
 
 import at.asitplus.KmmResult
+import at.asitplus.openid.OidcUserInfoExtended
+import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.wallet.lib.data.ConstantIndex
@@ -23,8 +25,9 @@ interface Issuer : ReferencedTokenIssuer<CredentialToBeIssued, KmmResult<Issuer.
      * A credential issued by an [Issuer], in a specific format
      */
     sealed class IssuedCredential {
-        // TODO add the userInfo
         abstract val scheme: ConstantIndex.CredentialScheme
+        abstract val subjectPublicKey: CryptoPublicKey
+        abstract val userInfo: OidcUserInfoExtended
 
         /**
          * Issued credential in W3C Verifiable Credentials JWT representation
@@ -35,6 +38,8 @@ interface Issuer : ReferencedTokenIssuer<CredentialToBeIssued, KmmResult<Issuer.
             @Deprecated("Use signedVcJws instead", ReplaceWith("signedVcJws"))
             val vcJws: String,
             override val scheme: ConstantIndex.CredentialScheme,
+            override val subjectPublicKey: CryptoPublicKey,
+            override val userInfo: OidcUserInfoExtended,
         ) : IssuedCredential()
 
         /**
@@ -46,6 +51,8 @@ interface Issuer : ReferencedTokenIssuer<CredentialToBeIssued, KmmResult<Issuer.
             @Deprecated("Use signedSdJwtVc instead", ReplaceWith("signedSdJwtVc"))
             val vcSdJwt: String,
             override val scheme: ConstantIndex.CredentialScheme,
+            override val subjectPublicKey: CryptoPublicKey,
+            override val userInfo: OidcUserInfoExtended,
         ) : IssuedCredential()
 
         /**
@@ -54,6 +61,8 @@ interface Issuer : ReferencedTokenIssuer<CredentialToBeIssued, KmmResult<Issuer.
         data class Iso(
             val issuerSigned: IssuerSigned,
             override val scheme: ConstantIndex.CredentialScheme,
+            override val subjectPublicKey: CryptoPublicKey,
+            override val userInfo: OidcUserInfoExtended,
         ) : IssuedCredential()
     }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Issuer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Issuer.kt
@@ -18,12 +18,15 @@ interface Issuer : ReferencedTokenIssuer<CredentialToBeIssued, KmmResult<Issuer.
      * A credential issued by an [Issuer], in a specific format
      */
     sealed class IssuedCredential {
+        // TODO add the typed credential and the userInfo
+        abstract val scheme: ConstantIndex.CredentialScheme
+
         /**
          * Issued credential in W3C Verifiable Credentials JWT representation
          */
         data class VcJwt(
             val vcJws: String,
-            val scheme: ConstantIndex.CredentialScheme,
+            override val scheme: ConstantIndex.CredentialScheme,
         ) : IssuedCredential()
 
         /**
@@ -31,7 +34,7 @@ interface Issuer : ReferencedTokenIssuer<CredentialToBeIssued, KmmResult<Issuer.
          */
         data class VcSdJwt(
             val vcSdJwt: String,
-            val scheme: ConstantIndex.CredentialScheme,
+            override val scheme: ConstantIndex.CredentialScheme,
         ) : IssuedCredential()
 
         /**
@@ -39,7 +42,7 @@ interface Issuer : ReferencedTokenIssuer<CredentialToBeIssued, KmmResult<Issuer.
          */
         data class Iso(
             val issuerSigned: IssuerSigned,
-            val scheme: ConstantIndex.CredentialScheme,
+            override val scheme: ConstantIndex.CredentialScheme,
         ) : IssuedCredential()
     }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
@@ -173,7 +173,7 @@ class IssuerAgent(
             Napier.w("issueVc error", it)
         }.getOrThrow().serialize()
 
-        return Issuer.IssuedCredential.VcJwt(vcInJws, credential.scheme).also {
+        return Issuer.IssuedCredential.VcJwt(vc, vcInJws, credential.scheme).also {
             issuerCredentialStore.updateStoredCredential(reference, it).getOrThrow()
         }
     }
@@ -227,7 +227,11 @@ class IssuerAgent(
         }.getOrThrow()
         val vcInSdJwt = (listOf(jws.serialize()) + disclosures).joinToString("~", postfix = "~")
         Napier.i("issueVcSd: $vcInSdJwt")
-        return Issuer.IssuedCredential.VcSdJwt(vcInSdJwt, credential.scheme).also {
+        return Issuer.IssuedCredential.VcSdJwt(
+            vcSdJwt,
+            vcInSdJwt,
+            credential.scheme
+        ).also {
             issuerCredentialStore.updateStoredCredential(reference, it).getOrThrow()
         }
     }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
@@ -137,7 +137,12 @@ class IssuerAgent(
             ).getOrThrow(),
         )
         Napier.i("issueMdoc: $issuerSigned")
-        return Issuer.IssuedCredential.Iso(issuerSigned, credential.scheme).also {
+        return Issuer.IssuedCredential.Iso(
+            issuerSigned = issuerSigned,
+            scheme = credential.scheme,
+            subjectPublicKey = credential.subjectPublicKey,
+            userInfo = credential.userInfo
+        ).also {
             issuerCredentialStore.updateStoredCredential(reference, it).getOrThrow()
         }
     }
@@ -178,7 +183,9 @@ class IssuerAgent(
             vc = vc,
             signedVcJws = vcInJws,
             vcJws = vcInJws.serialize(),
-            scheme = credential.scheme
+            scheme = credential.scheme,
+            subjectPublicKey = credential.subjectPublicKey,
+            userInfo = credential.userInfo,
         ).also {
             issuerCredentialStore.updateStoredCredential(reference, it).getOrThrow()
         }
@@ -237,7 +244,9 @@ class IssuerAgent(
             sdJwtVc = vcSdJwt,
             signedSdJwtVc = sdJwtSigned,
             vcSdJwt = sdJwtSigned.serialize(),
-            scheme = credential.scheme
+            scheme = credential.scheme,
+            subjectPublicKey = credential.subjectPublicKey,
+            userInfo = credential.userInfo,
         ).also {
             issuerCredentialStore.updateStoredCredential(reference, it).getOrThrow()
         }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerCredentialStore.kt
@@ -1,11 +1,15 @@
 package at.asitplus.wallet.lib.agent
 
+import at.asitplus.KmmResult
+import at.asitplus.iso.IssuerSignedItem
+import at.asitplus.iso.sha256
 import at.asitplus.signum.indispensable.CryptoPublicKey
+import at.asitplus.signum.indispensable.cosef.io.Base16Strict
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.CredentialSubject
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListView
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
-import at.asitplus.iso.IssuerSignedItem
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.datetime.Instant
 
 /**
@@ -13,37 +17,68 @@ import kotlinx.datetime.Instant
  */
 interface IssuerCredentialStore {
 
+    @Deprecated("Use `createStatusListIndex` and `updateStoredCredential` instead")
     sealed class Credential {
+        abstract val scheme: ConstantIndex.CredentialScheme
+        abstract val vcId: String
+
         data class VcJwt(
-            val vcId: String,
+            override val vcId: String,
             val credentialSubject: CredentialSubject,
-            val scheme: ConstantIndex.CredentialScheme
+            override val scheme: ConstantIndex.CredentialScheme,
         ) : Credential()
 
         data class VcSd(
-            val vcId: String,
+            override val vcId: String,
             val claims: Collection<ClaimToBeIssued>,
-            val scheme: ConstantIndex.CredentialScheme
+            override val scheme: ConstantIndex.CredentialScheme,
         ) : Credential()
 
         data class Iso(
             val issuerSignedItemList: List<IssuerSignedItem>,
-            val scheme: ConstantIndex.CredentialScheme
-        ) : Credential()
+            override val scheme: ConstantIndex.CredentialScheme,
+        ) : Credential() {
+            override val vcId = issuerSignedItemList.toString()
+                .encodeToByteArray().sha256().encodeToString(Base16Strict)
+        }
     }
+
+    data class StoredCredentialReference(
+        val id: String,
+        val timePeriod: Int,
+        val statusListIndex: ULong,
+    )
 
     /**
      * Called by the issuer when creating a new credential.
-     * Expected to return a new index to use as a `statusListIndex`
+     * Expected to return a new index to use as a `statusListIndex`.
      * Returns null if `vcId` is already registered
      */
+    @Deprecated("Use `createStatusListIndex` and `updateStoredCredential` instead")
     suspend fun storeGetNextIndex(
         credential: Credential,
         subjectPublicKey: CryptoPublicKey,
         issuanceDate: Instant,
         expirationDate: Instant,
-        timePeriod: Int
+        timePeriod: Int,
     ): Long?
+
+    /**
+     * Called by an [Issuer] when creating a new credential to get a `statusListIndex` first.
+     * [Issuer] will call [updateStoredCredential] with the issued credential afterwards.
+     */
+    suspend fun createStatusListIndex(
+        credential: CredentialToBeIssued,
+        timePeriod: Int,
+    ): KmmResult<StoredCredentialReference>
+
+    /**
+     * Called by an [Issuer] when the credential has been signed and delivered to the holder.
+     */
+    suspend fun updateStoredCredential(
+        reference: StoredCredentialReference,
+        credential: Issuer.IssuedCredential,
+    ): KmmResult<StoredCredentialReference>
 
     /**
      * Returns a list of revoked credentials, represented by their `statusListIndex`
@@ -53,5 +88,11 @@ interface IssuerCredentialStore {
     /**
      * Set the status of the credential with this `vcId`, if it exists
      */
+    @Deprecated("Use setStatus(timePeriod, index, status) instead")
     fun setStatus(vcId: String, status: TokenStatus, timePeriod: Int): Boolean
+
+    /**
+     * Set the [status] of the credential with this [index] for the [timePeriod], if it exists
+     */
+    fun setStatus(timePeriod: Int, index: ULong, status: TokenStatus): Boolean
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListAgent.kt
@@ -96,34 +96,25 @@ class StatusListAgent(
         issuerCredentialStore.getStatusListView(timePeriod ?: timePeriodProvider.getCurrentTimePeriod(clock))
 
     /**
-     * Revokes all verifiable credentials from [credentialsToRevoke] list that parse and validate.
-     * It returns true if all revocations was successful.
+     * Sets the status of one specific credential to [at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus.Invalid].
+     * Returns true if this credential has been revoked.
      */
-    // TODO remove this
-    override suspend fun revokeCredentials(credentialsToRevoke: List<String>): Boolean =
-        credentialsToRevoke.map {
-            validator.verifyVcJws(it, null)
-        }.filterIsInstance<Verifier.VerifyCredentialResult.SuccessJwt>().all {
-            issuerCredentialStore.setStatus(
-                vcId = it.jws.vc.id,
-                status = TokenStatus.Invalid,
-                timePeriod = timePeriodProvider.getTimePeriodFor(it.jws.vc.issuanceDate)
-            )
-        }
+    override fun revokeCredential(timePeriod: Int, statusListIndex: ULong): Boolean =
+        issuerCredentialStore.setStatus(timePeriod, statusListIndex, TokenStatus.Invalid)
+
+    /**
+     * Revokes all verifiable credentials from [credentialsToRevoke] list that parse and validate.
+     * It returns true if all revocations were successful.
+     */
+    @Deprecated("Use `revokeCredential` instead")
+    override suspend fun revokeCredentials(credentialsToRevoke: List<String>): Boolean = false
 
     /**
      * Revokes all verifiable credentials with ids from [credentialIdsToRevoke]
-     * It returns true if all revocations was successful.
+     * It returns true if all revocations were successful.
      */
-    // TODO remove this
-    override fun revokeCredentialsWithId(credentialIdsToRevoke: Map<String, Instant>): Boolean =
-        credentialIdsToRevoke.all {
-            issuerCredentialStore.setStatus(
-                vcId = it.key,
-                status = TokenStatus.Invalid,
-                timePeriod = timePeriodProvider.getTimePeriodFor(it.value),
-            )
-        }
+    @Deprecated("Use `revokeCredential` instead")
+    override fun revokeCredentialsWithId(credentialIdsToRevoke: Map<String, Instant>): Boolean = false
 
     override suspend fun provideStatusListToken(
         acceptedContentTypes: List<StatusListTokenMediaType>,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListAgent.kt
@@ -4,6 +4,7 @@ import at.asitplus.signum.indispensable.cosef.CoseHeader
 import at.asitplus.signum.indispensable.cosef.CoseSigned
 import at.asitplus.wallet.lib.DefaultZlibService
 import at.asitplus.wallet.lib.ZlibService
+import at.asitplus.wallet.lib.agent.FixedTimePeriodProvider.timePeriod
 import at.asitplus.wallet.lib.cbor.CoseHeaderCertificate
 import at.asitplus.wallet.lib.cbor.CoseHeaderKeyId
 import at.asitplus.wallet.lib.cbor.SignCose
@@ -98,6 +99,7 @@ class StatusListAgent(
      * Revokes all verifiable credentials from [credentialsToRevoke] list that parse and validate.
      * It returns true if all revocations was successful.
      */
+    // TODO remove this
     override suspend fun revokeCredentials(credentialsToRevoke: List<String>): Boolean =
         credentialsToRevoke.map {
             validator.verifyVcJws(it, null)
@@ -113,6 +115,7 @@ class StatusListAgent(
      * Revokes all verifiable credentials with ids from [credentialIdsToRevoke]
      * It returns true if all revocations was successful.
      */
+    // TODO remove this
     override fun revokeCredentialsWithId(credentialIdsToRevoke: Map<String, Instant>): Boolean =
         credentialIdsToRevoke.all {
             issuerCredentialStore.setStatus(

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListIssuer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListIssuer.kt
@@ -24,14 +24,22 @@ interface StatusListIssuer :
     fun buildStatusList(timePeriod: Int? = null): StatusList?
 
     /**
-     * Revokes all verifiable credentials from [credentialsToRevoke] list that parse and validate.
-     * It returns true if all revocations was successful.
+     * Sets the status of one specific credential to [at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus.Invalid].
+     * Returns true if this credential has been revoked.
      */
+    fun revokeCredential(timePeriod: Int, statusListIndex: ULong): Boolean
+
+    /**
+     * Revokes all verifiable credentials from [credentialsToRevoke] list that parse and validate.
+     * It returns true if all revocations were successful.
+     */
+    @Deprecated("Use `revokeCredential` instead")
     suspend fun revokeCredentials(credentialsToRevoke: List<String>): Boolean
 
     /**
      * Revokes all verifiable credentials with ids and issuance date from [credentialIdsToRevoke]
-     * It returns true if all revocations was successful.
+     * It returns true if all revocations were successful.
      */
+    @Deprecated("Use `revokeCredential` instead")
     fun revokeCredentialsWithId(credentialIdsToRevoke: Map<String, Instant>): Boolean
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Validator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Validator.kt
@@ -383,9 +383,10 @@ class Validator(
     private fun ByteStringWrapper<IssuerSignedItem>.verify(mdlItems: ValueDigestList?): Boolean {
         val issuerHash = mdlItems?.entries?.firstOrNull { it.key == value.digestId }
             ?: return false
-        val verifierHash =
-            coseCompliantSerializer.encodeToByteArray(ByteArraySerializer(), serialized).wrapInCborTag(24)
-                .sha256()
+        val verifierHash = coseCompliantSerializer
+            .encodeToByteArray(ByteArraySerializer(), serialized)
+            .wrapInCborTag(24)
+            .sha256()
         if (!verifierHash.contentEquals(issuerHash.value)) {
             Napier.w("Could not verify hash of value for ${value.elementIdentifier}")
             return false
@@ -397,7 +398,18 @@ class Validator(
      * Validates the content of a JWS, expected to contain a Verifiable Credential.
      *
      * @param input JWS in compact representation
-     * @param publicKey Optionally the local key, to verify VC was issued to correct subject
+     * @param publicKey Optionally, the local key, to verify VC was issued to the correct subject
+     */
+    suspend fun verifyVcJws(
+        input: JwsSigned<VerifiableCredentialJws>,
+        publicKey: CryptoPublicKey?,
+    ) = verifyVcJws(input.serialize(), publicKey)
+
+    /**
+     * Validates the content of a JWS, expected to contain a Verifiable Credential.
+     *
+     * @param input JWS in compact representation
+     * @param publicKey Optionally, the local key, to verify VC was issued to the correct subject
      */
     suspend fun verifyVcJws(
         input: String,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/rfc/tokenStatusList/StatusListView.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/rfc/tokenStatusList/StatusListView.kt
@@ -18,7 +18,9 @@ data class StatusListView(
     fun isNotEmpty() = !isEmpty()
 
     operator fun get(index: UInt) = get(index.toULong())
-    operator fun get(index: ULong) = getOrNull(index) ?: throw IndexOutOfBoundsException()
+    operator fun get(index: ULong) = getOrNull(index)
+        ?: throw IndexOutOfBoundsException("Index $index is out of bounds, size ${uncompressed.size.toULong() * Byte.SIZE_BITS.toULong() / statusBitSize.value}")
+
     fun getOrNull(index: ULong): TokenStatus? {
         val tokenStatusesPerByte = Byte.SIZE_BITS.toULong() / statusBitSize.value
 
@@ -29,7 +31,7 @@ data class StatusListView(
         }.toInt()
         val byte = uncompressed.getOrNull(byteIndex) ?: return null
 
-        val statusMask = when(statusBitSize) {
+        val statusMask = when (statusBitSize) {
             TokenStatusBitSize.ONE -> 0b1u
             TokenStatusBitSize.TWO -> 0b11u
             TokenStatusBitSize.FOUR -> 0xfu
@@ -85,7 +87,7 @@ data class StatusListView(
             }
 
             val usedBitSize = statusBitSize ?: requiredBitSize
-            if(usedBitSize.value < requiredBitSize.value) {
+            if (usedBitSize.value < requiredBitSize.value) {
                 throw IllegalArgumentException("Argument `tokenStatuses` contains entries that do not fit into the size specified in `statusBitSize`.")
             }
 

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentComplexSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentComplexSdJwtTest.kt
@@ -2,6 +2,8 @@ package at.asitplus.wallet.lib.agent
 
 import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
 import at.asitplus.openid.CredentialFormatEnum
+import at.asitplus.openid.OidcUserInfo
+import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.openid.dcql.*
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_FAMILY_NAME
@@ -445,6 +447,7 @@ private suspend fun issueAndStoreCredential(
                 expiration = Clock.System.now() + 1.minutes,
                 scheme = AtomicAttribute2023,
                 subjectPublicKey = holderKeyMaterial.publicKey,
+                userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
             )
         ).getOrThrow().toStoreCredentialInput()
     )

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
@@ -1,5 +1,7 @@
 package at.asitplus.wallet.lib.agent
 
+import at.asitplus.openid.OidcUserInfo
+import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.wallet.lib.agent.FixedTimePeriodProvider.timePeriod
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignature
 import at.asitplus.wallet.lib.data.AtomicAttribute2023
@@ -11,7 +13,6 @@ import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListTokenPayload
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents.communication.primitives.StatusListTokenMediaType
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
 import at.asitplus.wallet.lib.jws.VerifyJwsObject
-import com.benasher44.uuid.uuid4
 import io.kotest.assertions.fail
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -188,7 +189,8 @@ private suspend fun IssuerCredentialStore.revokeCredentialsWithIndexes(revokedIn
                 subject = cred,
                 expiration = expirationDate,
                 scheme = ConstantIndex.AtomicAttribute2023,
-                subjectPublicKey = EphemeralKeyWithoutCert().publicKey
+                subjectPublicKey = EphemeralKeyWithoutCert().publicKey,
+                userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
             ),
             timePeriod
         ).getOrThrow()
@@ -210,7 +212,8 @@ private suspend fun IssuerCredentialStore.revokeRandomCredentials(): List<ULong>
                 subject = cred,
                 expiration = expirationDate,
                 scheme = ConstantIndex.AtomicAttribute2023,
-                subjectPublicKey = EphemeralKeyWithoutCert().publicKey
+                subjectPublicKey = EphemeralKeyWithoutCert().publicKey,
+                userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
             ),
             timePeriod
         ).getOrThrow().statusListIndex

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
@@ -4,6 +4,7 @@ import at.asitplus.wallet.lib.agent.FixedTimePeriodProvider.timePeriod
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignature
 import at.asitplus.wallet.lib.data.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.PLAIN_JWT
 import at.asitplus.wallet.lib.data.StatusListToken
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusList
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListTokenPayload
@@ -54,7 +55,7 @@ class AgentRevocationTest : FreeSpec({
                     DummyCredentialDataProvider.getCredential(
                         verifierKeyMaterial.publicKey,
                         ConstantIndex.AtomicAttribute2023,
-                        ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                        PLAIN_JWT,
                     ).getOrThrow()
                 ).getOrElse {
                     fail("no issued credentials")
@@ -71,7 +72,7 @@ class AgentRevocationTest : FreeSpec({
                 DummyCredentialDataProvider.getCredential(
                     verifierKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                    PLAIN_JWT,
                 ).getOrThrow()
             ).getOrElse {
                 fail("no issued credentials")
@@ -93,7 +94,7 @@ class AgentRevocationTest : FreeSpec({
                 DummyCredentialDataProvider.getCredential(
                     verifierKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                    PLAIN_JWT,
                 ).getOrThrow()
             ).getOrElse {
                 fail("no issued credentials")
@@ -127,7 +128,7 @@ class AgentRevocationTest : FreeSpec({
             DummyCredentialDataProvider.getCredential(
                 verifierKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                PLAIN_JWT,
             ).getOrThrow()
         ).getOrElse {
             fail("no issued credentials")

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
@@ -182,7 +182,7 @@ private suspend fun IssuerCredentialStore.revokeCredentialsWithIndexes(revokedIn
     val issuanceDate = Clock.System.now()
     val expirationDate = issuanceDate + 60.seconds
     for (i in 1..16) {
-        val revListIndex = createStatusListIndex(
+        val reference = createStatusListIndex(
             CredentialToBeIssued.VcJwt(
                 subject = cred,
                 expiration = expirationDate,
@@ -190,7 +190,8 @@ private suspend fun IssuerCredentialStore.revokeCredentialsWithIndexes(revokedIn
                 subjectPublicKey = EphemeralKeyWithoutCert().publicKey
             ),
             timePeriod
-        ).getOrThrow().statusListIndex
+        ).getOrThrow()
+        val revListIndex = reference.statusListIndex
         if (revokedIndexes.contains(revListIndex)) {
             setStatus(timePeriod, revListIndex, TokenStatus.Invalid)
         }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
@@ -135,7 +135,7 @@ class AgentRevocationTest : FreeSpec({
         }
         result.shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
 
-        val vcJws = Validator().verifyVcJws(result.vcJws, verifierKeyMaterial.publicKey)
+        val vcJws = Validator().verifyVcJws(result.signedVcJws, verifierKeyMaterial.publicKey)
         vcJws.shouldBeInstanceOf<Verifier.VerifyCredentialResult.SuccessJwt>()
         val credentialStatus = vcJws.jws.vc.credentialStatus
         credentialStatus.shouldNotBeNull()

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
@@ -9,6 +9,7 @@ import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.wallet.lib.data.*
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_DATE_OF_BIRTH
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.CredentialPresentation.PresentationExchangePresentation
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 import at.asitplus.wallet.lib.iso.sha256
@@ -75,7 +76,7 @@ class AgentSdJwtTest : FreeSpec({
                 DummyCredentialDataProvider.getCredential(
                     holderKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.SD_JWT,
+                    SD_JWT,
                 ).getOrThrow()
             ).getOrThrow().toStoreCredentialInput()
         ).getOrThrow()
@@ -301,7 +302,7 @@ suspend fun createFreshSdJwtKeyBinding(challenge: String, verifierId: String): S
             DummyCredentialDataProvider.getCredential(
                 holderKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.SD_JWT,
+                SD_JWT,
             ).getOrThrow()
         ).getOrThrow().toStoreCredentialInput()
     )

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
@@ -157,13 +157,18 @@ class AgentSdJwtTest : FreeSpec({
             val vp = presentationParameters.presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            val listOfJwtId = holderCredentialStore.getCredentials().getOrThrow()
+            holderCredentialStore.getCredentials().getOrThrow()
                 .filterIsInstance<SubjectCredentialStore.StoreEntry.SdJwt>()
-                .associate { it.sdJwt.jwtId!! to it.sdJwt.notBefore!! }
-            statusListIssuer.revokeCredentialsWithId(listOfJwtId) shouldBe true
-            val verified = verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
+                .forEach {
+                    statusListIssuer.revokeCredential(
+                        FixedTimePeriodProvider.timePeriod,
+                        it.sdJwt.credentialStatus!!.statusList.index
+                    ) shouldBe true
+                }
+            verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
-            verified.freshnessSummary.tokenStatusValidationResult.shouldBeInstanceOf<TokenStatusValidationResult.Invalid>()
+                .freshnessSummary.tokenStatusValidationResult
+                .shouldBeInstanceOf<TokenStatusValidationResult.Invalid>()
         }
     }
 
@@ -255,13 +260,18 @@ class AgentSdJwtTest : FreeSpec({
             val vp = presentationParameters.verifiablePresentations.values.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            val listOfJwtId = holderCredentialStore.getCredentials().getOrThrow()
+            holderCredentialStore.getCredentials().getOrThrow()
                 .filterIsInstance<SubjectCredentialStore.StoreEntry.SdJwt>()
-                .associate { it.sdJwt.jwtId!! to it.sdJwt.notBefore!! }
-            statusListIssuer.revokeCredentialsWithId(listOfJwtId) shouldBe true
-            val verified = verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
+                .forEach {
+                    statusListIssuer.revokeCredential(
+                        FixedTimePeriodProvider.timePeriod,
+                        it.sdJwt.credentialStatus!!.statusList.index,
+                    ) shouldBe true
+                }
+            verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
-            verified.freshnessSummary.tokenStatusValidationResult.shouldBeInstanceOf<TokenStatusValidationResult.Invalid>()
+                .freshnessSummary.tokenStatusValidationResult
+                .shouldBeInstanceOf<TokenStatusValidationResult.Invalid>()
         }
     }
 })

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentTest.kt
@@ -10,6 +10,7 @@ import at.asitplus.openid.dcql.DCQLCredentialQueryInstance
 import at.asitplus.openid.dcql.DCQLCredentialQueryList
 import at.asitplus.openid.dcql.DCQLQuery
 import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.PLAIN_JWT
 import at.asitplus.wallet.lib.data.CredentialPresentation.PresentationExchangePresentation
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest
 import at.asitplus.wallet.lib.data.StatusListToken
@@ -87,7 +88,7 @@ class AgentTest : FreeSpec({
                     DummyCredentialDataProvider.getCredential(
                         holderKeyMaterial.publicKey,
                         ConstantIndex.AtomicAttribute2023,
-                        ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                        PLAIN_JWT,
                     ).getOrThrow()
                 ).getOrThrow().toStoreCredentialInput()
             ).getOrThrow()
@@ -112,7 +113,7 @@ class AgentTest : FreeSpec({
                     DummyCredentialDataProvider.getCredential(
                         holderKeyMaterial.publicKey,
                         ConstantIndex.AtomicAttribute2023,
-                        ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                        PLAIN_JWT,
                     ).getOrThrow()
                 ).getOrThrow().toStoreCredentialInput()
             ).getOrThrow()
@@ -145,7 +146,7 @@ class AgentTest : FreeSpec({
                     DummyCredentialDataProvider.getCredential(
                         holderKeyMaterial.publicKey,
                         ConstantIndex.AtomicAttribute2023,
-                        ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                        PLAIN_JWT,
                     ).getOrThrow()
                 ).getOrThrow()
                     .shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
@@ -168,7 +169,7 @@ class AgentTest : FreeSpec({
                     DummyCredentialDataProvider.getCredential(
                         holderKeyMaterial.publicKey,
                         ConstantIndex.AtomicAttribute2023,
-                        ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                        PLAIN_JWT,
                     ).getOrThrow()
                 ).getOrThrow()
                     .shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
@@ -206,7 +207,7 @@ class AgentTest : FreeSpec({
                 DummyCredentialDataProvider.getCredential(
                     holderKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                    PLAIN_JWT,
                 ).getOrThrow()
             ).getOrThrow()
             holder.storeCredential(credentials.toStoreCredentialInput()).getOrThrow()
@@ -234,7 +235,7 @@ class AgentTest : FreeSpec({
                 DummyCredentialDataProvider.getCredential(
                     holderKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                    PLAIN_JWT,
                 ).getOrThrow()
             ).getOrThrow()
             holder.storeCredential(credentials.toStoreCredentialInput()).getOrThrow()
@@ -252,7 +253,7 @@ class AgentTest : FreeSpec({
                 DummyCredentialDataProvider.getCredential(
                     holderKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                    PLAIN_JWT,
                 ).getOrThrow()
             ).getOrThrow()
                 .shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
@@ -282,7 +283,7 @@ class AgentTest : FreeSpec({
                     DummyCredentialDataProvider.getCredential(
                         holderKeyMaterial.publicKey,
                         ConstantIndex.AtomicAttribute2023,
-                        ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                        PLAIN_JWT,
                     ).getOrThrow()
                 ).getOrThrow().toStoreCredentialInput()
             ).getOrThrow()
@@ -305,7 +306,7 @@ class AgentTest : FreeSpec({
                     DummyCredentialDataProvider.getCredential(
                         holderKeyMaterial.publicKey,
                         ConstantIndex.AtomicAttribute2023,
-                        ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                        PLAIN_JWT,
                     ).getOrThrow()
                 ).getOrThrow().toStoreCredentialInput()
             ).getOrThrow()
@@ -338,7 +339,7 @@ class AgentTest : FreeSpec({
                 DummyCredentialDataProvider.getCredential(
                     holderKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                    PLAIN_JWT,
                 ).getOrThrow()
             ).getOrThrow()
             holder.storeCredential(credentials.toStoreCredentialInput()).getOrThrow()
@@ -364,7 +365,7 @@ class AgentTest : FreeSpec({
                 DummyCredentialDataProvider.getCredential(
                     holderKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                    PLAIN_JWT,
                 ).getOrThrow()
             ).getOrThrow()
             holder.storeCredential(credentials.toStoreCredentialInput()).getOrThrow()
@@ -381,7 +382,7 @@ class AgentTest : FreeSpec({
                 DummyCredentialDataProvider.getCredential(
                     holderKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                    PLAIN_JWT,
                 ).getOrThrow()
             ).getOrThrow()
                 .shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/DummyCredentialDataProvider.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/DummyCredentialDataProvider.kt
@@ -23,12 +23,9 @@ object DummyCredentialDataProvider {
         subjectPublicKey: CryptoPublicKey,
         credentialScheme: ConstantIndex.CredentialScheme,
         representation: ConstantIndex.CredentialRepresentation,
-        claimNames: Collection<String>? = null,
     ): KmmResult<CredentialToBeIssued> = catching {
         val expiration = Clock.System.now() + defaultLifetime
-        val claims = claimNames?.map {
-            ClaimToBeIssued(it, "${it}_DUMMY_VALUE")
-        } ?: listOf(
+        val claims = listOf(
             ClaimToBeIssued(CLAIM_GIVEN_NAME, "Susanne"),
             ClaimToBeIssued(CLAIM_FAMILY_NAME, "Meier"),
             ClaimToBeIssued(CLAIM_DATE_OF_BIRTH, LocalDate.parse("1990-01-01")),

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/DummyCredentialDataProvider.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/DummyCredentialDataProvider.kt
@@ -10,6 +10,8 @@ import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_FAMIL
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_PORTRAIT
 import at.asitplus.iso.IssuerSignedItem
+import at.asitplus.openid.OidcUserInfo
+import at.asitplus.openid.OidcUserInfoExtended
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlin.random.Random
@@ -38,6 +40,7 @@ object DummyCredentialDataProvider {
                 expiration = expiration,
                 scheme = credentialScheme,
                 subjectPublicKey = subjectPublicKey,
+                userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
             )
 
             ConstantIndex.CredentialRepresentation.PLAIN_JWT -> CredentialToBeIssued.VcJwt(
@@ -45,6 +48,7 @@ object DummyCredentialDataProvider {
                 expiration = expiration,
                 scheme = credentialScheme,
                 subjectPublicKey = subjectPublicKey,
+                userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
             )
 
             ConstantIndex.CredentialRepresentation.ISO_MDOC -> CredentialToBeIssued.Iso(
@@ -54,6 +58,7 @@ object DummyCredentialDataProvider {
                 expiration = expiration,
                 scheme = credentialScheme,
                 subjectPublicKey = subjectPublicKey,
+                userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
             )
         }
     }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/SdJwtVerificationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/SdJwtVerificationTest.kt
@@ -44,6 +44,7 @@ class SdJwtVerificationTest : FreeSpec({
         val sdJwtValidator = SdJwtValidator(sdJwtSigned)
         val reconstructed = sdJwtValidator.reconstructedJsonObject.shouldNotBeNull()
         sdJwtValidator.validDisclosures.shouldNotBeEmpty()
+        sdJwtSigned.serialize() shouldBe input
 
         val expected = """
             {
@@ -100,6 +101,7 @@ class SdJwtVerificationTest : FreeSpec({
         val sdJwtValidator = SdJwtValidator(sdJwtSigned)
         val reconstructed = sdJwtValidator.reconstructedJsonObject.shouldNotBeNull()
         sdJwtValidator.validDisclosures.shouldNotBeEmpty()
+        sdJwtSigned.serialize() shouldBe input
 
         val expected = """
             {
@@ -199,6 +201,7 @@ class SdJwtVerificationTest : FreeSpec({
         val sdJwtValidator = SdJwtValidator(sdJwtSigned)
         val reconstructed = sdJwtValidator.reconstructedJsonObject.shouldNotBeNull()
         sdJwtValidator.validDisclosures.shouldNotBeEmpty()
+        sdJwtSigned.serialize() shouldBe input
 
         val expected = """
             {

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/StoreEntrySerializationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/StoreEntrySerializationTest.kt
@@ -5,6 +5,9 @@ import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.iso.IssuerSigned
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.PLAIN_JWT
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -36,7 +39,7 @@ class StoreEntrySerializationTest : FreeSpec({
             DummyCredentialDataProvider.getCredential(
                 holderKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                PLAIN_JWT,
             ).getOrThrow()
         ).getOrThrow()
             .shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
@@ -55,7 +58,7 @@ class StoreEntrySerializationTest : FreeSpec({
             DummyCredentialDataProvider.getCredential(
                 holderKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.SD_JWT,
+                SD_JWT,
             ).getOrThrow()
         ).getOrThrow()
             .shouldBeInstanceOf<Issuer.IssuedCredential.VcSdJwt>()
@@ -80,7 +83,7 @@ class StoreEntrySerializationTest : FreeSpec({
             DummyCredentialDataProvider.getCredential(
                 holderKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.ISO_MDOC,
+                ISO_MDOC,
             ).getOrThrow()
         ).getOrThrow()
             .shouldBeInstanceOf<Issuer.IssuedCredential.Iso>()

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorMdocTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorMdocTest.kt
@@ -89,13 +89,9 @@ class ValidatorMdocTest : FreeSpec() {
             val value = validator.verifyIsoCred(credential.issuerSigned, issuerKey)
                 .shouldBeInstanceOf<Verifier.VerifyCredentialResult.SuccessIso>()
             issuerCredentialStore.setStatus(
-                credential.issuerSigned.namespaces!!.get(ConstantIndex.AtomicAttribute2023.isoNamespace)!!.entries.map {
-                    it.value
-                } .sortedBy {
-                    it.digestId
-                }.toString().encodeToByteArray().sha256().encodeToString(Base16(strict = true)),
+                timePeriod = FixedTimePeriodProvider.timePeriod,
+                index = credential.issuerSigned.issuerAuth.payload!!.status!!.statusList.index,
                 status = TokenStatus.Invalid,
-                FixedTimePeriodProvider.timePeriod,
             ) shouldBe true
             validator.checkRevocationStatus(value.issuerSigned)
                 .shouldBeInstanceOf<TokenStatusValidationResult.Invalid>()

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorMdocTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorMdocTest.kt
@@ -6,6 +6,7 @@ import at.asitplus.signum.indispensable.pki.X509Certificate
 import at.asitplus.wallet.lib.agent.StatusListAgent
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.StatusListToken
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
 import at.asitplus.wallet.lib.iso.sha256
@@ -55,7 +56,7 @@ class ValidatorMdocTest : FreeSpec() {
                 DummyCredentialDataProvider.getCredential(
                     verifierKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.ISO_MDOC,
+                    ISO_MDOC,
                 ).getOrThrow()
             ).getOrThrow()
             credential.shouldBeInstanceOf<Issuer.IssuedCredential.Iso>()
@@ -75,7 +76,7 @@ class ValidatorMdocTest : FreeSpec() {
                 DummyCredentialDataProvider.getCredential(
                     verifierKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.ISO_MDOC,
+                    ISO_MDOC,
                 ).getOrThrow()
             ).getOrThrow()
             credential.shouldBeInstanceOf<Issuer.IssuedCredential.Iso>()

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwtTest.kt
@@ -4,6 +4,7 @@ import at.asitplus.signum.indispensable.josef.ConfirmationClaim
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.wallet.lib.agent.SdJwtCreator.toSdJsonObject
 import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.SdJwtConstants
 import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import at.asitplus.wallet.lib.data.vckJsonSerializer
@@ -78,7 +79,7 @@ class ValidatorSdJwtTest : FreeSpec() {
     private fun buildCredentialData(): CredentialToBeIssued.VcSd = DummyCredentialDataProvider.getCredential(
         holderKeyMaterial.publicKey,
         ConstantIndex.AtomicAttribute2023,
-        ConstantIndex.CredentialRepresentation.SD_JWT,
+        SD_JWT,
     ).getOrThrow().shouldBeInstanceOf<CredentialToBeIssued.VcSd>()
 }
 

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwtTest.kt
@@ -128,5 +128,5 @@ private suspend fun issueVcSd(
     }
     val vcInSdJwt = (listOf(jws.serialize()) + disclosures).joinToString("~", postfix = "~")
     Napier.i("issueVcSd: $vcInSdJwt")
-    return Issuer.IssuedCredential.VcSdJwt(vcInSdJwt, credential.scheme)
+    return Issuer.IssuedCredential.VcSdJwt(vcSdJwt, vcInSdJwt, credential.scheme)
 }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwtTest.kt
@@ -135,6 +135,8 @@ private suspend fun issueVcSd(
         sdJwtVc = vcSdJwt,
         signedSdJwtVc = sdJwtSigned,
         vcSdJwt = sdJwtSigned.serialize(),
-        scheme = credential.scheme
+        scheme = credential.scheme,
+        subjectPublicKey = credential.subjectPublicKey,
+        userInfo = credential.userInfo,
     )
 }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcTest.kt
@@ -73,7 +73,7 @@ class ValidatorVcTest : FreeSpec() {
             ).getOrThrow()
             credential.shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
 
-            validator.verifyVcJws(credential.vcJws, verifierKeyMaterial.publicKey)
+            validator.verifyVcJws(credential.signedVcJws, verifierKeyMaterial.publicKey)
                 .shouldBeInstanceOf<VerifyCredentialResult.SuccessJwt>()
         }
 
@@ -87,7 +87,7 @@ class ValidatorVcTest : FreeSpec() {
             ).getOrThrow()
             credential.shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
 
-            val value = validator.verifyVcJws(credential.vcJws, verifierKeyMaterial.publicKey)
+            val value = validator.verifyVcJws(credential.signedVcJws, verifierKeyMaterial.publicKey)
                 .shouldBeInstanceOf<VerifyCredentialResult.SuccessJwt>()
             issuerCredentialStore.setStatus(
                 timePeriod = FixedTimePeriodProvider.timePeriod,
@@ -95,7 +95,7 @@ class ValidatorVcTest : FreeSpec() {
                 status = TokenStatus.Invalid,
             ) shouldBe true
 
-            validator.verifyVcJws(credential.vcJws, verifierKeyMaterial.publicKey)
+            validator.verifyVcJws(credential.signedVcJws, verifierKeyMaterial.publicKey)
                 .shouldBeInstanceOf<VerifyCredentialResult.SuccessJwt>()
 
             validator.checkRevocationStatus(value.jws)
@@ -113,7 +113,7 @@ class ValidatorVcTest : FreeSpec() {
             ).getOrThrow()
             credential.shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
 
-            validator.verifyVcJws(credential.vcJws, verifierKeyMaterial.publicKey)
+            validator.verifyVcJws(credential.signedVcJws, verifierKeyMaterial.publicKey)
                 .shouldBeInstanceOf<VerifyCredentialResult.ValidationError>()
         }
 
@@ -127,8 +127,10 @@ class ValidatorVcTest : FreeSpec() {
             ).getOrThrow()
             credential.shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
 
-            validator.verifyVcJws(credential.vcJws.replaceFirstChar { "f" }, verifierKeyMaterial.publicKey)
-                .shouldBeInstanceOf<VerifyCredentialResult.InvalidStructure>()
+            validator.verifyVcJws(
+                credential.signedVcJws.serialize().replaceFirstChar { "f" },
+                verifierKeyMaterial.publicKey
+            ).shouldBeInstanceOf<VerifyCredentialResult.InvalidStructure>()
         }
 
         "Manually created and valid credential is valid" {
@@ -351,7 +353,7 @@ class ValidatorVcTest : FreeSpec() {
         ).getOrThrow().statusListIndex
         val credentialStatus = Status(
             statusList = StatusListInfo(
-                index = statusListIndex.toULong(),
+                index = statusListIndex,
                 uri = UniformResourceIdentifier(revocationListUrl),
             )
         )

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcTest.kt
@@ -1,5 +1,7 @@
 package at.asitplus.wallet.lib.agent
 
+import at.asitplus.openid.OidcUserInfo
+import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.JwsAlgorithm
 import at.asitplus.signum.indispensable.josef.JwsHeader
@@ -348,7 +350,13 @@ class ValidatorVcTest : FreeSpec() {
         val vcId = "urn:uuid:${uuid4()}"
         val exp = expirationDate ?: (Clock.System.now() + 60.seconds)
         val statusListIndex = issuerCredentialStore.createStatusListIndex(
-            CredentialToBeIssued.VcJwt(sub, exp, ConstantIndex.AtomicAttribute2023, issuerKeyMaterial.publicKey),
+            CredentialToBeIssued.VcJwt(
+                subject = sub,
+                expiration = exp,
+                scheme = ConstantIndex.AtomicAttribute2023,
+                subjectPublicKey = issuerKeyMaterial.publicKey,
+                userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
+            ),
             FixedTimePeriodProvider.timePeriod
         ).getOrThrow().statusListIndex
         val credentialStatus = Status(

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcTest.kt
@@ -7,6 +7,7 @@ import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.signum.supreme.signature
 import at.asitplus.wallet.lib.agent.Verifier.VerifyCredentialResult
 import at.asitplus.wallet.lib.data.*
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.PLAIN_JWT
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListInfo
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
@@ -67,7 +68,7 @@ class ValidatorVcTest : FreeSpec() {
                 DummyCredentialDataProvider.getCredential(
                     verifierKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                    PLAIN_JWT,
                 ).getOrThrow()
             ).getOrThrow()
             credential.shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
@@ -81,7 +82,7 @@ class ValidatorVcTest : FreeSpec() {
                 DummyCredentialDataProvider.getCredential(
                     verifierKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                    PLAIN_JWT,
                 ).getOrThrow()
             ).getOrThrow()
             credential.shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
@@ -107,7 +108,7 @@ class ValidatorVcTest : FreeSpec() {
                 DummyCredentialDataProvider.getCredential(
                     EphemeralKeyWithoutCert().publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                    PLAIN_JWT,
                 ).getOrThrow()
             ).getOrThrow()
             credential.shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
@@ -121,7 +122,7 @@ class ValidatorVcTest : FreeSpec() {
                 DummyCredentialDataProvider.getCredential(
                     verifierKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                    PLAIN_JWT,
                 ).getOrThrow()
             ).getOrThrow()
             credential.shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
@@ -134,7 +135,7 @@ class ValidatorVcTest : FreeSpec() {
             DummyCredentialDataProvider.getCredential(
                 verifierKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                PLAIN_JWT
             ).getOrThrow().let {
                 issueCredential(it)
                     .let { wrapVcInJws(it) }
@@ -150,7 +151,7 @@ class ValidatorVcTest : FreeSpec() {
             DummyCredentialDataProvider.getCredential(
                 verifierKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                PLAIN_JWT
             ).getOrThrow().let {
                 issueCredential(it)
                     .let { wrapVcInJws(it) }
@@ -166,7 +167,7 @@ class ValidatorVcTest : FreeSpec() {
             DummyCredentialDataProvider.getCredential(
                 verifierKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                PLAIN_JWT
             ).getOrThrow().let {
                 issueCredential(it)
                     .let { wrapVcInJws(it, subject = "vc.id") }
@@ -182,7 +183,7 @@ class ValidatorVcTest : FreeSpec() {
             DummyCredentialDataProvider.getCredential(
                 verifierKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                PLAIN_JWT
             ).getOrThrow().let {
                 issueCredential(it)
                     .let { wrapVcInJws(it, issuer = "vc.issuer") }
@@ -197,7 +198,7 @@ class ValidatorVcTest : FreeSpec() {
             DummyCredentialDataProvider.getCredential(
                 verifierKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                PLAIN_JWT
             ).getOrThrow().let {
                 issueCredential(it)
                     .let { wrapVcInJws(it, jwtId = "vc.jwtId") }
@@ -213,7 +214,7 @@ class ValidatorVcTest : FreeSpec() {
             DummyCredentialDataProvider.getCredential(
                 verifierKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                PLAIN_JWT
             ).getOrThrow().let {
                 issueCredential(it, expirationDate = Clock.System.now() - 1.hours)
                     .let {
@@ -238,7 +239,7 @@ class ValidatorVcTest : FreeSpec() {
             DummyCredentialDataProvider.getCredential(
                 verifierKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                PLAIN_JWT
             ).getOrThrow().let {
                 issueCredential(it, expirationDate = null)
                     .let { wrapVcInJws(it) }
@@ -254,7 +255,7 @@ class ValidatorVcTest : FreeSpec() {
             DummyCredentialDataProvider.getCredential(
                 verifierKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                PLAIN_JWT
             ).getOrThrow().let {
                 issueCredential(it, expirationDate = Clock.System.now() + 1.hours)
                     .let { wrapVcInJws(it, expirationDate = Clock.System.now() - 1.hours) }
@@ -270,7 +271,7 @@ class ValidatorVcTest : FreeSpec() {
             DummyCredentialDataProvider.getCredential(
                 verifierKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                PLAIN_JWT
             ).getOrThrow().let {
                 it.let { issueCredential(it, expirationDate = Clock.System.now() + 1.hours) }
                     .let { wrapVcInJws(it, expirationDate = Clock.System.now() + 2.hours) }
@@ -286,7 +287,7 @@ class ValidatorVcTest : FreeSpec() {
             DummyCredentialDataProvider.getCredential(
                 verifierKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                PLAIN_JWT
             ).getOrThrow().let {
                 it.let { issueCredential(it) }
                     .let { wrapVcInJws(it, issuanceDate = Clock.System.now() + 2.hours) }
@@ -302,7 +303,7 @@ class ValidatorVcTest : FreeSpec() {
             DummyCredentialDataProvider.getCredential(
                 verifierKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                PLAIN_JWT
             ).getOrThrow().let {
                 issueCredential(it, issuanceDate = Clock.System.now() + 1.hours)
                     .let { wrapVcInJws(it) }
@@ -320,7 +321,7 @@ class ValidatorVcTest : FreeSpec() {
             DummyCredentialDataProvider.getCredential(
                 verifierKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.PLAIN_JWT
+                PLAIN_JWT
             ).getOrThrow().let {
                 issueCredential(it, issuanceDate = Clock.System.now() - 1.hours)
                     .let { wrapVcInJws(it, issuanceDate = Clock.System.now()) }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVpTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVpTest.kt
@@ -159,9 +159,9 @@ class ValidatorVpTest : FreeSpec({
             .map { it.vc }
             .forEach {
                 issuerCredentialStore.setStatus(
-                    it.vc.id,
-                    TokenStatus.Invalid,
-                    FixedTimePeriodProvider.timePeriod
+                    timePeriod = FixedTimePeriodProvider.timePeriod,
+                    index = it.vc.credentialStatus!!.statusList.index,
+                    status = TokenStatus.Invalid,
                 ) shouldBe true
             }
 

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVpTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVpTest.kt
@@ -6,6 +6,7 @@ import at.asitplus.dif.DifInputDescriptor
 import at.asitplus.dif.PresentationDefinition
 import at.asitplus.wallet.lib.agent.Verifier.VerifyPresentationResult
 import at.asitplus.wallet.lib.data.*
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.PLAIN_JWT
 import at.asitplus.wallet.lib.data.CredentialPresentation.PresentationExchangePresentation
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
@@ -83,7 +84,7 @@ class ValidatorVpTest : FreeSpec({
                 DummyCredentialDataProvider.getCredential(
                     holderKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+                    PLAIN_JWT,
                 ).getOrThrow()
             ).getOrThrow().toStoreCredentialInput()
         ).getOrThrow()

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/Tag24SerializationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/iso/Tag24SerializationTest.kt
@@ -32,6 +32,7 @@ import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
 import at.asitplus.wallet.lib.agent.Issuer
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.collections.shouldHaveAtLeastSize
@@ -119,7 +120,7 @@ class Tag24SerializationTest : FreeSpec({
             DummyCredentialDataProvider.getCredential(
                 holderKeyMaterial.publicKey,
                 ConstantIndex.AtomicAttribute2023,
-                ConstantIndex.CredentialRepresentation.ISO_MDOC
+                ISO_MDOC
             ).getOrThrow()
         ).getOrThrow().shouldBeInstanceOf<Issuer.IssuedCredential.Iso>()
 

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/openid/dcql/DCQLQueryProcedureAdapterTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/openid/dcql/DCQLQueryProcedureAdapterTest.kt
@@ -3,6 +3,7 @@ package at.asitplus.wallet.openid.dcql
 import at.asitplus.openid.dcql.DCQLQuery
 import at.asitplus.wallet.lib.agent.*
 import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.procedures.dcql.DCQLQueryAdapter
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.maps.shouldHaveSize
@@ -27,7 +28,7 @@ class DCQLQueryProcedureAdapterTest : FreeSpec({
                 DummyCredentialDataProvider.getCredential(
                     holderKeyMaterial.publicKey,
                     ConstantIndex.AtomicAttribute2023,
-                    ConstantIndex.CredentialRepresentation.SD_JWT,
+                    SD_JWT,
                 ).getOrThrow()
             ).getOrThrow().toStoreCredentialInput()
         ).getOrThrow()


### PR DESCRIPTION
Allows for a cleaner integration into an issuing backend, and stores more information about issued credentials which can be used for revocation sometime later.