### PR TITLE
Feature/refactor request generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 Release 5.9.0 (unreleased):
+ - Remove Generics from `OpenId4VpHolder` functions and work directly with `AuthorizationRequestParameters`
+ - In `PresentationFactory` replace `RequestParameters` in function signatures to work directly with `AuthorizationRequestParameters`
+ - Remove all parameters from `RequestParameters`. Moved into their respective implementing class.
  - Change dependency structure of modules
  - Remove `vck-rqes` module
    - Relevant classes now in `vck-openid` 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthenticationRequestParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthenticationRequestParameters.kt
@@ -34,7 +34,7 @@ data class AuthenticationRequestParameters(
      * Optional when JAR (RFC9101) is used.
      */
     @SerialName("response_type")
-    override val responseType: String? = null,
+    val responseType: String? = null,
 
     /**
      * OIDC: REQUIRED. OAuth 2.0 Client Identifier valid at the Authorization Server.
@@ -49,7 +49,7 @@ data class AuthenticationRequestParameters(
      * See also [clientIdWithoutPrefix] and the notes there.
      */
     @SerialName("client_id")
-    override val clientId: String? = null,
+    val clientId: String? = null,
 
     /**
      * OID4VP: OPTIONAL. A string identifying the scheme of the value in the `client_id` Authorization Request parameter
@@ -69,7 +69,7 @@ data class AuthenticationRequestParameters(
      * See also [redirectUrlExtracted]
      */
     @SerialName("redirect_uri")
-    override val redirectUrl: String? = null,
+    val redirectUrl: String? = null,
 
     /**
      * OIDC: REQUIRED. OpenID Connect requests MUST contain the openid scope value. If the openid scope value is not
@@ -86,7 +86,7 @@ data class AuthenticationRequestParameters(
      * parameter with a browser cookie.
      */
     @SerialName("state")
-    override val state: String? = null,
+    val state: String? = null,
 
     /**
      * OIDC: OPTIONAL. String value used to associate a Client session with an ID Token, and to mitigate replay attacks.
@@ -94,7 +94,7 @@ data class AuthenticationRequestParameters(
      * be present in the nonce values used to prevent attackers from guessing values.
      */
     @SerialName("nonce")
-    override val nonce: String? = null,
+    val nonce: String? = null,
 
     /**
      * OpenID4VP: When received in [RequestObjectParameters.walletNonce], the Verifier MUST use it as the [walletNonce]
@@ -257,7 +257,7 @@ data class AuthenticationRequestParameters(
      * `invalid_request` Authorization Response error.
      */
     @SerialName("response_uri")
-    override val responseUrl: String? = null,
+    val responseUrl: String? = null,
 
     /**
      * OAuth 2.0 JAR: If signed, the Authorization Request Object SHOULD contain the Claims `iss` (issuer) and `aud`
@@ -265,7 +265,7 @@ data class AuthenticationRequestParameters(
      * value of `aud` should be the value of the authorization server (AS) `issuer`, as defined in RFC 8414.
      */
     @SerialName("aud")
-    override val audience: String? = null,
+    val audience: String? = null,
 
     /**
      * OAuth 2.0 JAR: If signed, the Authorization Request Object SHOULD contain the Claims `iss` (issuer) and `aud`
@@ -273,7 +273,7 @@ data class AuthenticationRequestParameters(
      * value of `aud` should be the value of the authorization server (AS) `issuer`, as defined in RFC 8414.
      */
     @SerialName("iss")
-    override val issuer: String? = null,
+    val issuer: String? = null,
 
     /**
      * OPTIONAL. Time at which the request was issued.
@@ -387,7 +387,7 @@ data class AuthenticationRequestParameters(
      * data not conforming to the respective type definition.
      */
     @SerialName("transaction_data")
-    override val transactionData: List<TransactionDataBase64Url>? = null,
+    val transactionData: List<TransactionDataBase64Url>? = null,
 
     /**
      * DCAPI: REQUIRED when signed requests defined in Appendix A.3.2 are used with the Digital
@@ -406,8 +406,27 @@ data class AuthenticationRequestParameters(
      * Reads the [OpenIdConstants.ClientIdScheme] of this request either directly from [clientIdScheme],
      * or by extracting the prefix from [clientId] (as specified in OpenID4VP draft 22 onwards).
      */
-    override val clientIdSchemeExtracted: OpenIdConstants.ClientIdScheme?
+    val clientIdSchemeExtracted: OpenIdConstants.ClientIdScheme?
         get() = clientId?.let { OpenIdConstants.ClientIdScheme.decodeFromClientId(it) }
+
+    /**
+     * Reads the [clientId] and removes the prefix of the [clientIdSchemeExtracted],
+     * as specified in OpenID4VP draft 22 onwards.
+     * OpenID4VP states that the *full* [clientId] must be used for presentations and anything else.
+     */
+    val clientIdWithoutPrefix: String?
+        get() = clientId?.let { clientId ->
+            clientIdSchemeExtracted?.let { clientId.removePrefix("${it.stringRepresentation}:") }
+        }
+
+    /**
+     * Reads the [redirectUrl], or the [clientIdWithoutPrefix] if [clientIdSchemeExtracted] is
+     * [OpenIdConstants.ClientIdScheme.RedirectUri], as specified in OpenID4VP draft 22 onwards.
+     */
+    val redirectUrlExtracted: String?
+        get() = redirectUrl
+            ?: (clientIdSchemeExtracted as? OpenIdConstants.ClientIdScheme.RedirectUri)?.let { clientIdWithoutPrefix }
+
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestObjectParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestObjectParameters.kt
@@ -33,17 +33,7 @@ data class RequestObjectParameters(
         walletMetadataString = metadata.catchingUnwrapped { joseCompliantSerializer.encodeToString(this) }.getOrNull(),
         walletNonce = nonce
     )
-
-    override val responseType: String? = null
-    override val nonce: String? = null
-    override val clientId: String? = null
-    override val redirectUrl: String? = null
-    override val responseUrl: String? = null
-    override val audience: String? = null
-    override val issuer: String? = null
-    override val state: String? = null
-    override val transactionData: List<TransactionDataBase64Url>? = null
-
+    
     val walletMetadata: OAuth2AuthorizationServerMetadata?
         get() = walletMetadataString?.let {
             catchingUnwrapped {

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParameters.kt
@@ -4,47 +4,12 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonClassDiscriminator
 
 /**
+ * Any set of parameters that might need complex parsing. See [at.asitplus.wallet.lib.openid.RequestParser]
  * Uses open serialization in order to avoid type-discriminator in serialization
  */
 @JsonClassDiscriminator("")
 @Serializable(with = RequestParametersSerializer::class)
-sealed class RequestParameters {
-    abstract val responseType: String?
-    abstract val nonce: String?
-    abstract val clientId: String?
-    abstract val redirectUrl: String?
-    abstract val responseUrl: String?
-    abstract val issuer: String?
-    abstract val audience: String?
-    abstract val state: String?
-    abstract val transactionData: List<TransactionDataBase64Url>?
-
-    /**
-     * Reads the [OpenIdConstants.ClientIdScheme] of this request either directly from [clientIdScheme],
-     * or by extracting the prefix from [clientId] (as specified in OpenID4VP draft 22 onwards).
-     */
-    open val clientIdSchemeExtracted: OpenIdConstants.ClientIdScheme?
-        get() = clientId?.let { OpenIdConstants.ClientIdScheme.decodeFromClientId(it) }
-
-    /**
-     * Reads the [clientId] and removes the prefix of the [clientIdSchemeExtracted],
-     * as specified in OpenID4VP draft 22 onwards.
-     * OpenID4VP states that the *full* [clientId] must be used for presentations and anything else.
-     */
-    open val clientIdWithoutPrefix: String?
-        get() = clientId?.let { clientId ->
-            clientIdSchemeExtracted?.let { clientId.removePrefix("${it.stringRepresentation}:") }
-        }
-
-    /**
-     * Reads the [redirectUrl], or the [clientIdWithoutPrefix] if [clientIdSchemeExtracted] is
-     * [OpenIdConstants.ClientIdScheme.RedirectUri], as specified in OpenID4VP draft 22 onwards.
-     */
-    open val redirectUrlExtracted: String?
-        get() = redirectUrl
-            ?: (clientIdSchemeExtracted as? OpenIdConstants.ClientIdScheme.RedirectUri)?.let { clientIdWithoutPrefix }
-
-}
+sealed class RequestParameters
 
 
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/SignatureRequestParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/SignatureRequestParameters.kt
@@ -27,13 +27,13 @@ data class SignatureRequestParameters(
      * Optional when JAR (RFC9101) is used.
      */
     @SerialName("response_type")
-    override val responseType: String,
+    val responseType: String,
 
     /**
      * OIDC: REQUIRED. OAuth 2.0 Client Identifier valid at the Authorization Server.
      */
     @SerialName("client_id")
-    override val clientId: String,
+    val clientId: String,
 
     /**
      * OID4VP: OPTIONAL. A string identifying the scheme of the value in the `client_id` Authorization Request parameter
@@ -66,7 +66,7 @@ data class SignatureRequestParameters(
      * `invalid_request` Authorization Response error.
      */
     @SerialName("response_uri")
-    override val responseUrl: String? = null,
+    val responseUrl: String? = null,
 
     /**
      * OIDC: OPTIONAL. String value used to associate a Client session with an ID Token, and to mitigate replay attacks.
@@ -74,7 +74,7 @@ data class SignatureRequestParameters(
      * be present in the nonce values used to prevent attackers from guessing values.
      */
     @SerialName("nonce")
-    override val nonce: String? = null,
+    val nonce: String? = null,
 
     /**
      * OIDC: RECOMMENDED. Opaque value used to maintain state between the request and the callback. Typically,
@@ -82,7 +82,7 @@ data class SignatureRequestParameters(
      * parameter with a browser cookie.
      */
     @SerialName("state")
-    override val state: String? = null,
+    val state: String? = null,
 
     /**
      * UC5 Draft REQUIRED.
@@ -134,11 +134,5 @@ data class SignatureRequestParameters(
      * data not conforming to the respective type definition.
      */
     @SerialName("transaction_data")
-    override val transactionData: List<TransactionDataBase64Url>? = null,
-) : RequestParameters() {
-
-    override val redirectUrl: String? = null
-    override val audience: String? = null
-    override val issuer: String? = null
-
-}
+    val transactionData: List<TransactionDataBase64Url>? = null,
+) : RequestParameters()

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -253,8 +253,8 @@ class OpenId4VpHolder(
      *
      * @param request the parsed authentication request
      */
-    suspend fun <T : RequestParameters> finalizeAuthorizationResponseParameters(
-        request: RequestParametersFrom<T>,
+    suspend fun finalizeAuthorizationResponseParameters(
+        request: RequestParametersFrom<AuthenticationRequestParameters>,
         clientMetadata: RelyingPartyMetadata?,
         credentialPresentation: CredentialPresentation?,
     ): KmmResult<AuthenticationResponse> = catching {
@@ -345,7 +345,7 @@ class OpenId4VpHolder(
     * the Client Identifier is not used as the audience for the response.
      */
     @Throws(OAuth2Exception::class)
-    private fun RequestParameters.extractAudience(
+    private fun AuthenticationRequestParameters.extractAudience(
         clientJsonWebKeySet: JsonWebKeySet?,
         dcApiRequest: Oid4vpDCAPIRequest?,
     ) = dcApiRequest?.let { "origin:${it.callingOrigin}" }


### PR DESCRIPTION
`SignatureRequestParameter` only need to be supported in `RequestParser` which allows us to remove Generics in `OpenId4VpHolder` and `PresentationFactory` and replace them again with `AuthenticationRequestParameters`.
This allows us to remove `RequestParameter` parameters which are not shared by all implementing classes (i.e. all of them) by moving the required into `AuthenticationRequestParameters` directly.

Also add comment to note that RequestParameters is interface specifically made for complex request parsing.