### PR TITLE
 Rework split between OID4VCI and OAuth 2.0 pt1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Release 5.9.0 (unreleased):
  - OAuth 2.0:
    - Refactor the split between credential issuer (OpenID4VCI) and authorization server (OAuth2.0)
    - `SimpleAuthorizationService` supports token exchange acc. to [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)
+   - Implement `RemoteOAuth2AuthorizationServerAdapter` so that credential issuers may be connected to external OAuth2.0 authorization servers
 
 Release 5.8.0:
  - Refactor `AuthorizationServiceStrategy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Release 5.9.0 (unreleased):
    - DCAPI: Remove (already deprecated) preview data class `PreviewDCAPIRequest`, either use OpenID4VP or ISO 18013-7 Annex C
  - JWE:
    - Add `EncryptJweSymmetricFun` and `EncryptJweSymmetric` and `DecryptJweSymmetric`
+ - OAuth 2.0:
+   - Refactor the split between credential issuer (OpenID4VCI) and authorization server (OAuth2.0)
+   - `SimpleAuthorizationService` supports token exchange acc. to [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)
 
 Release 5.8.0:
  - Refactor `AuthorizationServiceStrategy`

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OAuth2AuthorizationServerMetadata.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OAuth2AuthorizationServerMetadata.kt
@@ -41,6 +41,15 @@ data class OAuth2AuthorizationServerMetadata(
     val authorizationEndpoint: String? = null,
 
     /**
+     * OIDC: The UserInfo Endpoint is an OAuth 2.0 Protected Resource that returns Claims about the authenticated
+     * End-User. To obtain the requested Claims about the End-User, the Client makes a request to the UserInfo Endpoint
+     * using an Access Token obtained through OpenID Connect Authentication. These Claims are normally represented by a
+     * JSON object that contains a collection of name and value pairs for the Claims.
+     */
+    @SerialName("userinfo_endpoint")
+    val userInfoEndpoint: String? = null,
+
+    /**
      * RFC 9126: The URL of the pushed authorization request endpoint at which a client can post an authorization
      * request to exchange for a request_uri value usable at the authorization server.
      *

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
@@ -10,62 +10,102 @@ import kotlinx.serialization.encoding.Encoder
 
 object OpenIdConstants {
 
+    /** `id_token` */
     const val ID_TOKEN = "id_token"
 
+    /** `vp_token` */
     const val VP_TOKEN = "vp_token"
 
+    /** `code` */
     const val GRANT_TYPE_CODE = "code"
 
+    /** `authorization_code` */
     const val GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code"
 
+    /** `urn:ietf:params:oauth:grant-type:pre-authorized_code` */
     const val GRANT_TYPE_PRE_AUTHORIZED_CODE = "urn:ietf:params:oauth:grant-type:pre-authorized_code"
 
+    /** `urn:ietf:params:oauth:grant-type:token-exchange` */
+    const val GRANT_TYPE_TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+    /** `refresh_token` */
     const val GRANT_TYPE_REFRESH_TOKEN = "refresh_token"
 
+    /** `Bearer ` */
     const val TOKEN_PREFIX_BEARER = "Bearer "
 
+    /** `DPoP ` */
     const val TOKEN_PREFIX_DPOP = "DPoP "
 
+    /** `bearer` */
     const val TOKEN_TYPE_BEARER = "bearer"
 
+    /** `DPoP` */
     const val TOKEN_TYPE_DPOP = "DPoP"
 
+    /** `urn:ietf:params:oauth:jwk-thumbprint` */
     const val URN_TYPE_JWK_THUMBPRINT = "urn:ietf:params:oauth:jwk-thumbprint"
 
+    /** `cose_key` */
     const val BINDING_METHOD_COSE_KEY = "cose_key"
 
+    /** `did:key` */
     const val PREFIX_DID_KEY = "did:key"
 
-    /** OID4VCI support binding keys to [at.asitplus.signum.indispensable.josef.JsonWebKey] */
+    /** `jwk`, OID4VCI support binding keys to [at.asitplus.signum.indispensable.josef.JsonWebKey] */
     const val BINDING_METHOD_JWK = "jwk"
 
+    /** `/.well-known/openid-credential-issuer` */
     const val PATH_WELL_KNOWN_CREDENTIAL_ISSUER = "/.well-known/openid-credential-issuer"
 
+    /** `/.well-known/openid-configuration` */
     const val PATH_WELL_KNOWN_OPENID_CONFIGURATION = "/.well-known/openid-configuration"
 
+    /** `/.well-known/oauth-authorization-server` */
     const val PATH_WELL_KNOWN_OAUTH_AUTHORIZATION_SERVER = "/.well-known/oauth-authorization-server"
 
+    /** `/.well-known/jwt-vc-issuer` */
     const val PATH_WELL_KNOWN_JWT_VC_ISSUER_METADATA = "/.well-known/jwt-vc-issuer"
 
+    /** `/.well-known/jar-issuer` */
     const val PATH_WELL_KNOWN_JAR_ISSUER = "/.well-known/jar-issuer"
 
+    /** `openid` */
     const val SCOPE_OPENID = "openid"
 
+    /** `profile` */
     const val SCOPE_PROFILE = "profile"
 
+    /** `S256` */
     const val CODE_CHALLENGE_METHOD_SHA256 = "S256"
 
+    /** `openid4vci-proof+jwt` */
     const val PROOF_JWT_TYPE = "openid4vci-proof+jwt"
 
+    /** `key-attestation+jwt` */
     const val KEY_ATTESTATION_JWT_TYPE = "key-attestation+jwt"
 
+    /** `attest_jwt_client_auth` */
     const val AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH = "attest_jwt_client_auth"
 
+    /** `prompt` */
     const val PARAMETER_PROMPT = "prompt"
 
+    /** `login` */
     const val PARAMETER_PROMPT_LOGIN = "login"
 
+    /** `openid4vp` */
     const val DC_API_OID4VP_PROTOCOL_IDENTIFIER = "openid4vp"
+
+    /**
+     * Token Type Identifiers from [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693#section-3)
+     */
+    object TokenTypes {
+        /** `urn:ietf:params:oauth:token-type:access_token` */
+        const val ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token"
+        /** `urn:ietf:params:oauth:token-type:refresh_token` */
+        const val REFRESH_TOKEN = "urn:ietf:params:oauth:token-type:refresh_token"
+    }
 
 
     @Serializable(with = ProofType.Serializer::class)

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TokenRequestParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TokenRequestParameters.kt
@@ -32,9 +32,57 @@ data class TokenRequestParameters(
      * RFC8707: When requesting a token, the client can indicate the desired target service(s) where it intends to use
      * that token by way of the [resource] parameter and can indicate the desired scope of the requested token using the
      * [scope] parameter.
+     *
+     * RFC8693: Optional URI that indicates the target service or resource where the client intends to use the requested
+     * security token. This enables the authorization server to apply policy as appropriate for the target, such as
+     * determining the type and content of the token to be issued or if and how the token is to be encrypted.
      */
     @SerialName("resource")
     val resource: String? = null,
+
+    /**
+     * RFC8693: Optional logical name of the target service where the client intends to use the requested security
+     * token. This serves a purpose similar to the resource parameter but with the client providing a logical name for
+     * the target service.
+     */
+    @SerialName("audience")
+    val audience: String? = null,
+
+    /**
+     * RFC8693: Optional identifier for the type of the requested security token. If the requested type is unspecified,
+     * the issued token type is at the discretion of the authorization server and may be dictated by knowledge of the
+     * requirements of the service or resource indicated by the resource or audience parameter.
+     */
+    @SerialName("requested_token_type")
+    val requestedTokenType: String? = null,
+
+    /**
+     * RFC8693: Required security token that represents the identity of the party on behalf of whom the request is
+     * being made. Typically, the subject of this token will be the subject of the security token issued in response
+     * to the request.
+     */
+    @SerialName("subject_token")
+    val subjectToken: String? = null,
+
+    /**
+     * RFC8693: Required identifier that indicates the type of the security token in the subject_token parameter.
+     */
+    @SerialName("subject_token_type")
+    val subjectTokenType: String? = null,
+
+    /**
+     * RFC8693: Optional security token that represents the identity of the acting party. Typically, this will be the
+     * party that is authorized to use the requested security token and act on behalf of the subject.
+     */
+    @SerialName("actor_token")
+    val actorToken: String? = null,
+
+    /**
+     * RFC8693: An identifier that indicates the type of the security token in the [actorToken] parameter.
+     * This is REQUIRED when the [actorToken] parameter is present in the request but MUST NOT be included otherwise.
+     */
+    @SerialName("actor_token_type")
+    val actorTokenType: String? = null,
 
     /**
      * RFC6749: OPTIONAL. The refresh token issued to the client.
@@ -43,19 +91,17 @@ data class TokenRequestParameters(
     val refreshToken: String? = null,
 
     /**
-     * RFC6749:
-     * REQUIRED, if the "redirect_uri" parameter was included in the authorization request,
+     * RFC6749: REQUIRED, if the `redirect_uri` parameter was included in the authorization request,
      * and their values MUST be identical.
      */
     @SerialName("redirect_uri")
-    val redirectUrl: String,
+    val redirectUrl: String? = null,
 
     /**
-     * RFC6749:
-     * REQUIRED, if the client is not authenticating with the authorization server.
+     * RFC6749: REQUIRED, if the client is not authenticating with the authorization server.
      */
     @SerialName("client_id")
-    val clientId: String,
+    val clientId: String? = null,
 
     /**
      * OID4VCI: Credential Issuers MAY support requesting authorization to issue a Credential using this parameter.

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/Extensions.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/Extensions.kt
@@ -1,0 +1,12 @@
+package at.asitplus.wallet.lib.ktor.openid
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+
+fun <T> CoroutineScope.lazyDeferred(
+    block: suspend CoroutineScope.() -> T,
+): Lazy<Deferred<T>> = lazy {
+    async(start = CoroutineStart.LAZY) { block() }
+}

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
@@ -1,0 +1,386 @@
+package at.asitplus.wallet.lib.ktor.openid
+
+import at.asitplus.KmmResult
+import at.asitplus.catching
+import at.asitplus.openid.AuthenticationRequestParameters
+import at.asitplus.openid.AuthenticationResponseParameters
+import at.asitplus.openid.OAuth2AuthorizationServerMetadata
+import at.asitplus.openid.OpenIdAuthorizationDetails
+import at.asitplus.openid.OpenIdConstants
+import at.asitplus.openid.PushedAuthenticationResponseParameters
+import at.asitplus.openid.SupportedCredentialFormat
+import at.asitplus.openid.TokenRequestParameters
+import at.asitplus.openid.TokenResponseParameters
+import at.asitplus.signum.indispensable.josef.JsonWebToken
+import at.asitplus.signum.indispensable.josef.JwsAlgorithm
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.data.vckJsonSerializer
+import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
+import at.asitplus.wallet.lib.jws.JwsHeaderNone
+import at.asitplus.wallet.lib.jws.SignJwt
+import at.asitplus.wallet.lib.jws.SignJwtFun
+import at.asitplus.wallet.lib.oauth2.OAuth2Client
+import at.asitplus.wallet.lib.oauth2.OAuth2Client.AuthorizationForToken
+import at.asitplus.wallet.lib.oidvci.BuildClientAttestationPoPJwt
+import at.asitplus.wallet.lib.oidvci.BuildDPoPHeader
+import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
+import at.asitplus.wallet.lib.oidvci.encodeToParameters
+import com.benasher44.uuid.uuid4
+import io.github.aakira.napier.Napier
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.call.body
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.cookies.CookiesStorage
+import io.ktor.client.plugins.cookies.HttpCookies
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.request.header
+import io.ktor.client.request.headers
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.URLBuilder
+import io.ktor.http.Url
+import io.ktor.http.parameters
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.util.flattenEntries
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Implements the client side of OAuth2
+ *
+ * Supported features:
+ *  * Token requests and responses
+ *  * [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)
+ *  * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-04.html)
+ *  * [OAuth 2.0 Pushed Authorization Requests](https://datatracker.ietf.org/doc/html/rfc9126)
+ */
+class OAuth2KtorClient(
+    /** ktor engine to use to make requests to issuing service. */
+    engine: HttpClientEngine,
+    /**
+     * Callers are advised to implement a persistent cookie storage,
+     * to keep the session at the issuing service alive after receiving the auth code.
+     */
+    cookiesStorage: CookiesStorage? = null,
+    /** Additional configuration for building the HTTP client, e.g. callers may enable logging. */
+    httpClientConfig: (HttpClientConfig<*>.() -> Unit)? = null,
+    /**
+     * Callback to load the client attestation JWT, which may be needed as authentication at the AS, where the
+     * `clientId` must match [OAuth2Client.clientId] in [oAuth2Client] and the key attested in `cnf` must match
+     * the key behind [signClientAttestationPop], see
+     * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-04.html)
+     */
+    private val loadClientAttestationJwt: (suspend () -> String)? = null,
+    /** Used for authenticating the client at the authorization server with client attestation. */
+    private val signClientAttestationPop: SignJwtFun<JsonWebToken>? = SignJwt(
+        EphemeralKeyWithoutCert(),
+        JwsHeaderNone()
+    ),
+    /** Used to calculate DPoP, i.e. the key the access token and refresh token gets bound to. */
+    private val signDpop: SignJwtFun<JsonWebToken> = SignJwt(EphemeralKeyWithoutCert(), JwsHeaderCertOrJwk()),
+    private val dpopAlgorithm: JwsAlgorithm = JwsAlgorithm.Signature.ES256,
+    /**
+     * Implements OAuth2 protocol, `redirectUrl` needs to be registered by the OS for this application, so redirection
+     * back from browser works
+     */
+    val oAuth2Client: OAuth2Client,
+) {
+
+    private val client: HttpClient = HttpClient(engine) {
+        followRedirects = false
+        install(ContentNegotiation) {
+            json(vckJsonSerializer)
+        }
+        install(DefaultRequest.Plugin) {
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
+        }
+        httpClientConfig?.let { apply(it) }
+        install(HttpCookies.Companion) {
+            cookiesStorage?.let {
+                storage = it
+            }
+        }
+    }
+
+    /**
+     * Open the [url] in a browser (so the user can authenticate at the AS), and store [state] to use in next call.
+     */
+    data class OpenUrlForAuthnRequest(
+        val url: String,
+        val state: String,
+    )
+
+    /**
+     * Uses a pre-authorized code from the authorization server to request an access token.
+     */
+    suspend fun requestTokenWithPreAuthorizedCode(
+        oauthMetadata: OAuth2AuthorizationServerMetadata,
+        credentialIssuer: String,
+        preAuthorizedCode: String,
+        transactionCode: String?,
+        scope: String?,
+        authorizationDetails: Set<OpenIdAuthorizationDetails>,
+    ): KmmResult<TokenResponseParameters> = catching {
+        Napier.i("requestTokenWithPreAuthorizedCode")
+        val state = uuid4().toString()
+
+        val hasScope = scope != null
+        val tokenResponse = postToken(
+            oauthMetadata = oauthMetadata,
+            tokenRequest = oAuth2Client.createTokenRequestParameters(
+                state = state,
+                authorization = AuthorizationForToken.PreAuthCode(preAuthorizedCode, transactionCode),
+                scope = scope,
+                authorizationDetails = if (!hasScope) authorizationDetails else null
+            ),
+            credentialIssuer = credentialIssuer
+        )
+        Napier.i("Received token response")
+        Napier.d("Received token response: $tokenResponse")
+        tokenResponse
+    }
+
+    /**
+     * Uses the auth code to request an access token.
+     *
+     * Prefers building the token request by using `scope` (from [SupportedCredentialFormat]), as advised in
+     * [OpenID4VC HAIP](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html),
+     * but falls back to authorization details if needed.
+     *
+     * @param url the URL as it has been redirected back from the authorization server, i.e. containing param `code`
+     */
+    suspend fun requestTokenWithAuthCode(
+        oauthMetadata: OAuth2AuthorizationServerMetadata,
+        url: String,
+        credentialIssuer: String,
+        state: String,
+        scope: String?,
+        authorizationDetails: Set<OpenIdAuthorizationDetails>,
+    ): KmmResult<TokenResponseParameters> = catching {
+        Napier.i("resumeWithAuthCode")
+        Napier.d("resumeWithAuthCode: $url")
+
+        val authnResponse = Url(url).parameters.flattenEntries().toMap()
+            .decodeFromUrlQuery<AuthenticationResponseParameters>()
+        val code = authnResponse.code
+            ?: throw Exception("No authn code in $url")
+
+        val hasScope = scope != null
+        val tokenResponse = postToken(
+            oauthMetadata = oauthMetadata,
+            tokenRequest = oAuth2Client.createTokenRequestParameters(
+                authorization = AuthorizationForToken.Code(code),
+                state = state,
+                scope = scope,
+                authorizationDetails = if (!hasScope) authorizationDetails else null
+            ),
+            credentialIssuer = credentialIssuer,
+        )
+        Napier.i("Received token response")
+        Napier.d("Received token response $tokenResponse")
+        tokenResponse
+    }
+
+    /**
+     * Uses the refresh token to request a new access token.
+     *
+     * Prefers building the token request by using `scope` (from [SupportedCredentialFormat]), as advised in
+     * [OpenID4VC HAIP](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html),
+     * but falls back to authorization details if needed.
+     */
+    suspend fun requestTokenWithRefreshToken(
+        oauthMetadata: OAuth2AuthorizationServerMetadata,
+        credentialIssuer: String,
+        refreshToken: String,
+        scope: String?,
+        authorizationDetails: Set<OpenIdAuthorizationDetails>,
+    ): KmmResult<TokenResponseParameters> = catching {
+        Napier.i("refreshCredential")
+        Napier.d("refreshCredential: $refreshToken")
+        val hasScope = scope != null
+        val tokenResponse = postToken(
+            oauthMetadata = oauthMetadata,
+            tokenRequest = oAuth2Client.createTokenRequestParameters(
+                authorization = AuthorizationForToken.RefreshToken(refreshToken),
+                state = null,
+                scope = scope,
+                authorizationDetails = if (!hasScope) authorizationDetails else null
+            ),
+            credentialIssuer = credentialIssuer,
+        )
+        Napier.i("Received token response")
+        Napier.d("Received token response $tokenResponse")
+        tokenResponse
+    }
+
+    @Throws(Exception::class)
+    private suspend fun postToken(
+        oauthMetadata: OAuth2AuthorizationServerMetadata,
+        tokenRequest: TokenRequestParameters,
+        credentialIssuer: String,
+    ): TokenResponseParameters {
+        val tokenEndpointUrl = oauthMetadata.tokenEndpoint
+            ?: throw Exception("No tokenEndpoint in $oauthMetadata")
+        Napier.i("postToken: $tokenEndpointUrl with $tokenRequest")
+
+        val clientAttestationJwt = if (oauthMetadata.useClientAuth()) {
+            loadClientAttestationJwt?.invoke()
+        } else null
+        val clientAttestationPoPJwt =
+            if (oauthMetadata.useClientAuth() && signClientAttestationPop != null && clientAttestationJwt != null) {
+                BuildClientAttestationPoPJwt(
+                    signClientAttestationPop,
+                    clientId = oAuth2Client.clientId,
+                    audience = credentialIssuer,
+                    lifetime = 10.minutes,
+                ).serialize()
+            } else null
+        val dpopHeader = if (oauthMetadata.hasMatchingDpopAlgorithm()) {
+            BuildDPoPHeader(signDpop, url = tokenEndpointUrl)
+        } else null
+
+        return client.submitForm(
+            url = tokenEndpointUrl,
+            formParameters = parameters {
+                tokenRequest.encodeToParameters<TokenRequestParameters>().forEach { append(it.key, it.value) }
+            }
+        ) {
+            headers {
+                clientAttestationJwt?.let { append(HttpHeaders.OAuthClientAttestation, it) }
+                clientAttestationPoPJwt?.let { append(HttpHeaders.OAuthClientAttestationPop, it) }
+                dpopHeader?.let { append(HttpHeaders.DPoP, it) }
+            }
+        }.body<TokenResponseParameters>()
+    }
+
+    private fun OAuth2AuthorizationServerMetadata.useClientAuth(): Boolean =
+        tokenEndPointAuthMethodsSupported?.contains(OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH) == true
+
+    private fun OAuth2AuthorizationServerMetadata.hasMatchingDpopAlgorithm(): Boolean =
+        dpopSigningAlgValuesSupported?.contains(dpopAlgorithm) == true
+
+
+    /**
+     * Builds the authorization request ([at.asitplus.openid.AuthenticationRequestParameters]) to start authentication at the
+     * authorization server associated with the credential issuer.
+     *
+     * Prefers building the authn request by using `scope` (from [SupportedCredentialFormat]), as advised in
+     * [OpenID4VC HAIP](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html),
+     * but falls back to authorization details if needed.
+     *
+     * Uses Pushed Authorization Requests [RFC 9126](https://datatracker.ietf.org/doc/html/rfc9126) if advised
+     * by the authorization server.
+     *
+     * Clients need to contiune the process (after getting back from the browser) with [requestTokenWithAuthCode].
+     */
+    @Throws(Exception::class)
+    suspend fun startAuthorization(
+        state: String = uuid4().toString(),
+        credentialIssuer: String,
+        issuerState: String? = null,
+        oauthMetadata: OAuth2AuthorizationServerMetadata,
+        authorizationDetails: Set<OpenIdAuthorizationDetails>?,
+        scope: String?,
+    ): OpenUrlForAuthnRequest {
+        val authorizationEndpointUrl = oauthMetadata.authorizationEndpoint
+            ?: throw Exception("no authorizationEndpoint in $oauthMetadata")
+        val wrapAsJar =
+            oauthMetadata.requestObjectSigningAlgorithmsSupported?.contains(JwsAlgorithm.Signature.ES256) == true
+        val authRequest = oAuth2Client.createAuthRequest(
+            state = state,
+            authorizationDetails = if (scope == null) authorizationDetails else null,
+            issuerState = issuerState,
+            scope = scope,
+            wrapAsJar = wrapAsJar
+        )
+        val requiresPar = oauthMetadata.requirePushedAuthorizationRequests == true
+        val parEndpointUrl = oauthMetadata.pushedAuthorizationRequestEndpoint
+        val authorizationUrl = if (parEndpointUrl != null && requiresPar) {
+            val authRequestAfterPar = pushAuthorizationRequest(
+                authRequest = authRequest,
+                state = state,
+                url = parEndpointUrl,
+                credentialIssuer = credentialIssuer,
+                tokenAuthMethods = oauthMetadata.tokenEndPointAuthMethodsSupported
+            )
+            URLBuilder(authorizationEndpointUrl).also { builder ->
+                authRequestAfterPar.encodeToParameters<AuthenticationRequestParameters>().forEach {
+                    builder.parameters.append(it.key, it.value)
+                }
+            }.build().toString()
+        } else {
+            URLBuilder(authorizationEndpointUrl).also { builder ->
+                authRequest.encodeToParameters<AuthenticationRequestParameters>().forEach {
+                    builder.parameters.append(it.key, it.value)
+                }
+                builder.parameters.append(OpenIdConstants.PARAMETER_PROMPT, OpenIdConstants.PARAMETER_PROMPT_LOGIN)
+            }.build().toString()
+        }
+        Napier.i("Provisioning starts by returning URL to open: $authorizationUrl")
+        return OpenUrlForAuthnRequest(authorizationUrl, state)
+    }
+
+    @Throws(Exception::class)
+    private suspend fun pushAuthorizationRequest(
+        authRequest: AuthenticationRequestParameters,
+        state: String,
+        url: String,
+        credentialIssuer: String,
+        tokenAuthMethods: Set<String>?,
+    ): AuthenticationRequestParameters {
+        val shouldIncludeClientAttestation =
+            tokenAuthMethods?.contains(OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH) == true
+        val clientAttestationJwt = if (shouldIncludeClientAttestation) {
+            loadClientAttestationJwt?.invoke()
+        } else null
+        val clientAttestationPoPJwt =
+            if (shouldIncludeClientAttestation && signClientAttestationPop != null && clientAttestationJwt != null) {
+                BuildClientAttestationPoPJwt(
+                    signClientAttestationPop,
+                    clientId = oAuth2Client.clientId,
+                    audience = credentialIssuer,
+                    lifetime = 10.minutes,
+                ).serialize()
+            } else null
+        val response = client.submitForm(
+            url = url,
+            formParameters = parameters {
+                authRequest.encodeToParameters().forEach { append(it.key, it.value) }
+                append(OpenIdConstants.PARAMETER_PROMPT, OpenIdConstants.PARAMETER_PROMPT_LOGIN)
+            }
+        ) {
+            headers {
+                clientAttestationJwt?.let { append(HttpHeaders.OAuthClientAttestation, it) }
+                clientAttestationPoPJwt?.let { append(HttpHeaders.OAuthClientAttestationPop, it) }
+            }
+        }.body<PushedAuthenticationResponseParameters>()
+        if (response.errorDescription != null) {
+            throw Exception(response.errorDescription)
+        }
+        if (response.error != null) {
+            throw Exception(response.error)
+        }
+        if (response.requestUri == null) {
+            throw Exception("No request_uri from PAR response at $url")
+        }
+
+        return AuthenticationRequestParameters(
+            clientId = oAuth2Client.clientId,
+            requestUri = response.requestUri,
+            state = state,
+        )
+    }
+
+}
+
+val HttpHeaders.OAuthClientAttestation: String
+    get() = "OAuth-Client-Attestation"
+
+val HttpHeaders.OAuthClientAttestationPop: String
+    get() = "OAuth-Client-Attestation-PoP"
+
+val HttpHeaders.DPoP: String
+    get() = "DPoP"
+

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
@@ -193,15 +193,14 @@ class OpenId4VciClient(
         }
 
         oauth2Client.startAuthorization(
-            credentialIssuer = credentialIssuerUrl,
-            issuerState = null,
             oauthMetadata = oauthMetadata,
+            popAudience = credentialIssuerUrl,
             authorizationDetails = oid4vciService.buildAuthorizationDetails(
                 credentialIdentifierInfo.credentialIdentifier,
                 issuerMetadata.authorizationServers
             ),
             scope = credentialIdentifierInfo.supportedCredentialFormat.scope,
-        ).let {
+        ).getOrThrow().let {
             CredentialIssuanceResult.OpenUrlForAuthnRequest(
                 url = it.url,
                 context = ProvisioningContext(
@@ -235,7 +234,7 @@ class OpenId4VciClient(
         val tokenResponse = oauth2Client.requestTokenWithAuthCode(
             oauthMetadata = context.oauthMetadata,
             url = url,
-            credentialIssuer = context.issuerMetadata.credentialIssuer,
+            popAudience = context.issuerMetadata.credentialIssuer,
             state = context.state,
             scope = context.credential.supportedCredentialFormat.scope,
             authorizationDetails = oid4vciService.buildAuthorizationDetails(
@@ -420,16 +419,16 @@ class OpenId4VciClient(
         } ?: credentialOffer.grants?.authorizationCode?.let {
 
             oauth2Client.startAuthorization(
-                state = state,
-                credentialIssuer = credentialOffer.credentialIssuer,
-                issuerState = it.issuerState,
                 oauthMetadata = oauthMetadata,
+                popAudience = credentialOffer.credentialIssuer,
+                state = state,
+                issuerState = it.issuerState,
                 authorizationDetails = oid4vciService.buildAuthorizationDetails(
                     credentialIdentifierInfo.credentialIdentifier,
                     issuerMetadata.authorizationServers
                 ),
                 scope = credentialIdentifierInfo.supportedCredentialFormat.scope,
-            ).let {
+            ).getOrThrow().let {
                 CredentialIssuanceResult.OpenUrlForAuthnRequest(
                     url = it.url,
                     context = ProvisioningContext(

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
@@ -194,7 +194,7 @@ class OpenId4VciClient(
 
         oauth2Client.startAuthorization(
             oauthMetadata = oauthMetadata,
-            popAudience = credentialIssuerUrl,
+            authorizationServer = authorizationServer,
             authorizationDetails = oid4vciService.buildAuthorizationDetails(
                 credentialIdentifierInfo.credentialIdentifier,
                 issuerMetadata.authorizationServers
@@ -234,7 +234,7 @@ class OpenId4VciClient(
         val tokenResponse = oauth2Client.requestTokenWithAuthCode(
             oauthMetadata = context.oauthMetadata,
             url = url,
-            popAudience = context.issuerMetadata.credentialIssuer,
+            authorizationServer = context.issuerMetadata.credentialIssuer,
             state = context.state,
             scope = context.credential.supportedCredentialFormat.scope,
             authorizationDetails = oid4vciService.buildAuthorizationDetails(
@@ -398,7 +398,7 @@ class OpenId4VciClient(
             )
             val tokenResponse = oauth2Client.requestTokenWithPreAuthorizedCode(
                 oauthMetadata = oauthMetadata,
-                credentialIssuer = issuerMetadata.credentialIssuer,
+                authorizationServer = issuerMetadata.credentialIssuer,
                 preAuthorizedCode = it.preAuthorizedCode,
                 transactionCode = transactionCode,
                 scope = credentialIdentifierInfo.supportedCredentialFormat.scope,
@@ -420,7 +420,7 @@ class OpenId4VciClient(
 
             oauth2Client.startAuthorization(
                 oauthMetadata = oauthMetadata,
-                popAudience = credentialOffer.credentialIssuer,
+                authorizationServer = authorizationServer,
                 state = state,
                 issuerState = it.issuerState,
                 authorizationDetails = oid4vciService.buildAuthorizationDetails(

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/RemoteOAuth2AuthorizationServerAdapter.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/RemoteOAuth2AuthorizationServerAdapter.kt
@@ -1,0 +1,160 @@
+package at.asitplus.wallet.lib.ktor.openid
+
+import at.asitplus.KmmResult
+import at.asitplus.catching
+import at.asitplus.openid.OAuth2AuthorizationServerMetadata
+import at.asitplus.openid.OidcUserInfo
+import at.asitplus.openid.OidcUserInfoExtended
+import at.asitplus.openid.OpenIdConstants.PATH_WELL_KNOWN_OAUTH_AUTHORIZATION_SERVER
+import at.asitplus.openid.OpenIdConstants.PATH_WELL_KNOWN_OPENID_CONFIGURATION
+import at.asitplus.openid.OpenIdConstants.TOKEN_PREFIX_DPOP
+import at.asitplus.openid.OpenIdConstants.TOKEN_TYPE_BEARER
+import at.asitplus.openid.OpenIdConstants.TOKEN_TYPE_DPOP
+import at.asitplus.wallet.lib.data.vckJsonSerializer
+import at.asitplus.wallet.lib.oauth2.OAuth2Client
+import at.asitplus.wallet.lib.oauth2.RequestInfo
+import at.asitplus.wallet.lib.oauth2.TokenVerificationService
+import at.asitplus.wallet.lib.oauth2.ValidatedAccessToken
+import at.asitplus.wallet.lib.oidvci.OAuth2AuthorizationServerAdapter
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidToken
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.call.body
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.cookies.CookiesStorage
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.request
+import io.ktor.client.request.url
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Uses an external OAuth 2.0 Authorization Server with a [at.asitplus.wallet.lib.oidvci.CredentialIssuer],
+ * i.e., delegate authorization to the external AS, and load user info from there
+ * (after performing token exchange with the Wallet's access token to get a fresh one).
+ * Make sure to configure [oauth2Client] to use the correct [OAuth2KtorClient.loadClientAttestationJwt].
+ */
+class RemoteOAuth2AuthorizationServerAdapter(
+    /** Base URL of the remote Authorization Server. */
+    override val publicContext: String,
+    /** ktor engine to make requests to the verifier. */
+    engine: HttpClientEngine,
+    /**
+     * Callers are advised to implement a persistent cookie storage,
+     * to keep the session at the issuing service alive after receiving the auth code.
+     */
+    cookiesStorage: CookiesStorage? = null,
+    /** Additional configuration for building the HTTP client, e.g., callers may enable logging. */
+    httpClientConfig: (HttpClientConfig<*>.() -> Unit)? = null,
+    /** [CoroutineScope] to fetch the authorization server's metadata. */
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO),
+    /** OAuth 2.0 client to use when exchanging Wallet's token for a fresh access token. */
+    private val oauth2Client: OAuth2KtorClient = OAuth2KtorClient(
+        engine = engine,
+        cookiesStorage = cookiesStorage,
+        httpClientConfig = httpClientConfig,
+        oAuth2Client = OAuth2Client(),
+    ),
+) : OAuth2AuthorizationServerAdapter {
+
+    private val client: HttpClient = HttpClient(engine) {
+        followRedirects = false
+        install(ContentNegotiation) {
+            json(vckJsonSerializer)
+        }
+        install(DefaultRequest.Plugin) {
+            header(HttpHeaders.ContentType, ContentType.Application.Json)
+        }
+        httpClientConfig?.let { apply(it) }
+    }
+
+    private val _metadata: Deferred<OAuth2AuthorizationServerMetadata> by scope.lazyDeferred {
+        catching {
+            client.get("$publicContext$PATH_WELL_KNOWN_OPENID_CONFIGURATION")
+                .body<OAuth2AuthorizationServerMetadata>()
+        }.getOrElse {
+            client.get("$publicContext$PATH_WELL_KNOWN_OAUTH_AUTHORIZATION_SERVER")
+                .body<OAuth2AuthorizationServerMetadata>()
+        }
+    }
+
+    @Deprecated("Use [validateTokenExtractUser] instead")
+    override val tokenVerificationService: TokenVerificationService
+        get() = object : TokenVerificationService {
+            override suspend fun validateRefreshToken(
+                refreshToken: String,
+                request: RequestInfo?,
+            ): String {
+                TODO("Not yet implemented")
+            }
+
+            override suspend fun validateTokenExtractUser(
+                authorizationHeader: String,
+                request: RequestInfo?,
+            ): ValidatedAccessToken {
+                TODO("Not yet implemented")
+            }
+
+            override suspend fun validateTokenForTokenExchange(
+                subjectToken: String,
+            ): ValidatedAccessToken {
+                TODO("Not yet implemented")
+            }
+        }
+
+    @Deprecated("Use [metadata()] instead")
+    override val metadata: OAuth2AuthorizationServerMetadata by lazy {
+        runBlocking {
+            _metadata.await()
+        }
+    }
+
+    override suspend fun metadata(): OAuth2AuthorizationServerMetadata = _metadata.await()
+
+    override suspend fun userInfo(
+        authorizationHeader: String,
+        credentialIdentifier: String?,
+        credentialConfigurationId: String?,
+        request: RequestInfo?,
+    ): KmmResult<JsonObject> = catching {
+        val userInfoEndpoint = _metadata.await().userInfoEndpoint
+            ?: throw InvalidToken("No UserInfo Endpoint found in Authorization Server metadata")
+        if (authorizationHeader.startsWith(TOKEN_TYPE_BEARER, ignoreCase = true)) {
+            callUserInfo(userInfoEndpoint, authorizationHeader)
+        } else if (authorizationHeader.startsWith(TOKEN_TYPE_DPOP, ignoreCase = true)) {
+            // TODO Validate the DPoP from the client!
+            oauth2Client.requestTokenWithTokenExchange(
+                oauthMetadata = _metadata.await(),
+                authorizationServer = publicContext,
+                subjectToken = authorizationHeader.substringAfter(TOKEN_PREFIX_DPOP).trim(),
+                resource = userInfoEndpoint,
+            ).getOrThrow().let {
+                callUserInfo(userInfoEndpoint, it.toHttpHeaderValue())
+            }
+        } else {
+            throw InvalidToken("authorization header not valid: $authorizationHeader")
+        }
+    }
+
+    private suspend fun callUserInfo(
+        userInfoEndpoint: String,
+        authorizationHeader: String,
+    ): JsonObject = client.request {
+        url(userInfoEndpoint)
+        method = HttpMethod.Get
+        header(HttpHeaders.Authorization, authorizationHeader)
+        // TODO Also the DPoP and so on!
+    }.body<JsonObject>()
+
+}

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClientTest.kt
@@ -1,0 +1,178 @@
+package at.asitplus.wallet.lib.ktor.openid
+
+import at.asitplus.catching
+import at.asitplus.openid.AuthenticationRequestParameters
+import at.asitplus.openid.OAuth2AuthorizationServerMetadata
+import at.asitplus.openid.OidcUserInfoExtended
+import at.asitplus.openid.OpenIdConstants
+import at.asitplus.openid.PushedAuthenticationResponseParameters
+import at.asitplus.openid.TokenRequestParameters
+import at.asitplus.openid.TokenResponseParameters
+import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
+import at.asitplus.wallet.eupid.EuPidScheme
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.agent.KeyMaterial
+import at.asitplus.wallet.lib.data.vckJsonSerializer
+import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
+import at.asitplus.wallet.lib.jws.JwsHeaderNone
+import at.asitplus.wallet.lib.jws.SignJwt
+import at.asitplus.wallet.lib.oauth2.ClientAuthenticationService
+import at.asitplus.wallet.lib.oauth2.OAuth2Client
+import at.asitplus.wallet.lib.oauth2.RequestInfo
+import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService
+import at.asitplus.wallet.lib.oauth2.TokenService
+import at.asitplus.wallet.lib.oidvci.BuildClientAttestationJwt
+import at.asitplus.wallet.lib.oidvci.CredentialAuthorizationServiceStrategy
+import at.asitplus.wallet.lib.oidvci.DefaultNonceService
+import at.asitplus.wallet.lib.oidvci.decodeFromPostBody
+import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
+import io.github.aakira.napier.Napier
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.util.*
+
+class OAuth2KtorClientTest : FunSpec() {
+
+    lateinit var dpopKeyMaterial: KeyMaterial
+    lateinit var clientAuthKeyMaterial: KeyMaterial
+
+    lateinit var mockEngine: MockEngine
+    lateinit var authorizationService: SimpleAuthorizationService
+    lateinit var client: OAuth2KtorClient
+
+    init {
+        val strategy = CredentialAuthorizationServiceStrategy(setOf(EuPidScheme))
+        val requestedScope = strategy.validScopes().split(" ").first()
+        setup(strategy)
+
+        test("auth code and token") {
+            client.startAuthorization(
+                oauthMetadata = authorizationService.metadata(),
+                popAudience = authorizationService.publicContext,
+                scope = requestedScope,
+            ).getOrThrow().also {
+                // Simulates the browser, handling authorization to get the authCode
+                val httpClient = HttpClient(mockEngine) { followRedirects = false }
+                val authCodeUrl = httpClient.get(it.url).headers[HttpHeaders.Location].shouldNotBeNull()
+                client.requestTokenWithAuthCode(
+                    oauthMetadata = authorizationService.metadata(),
+                    url = authCodeUrl,
+                    popAudience = authorizationService.publicContext,
+                    state = it.state,
+                    scope = requestedScope,
+                    authorizationDetails = setOf()
+                ).getOrThrow().also {
+                    it.accessToken.shouldNotBeNull()
+                }
+            }
+        }
+    }
+
+    private fun setup(strategy: CredentialAuthorizationServiceStrategy) {
+        dpopKeyMaterial = EphemeralKeyWithoutCert()
+        clientAuthKeyMaterial = EphemeralKeyWithoutCert()
+        val authorizationEndpointPath = "/authorize"
+        val tokenEndpointPath = "/token"
+        val parEndpointPath = "/par"
+        val publicContext = "https://issuer.example.com"
+        authorizationService = SimpleAuthorizationService(
+            strategy = strategy,
+            publicContext = publicContext,
+            authorizationEndpointPath = authorizationEndpointPath,
+            tokenEndpointPath = tokenEndpointPath,
+            pushedAuthorizationRequestEndpointPath = parEndpointPath,
+            clientAuthenticationService = ClientAuthenticationService(
+                enforceClientAuthentication = true,
+            ),
+            tokenService = TokenService.jwt(
+                nonceService = DefaultNonceService(),
+                keyMaterial = EphemeralKeyWithoutCert(),
+                issueRefreshTokens = true
+            ),
+        )
+        mockEngine = MockEngine { request ->
+            when {
+                request.url.fullPath == OpenIdConstants.PATH_WELL_KNOWN_OPENID_CONFIGURATION -> respond(
+                    vckJsonSerializer.encodeToString<OAuth2AuthorizationServerMetadata>(authorizationService.metadata()),
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                )
+
+                request.url.fullPath == OpenIdConstants.PATH_WELL_KNOWN_OAUTH_AUTHORIZATION_SERVER -> respond(
+                    vckJsonSerializer.encodeToString<OAuth2AuthorizationServerMetadata>(authorizationService.metadata()),
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                )
+
+                request.url.fullPath.startsWith(parEndpointPath) -> {
+                    val requestBody = request.body.toByteArray().decodeToString()
+                    val authnRequest: AuthenticationRequestParameters =
+                        requestBody.decodeFromPostBody<AuthenticationRequestParameters>()
+                    val result = authorizationService.par(
+                        authnRequest,
+                        request.headers["OAuth-Client-Attestation"],
+                        request.headers["OAuth-Client-Attestation-PoP"]
+                    ).getOrThrow()
+                    respond(
+                        vckJsonSerializer.encodeToString<PushedAuthenticationResponseParameters>(result),
+                        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    )
+                }
+
+                request.url.fullPath.startsWith(authorizationEndpointPath) -> {
+                    val requestBody = request.body.toByteArray().decodeToString()
+                    val queryParameters: Map<String, String> =
+                        request.url.parameters.toMap().entries.associate { it.key to it.value.first() }
+                    val authnRequest: AuthenticationRequestParameters =
+                        if (requestBody.isEmpty()) queryParameters.decodeFromUrlQuery<AuthenticationRequestParameters>()
+                        else requestBody.decodeFromPostBody<AuthenticationRequestParameters>()
+                    val result = authorizationService.authorize(authnRequest) { catching { dummyUser() } }.getOrThrow()
+                    respondRedirect(result.url)
+                }
+
+                request.url.fullPath.startsWith(tokenEndpointPath) -> {
+                    val requestBody = request.body.toByteArray().decodeToString()
+                    val authn = request.headers[HttpHeaders.Authorization]
+                    val params: TokenRequestParameters = requestBody.decodeFromPostBody<TokenRequestParameters>()
+                    val result = authorizationService.token(params, authn, request.toRequestInfo()).getOrThrow()
+                    respond(
+                        vckJsonSerializer.encodeToString<TokenResponseParameters>(result),
+                        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    )
+                }
+
+                else -> respondError(HttpStatusCode.NotFound)
+                    .also { Napier.w("NOT MATCHED ${request.url.fullPath}") }
+            }
+        }
+        val clientId = "https://example.com/rp"
+        client = OAuth2KtorClient(
+            engine = mockEngine,
+            loadClientAttestationJwt = {
+                BuildClientAttestationJwt(
+                    SignJwt(EphemeralKeyWithSelfSignedCert(), JwsHeaderCertOrJwk()),
+                    clientId = clientId,
+                    issuer = "issuer",
+                    clientKey = clientAuthKeyMaterial.jsonWebKey
+                ).serialize()
+            },
+            signClientAttestationPop = SignJwt(clientAuthKeyMaterial, JwsHeaderNone()),
+            signDpop = SignJwt(dpopKeyMaterial, JwsHeaderCertOrJwk()),
+            dpopAlgorithm = dpopKeyMaterial.signatureAlgorithm.toJwsAlgorithm().getOrThrow(),
+            oAuth2Client = OAuth2Client(clientId = clientId)
+        )
+    }
+
+    private fun HttpRequestData.toRequestInfo(): RequestInfo = RequestInfo(
+        url = url.toString(),
+        method = method,
+        dpop = headers["DPoP"],
+        clientAttestation = headers["OAuth-Client-Attestation"],
+        clientAttestationPop = headers["OAuth-Client-Attestation-PoP"],
+    )
+
+    private fun dummyUser(): OidcUserInfoExtended = OidcUserInfoExtended.deserialize("{\"sub\": \"foo\"}").getOrThrow()
+}

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClientTest.kt
@@ -53,7 +53,7 @@ class OAuth2KtorClientTest : FunSpec() {
         test("auth code and token") {
             client.startAuthorization(
                 oauthMetadata = authorizationService.metadata(),
-                popAudience = authorizationService.publicContext,
+                authorizationServer = authorizationService.publicContext,
                 scope = requestedScope,
             ).getOrThrow().also {
                 // Simulates the browser, handling authorization to get the authCode
@@ -62,7 +62,7 @@ class OAuth2KtorClientTest : FunSpec() {
                 client.requestTokenWithAuthCode(
                     oauthMetadata = authorizationService.metadata(),
                     url = authCodeUrl,
-                    popAudience = authorizationService.publicContext,
+                    authorizationServer = authorizationService.publicContext,
                     state = it.state,
                     scope = requestedScope,
                     authorizationDetails = setOf()

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
@@ -258,12 +258,12 @@ class OpenId4VciClientTest : FunSpec() {
                 )
 
                 request.url.fullPath == OpenIdConstants.PATH_WELL_KNOWN_OPENID_CONFIGURATION -> respond(
-                    vckJsonSerializer.encodeToString<OAuth2AuthorizationServerMetadata>(authorizationService.metadata),
+                    vckJsonSerializer.encodeToString<OAuth2AuthorizationServerMetadata>(authorizationService.metadata()),
                     headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 )
 
                 request.url.fullPath == OpenIdConstants.PATH_WELL_KNOWN_OAUTH_AUTHORIZATION_SERVER -> respond(
-                    vckJsonSerializer.encodeToString<OAuth2AuthorizationServerMetadata>(authorizationService.metadata),
+                    vckJsonSerializer.encodeToString<OAuth2AuthorizationServerMetadata>(authorizationService.metadata()),
                     headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 )
 

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
@@ -295,8 +295,9 @@ class OpenId4VciClientTest : FunSpec() {
 
                 request.url.fullPath.startsWith(tokenEndpointPath) -> {
                     val requestBody = request.body.toByteArray().decodeToString()
+                    val authn = request.headers[HttpHeaders.Authorization]
                     val params: TokenRequestParameters = requestBody.decodeFromPostBody<TokenRequestParameters>()
-                    val result = authorizationService.token(params, request.toRequestInfo()).getOrThrow()
+                    val result = authorizationService.token(params, authn, request.toRequestInfo()).getOrThrow()
                     respond(
                         vckJsonSerializer.encodeToString<TokenResponseParameters>(result),
                         headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
@@ -35,6 +35,7 @@ import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
 import at.asitplus.wallet.lib.jws.JwsHeaderNone
 import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.oauth2.ClientAuthenticationService
+import at.asitplus.wallet.lib.oauth2.OAuth2Client
 import at.asitplus.wallet.lib.oauth2.RequestInfo
 import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService
 import at.asitplus.wallet.lib.oauth2.TokenService
@@ -334,21 +335,27 @@ class OpenId4VciClientTest : FunSpec() {
         val clientId = "https://example.com/rp"
         client = OpenId4VciClient(
             engine = mockEngine,
-            loadClientAttestationJwt = {
-                BuildClientAttestationJwt(
-                    SignJwt(EphemeralKeyWithSelfSignedCert(), JwsHeaderCertOrJwk()),
-                    clientId = clientId,
-                    issuer = "issuer",
-                    clientKey = clientAuthKeyMaterial.jsonWebKey
-                ).serialize()
-            },
-            signClientAttestationPop = SignJwt(clientAuthKeyMaterial, JwsHeaderNone()),
-            signDpop = SignJwt(dpopKeyMaterial, JwsHeaderCertOrJwk()),
-            dpopAlgorithm = dpopKeyMaterial.signatureAlgorithm.toJwsAlgorithm().getOrThrow(),
             oid4vciService = WalletService(
                 clientId = clientId,
                 keyMaterial = credentialKeyMaterial,
             ),
+            oauth2Client = OAuth2KtorClient(
+                engine = mockEngine,
+                loadClientAttestationJwt = {
+                    BuildClientAttestationJwt(
+                        SignJwt(EphemeralKeyWithSelfSignedCert(), JwsHeaderCertOrJwk()),
+                        clientId = clientId,
+                        issuer = "issuer",
+                        clientKey = clientAuthKeyMaterial.jsonWebKey
+                    ).serialize()
+                },
+                signClientAttestationPop = SignJwt(clientAuthKeyMaterial, JwsHeaderNone()),
+                signDpop = SignJwt(dpopKeyMaterial, JwsHeaderCertOrJwk()),
+                dpopAlgorithm = dpopKeyMaterial.signatureAlgorithm.toJwsAlgorithm().getOrThrow(),
+                oAuth2Client = OAuth2Client(
+                    clientId = clientId,
+                )
+            )
         )
     }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AuthorizationService.kt
@@ -55,17 +55,25 @@ interface AuthorizationService {
         loadUserFun: OAuth2LoadUserFun,
     ): KmmResult<AuthenticationResponseResult.Redirect>
 
+    @Deprecated("Use [token] with parameter instead", ReplaceWith("token(request, null, httpRequest)"))
+    suspend fun token(
+        request: TokenRequestParameters,
+        httpRequest: RequestInfo? = null,
+    ): KmmResult<TokenResponseParameters>
+
     /**
      * Verifies the authorization code sent by the client and issues an access token.
      * Send this value JSON-serialized back to the client.
 
      * @param request as sent from the client as `POST`
+     * @param authorizationHeader value of HTTP header `Authorization` sent by the client, with all prefixes
      * @param httpRequest information about the HTTP request from the client, to validate authentication
      *
      * @return [KmmResult] may contain a [OAuth2Exception]
      */
     suspend fun token(
         request: TokenRequestParameters,
+        authorizationHeader: String? = null,
         httpRequest: RequestInfo? = null,
     ): KmmResult<TokenResponseParameters>
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2Client.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2Client.kt
@@ -115,7 +115,10 @@ class OAuth2Client(
     ).wrapIfNecessary(wrapAsJar, audience)
 
     private suspend fun AuthenticationRequestParameters.wrapIfNecessary(wrapAsJar: Boolean, audience: String?) =
-        if (signPushedAuthorizationRequest != null && wrapAsJar) wrapInJar(signPushedAuthorizationRequest, audience) else this
+        if (signPushedAuthorizationRequest != null && wrapAsJar) wrapInJar(
+            signPushedAuthorizationRequest,
+            audience
+        ) else this
 
     private suspend fun AuthenticationRequestParameters.wrapInJar(
         signPushedAuthorizationRequest: SignJwtFun<AuthenticationRequestParameters>,
@@ -168,6 +171,10 @@ class OAuth2Client(
         data class PreAuthCode(
             val preAuthorizedCode: String,
             val transactionCode: String? = null,
+        ) : AuthorizationForToken()
+
+        data class TokenExchange(
+            val subjectToken: String,
         ) : AuthorizationForToken()
     }
 
@@ -252,6 +259,15 @@ class OAuth2Client(
             redirectUrl = redirectUrl,
             clientId = clientId,
             authorizationDetails = authorizationDetails,
+            scope = scope,
+            resource = resource,
+        )
+
+        is AuthorizationForToken.TokenExchange -> TokenRequestParameters(
+            grantType = OpenIdConstants.GRANT_TYPE_TOKEN_EXCHANGE,
+            subjectToken = authorization.subjectToken,
+            subjectTokenType = OpenIdConstants.TokenTypes.ACCESS_TOKEN,
+            requestedTokenType = OpenIdConstants.TokenTypes.ACCESS_TOKEN,
             scope = scope,
             resource = resource,
         )

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/OpenId4VciAccessToken.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/OpenId4VciAccessToken.kt
@@ -39,12 +39,6 @@ data class OpenId4VciAccessToken(
     @SerialName("cnf")
     val confirmationClaim: ConfirmationClaim? = null,
 
-    /**
-     * All user information, can be parsed into [at.asitplus.openid.OidcUserInfoExtended] when needed.
-     */
-    @SerialName("userInfo")
-    val userInfo: JsonObject? = null,
-
     /** Scope that has been validated to use for credential issuance. */
     @SerialName("scope")
     val scope: String? = null,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -139,9 +139,7 @@ class SimpleAuthorizationService(
      * see [OpenIdConstants.PATH_WELL_KNOWN_OAUTH_AUTHORIZATION_SERVER]
      */
     @Deprecated("Use [metadata()] instead")
-    override val metadata: OAuth2AuthorizationServerMetadata by lazy {
-        _metadata
-    }
+    override val metadata: OAuth2AuthorizationServerMetadata by lazy { _metadata }
 
     override suspend fun metadata(): OAuth2AuthorizationServerMetadata = _metadata
 
@@ -559,4 +557,3 @@ class SimpleAuthorizationService(
         }
     }
 }
-

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenService.kt
@@ -1,39 +1,84 @@
 package at.asitplus.wallet.lib.oauth2
 
-import at.asitplus.signum.indispensable.josef.JwsAlgorithm
+import at.asitplus.openid.OAuth2AuthorizationServerMetadata
+import at.asitplus.openid.OpenIdConstants.TokenTypes
+import at.asitplus.openid.TokenRequestParameters
+import at.asitplus.openid.TokenResponseParameters
+import at.asitplus.signum.indispensable.josef.JwsAlgorithm.Signature
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.oidvci.DefaultNonceService
 import at.asitplus.wallet.lib.oidvci.NonceService
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidGrant
+import io.github.aakira.napier.Napier
 
 /** Combines access token generation and verification. */
-data class TokenService(
+class TokenService(
     val generation: TokenGenerationService,
     val verification: TokenVerificationService,
     val dpopSigningAlgValuesSupportedStrings: Set<String>?,
     val supportsRefreshTokens: Boolean,
 ) {
+    /**
+     * Performs token exchange: Validate the received token from [TokenRequestParameters.subjectToken]
+     * and issue a fresh access token.
+     * Callers need to make sure that the client has been authenticated before calling this method.
+     */
+    suspend fun tokenExchange(
+        request: TokenRequestParameters,
+        httpRequest: RequestInfo?,
+        metadata: OAuth2AuthorizationServerMetadata,
+    ): TokenResponseParameters {
+        Napier.i("tokenExchange: called")
+        Napier.d("tokenExchange: called with $request")
+        // Client wants to exchange Wallet's access token (probably DPoP-constrained) with a fresh one for userInfo
+        if (request.subjectTokenType == null || request.subjectToken == null) {
+            throw InvalidGrant("subject_token or subject_token_type is null")
+        }
+        if (request.resource != metadata.userInfoEndpoint) {
+            throw InvalidGrant("resource is not valid, is not for ${metadata.userInfoEndpoint}")
+        }
+        if (request.requestedTokenType != TokenTypes.ACCESS_TOKEN) {
+            throw InvalidGrant("requested_token_type is not valid, must be ${TokenTypes.ACCESS_TOKEN}")
+        }
+        val validated = verification.validateTokenForTokenExchange(
+            subjectToken = request.subjectToken!!,
+        ).apply {
+            if (userInfoExtended == null)
+                throw InvalidGrant("subject_token is not valid, no stored user")
+        }
+        return generation.buildToken(
+            userInfo = validated.userInfoExtended!!,
+            httpRequest = httpRequest,
+            authorizationDetails = validated.authorizationDetails,
+            scope = validated.scope
+        ).also { Napier.i("tokenExchange returns: $it") }
+    }
+
     companion object {
         fun jwt(
             publicContext: String = "https://wallet.a-sit.at/authorization-server",
             nonceService: NonceService = DefaultNonceService(),
             keyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
             issueRefreshTokens: Boolean = false,
-            verificationAlgorithms: Collection<JwsAlgorithm.Signature> = setOf(JwsAlgorithm.Signature.ES256), // per OID4VC HAIP
-        ) = TokenService(
-            generation = JwtTokenGenerationService(
-                nonceService = nonceService,
-                publicContext = publicContext,
-                keyMaterial = keyMaterial,
-                issueRefreshToken = issueRefreshTokens,
-            ),
-            verification = JwtTokenVerificationService(
-                nonceService = nonceService,
-                issuerKey = keyMaterial.jsonWebKey,
-            ),
-            dpopSigningAlgValuesSupportedStrings = verificationAlgorithms.map { it.identifier }.toSet(),
-            supportsRefreshTokens = true,
-        )
+            verificationAlgorithms: Collection<Signature> = setOf(Signature.ES256), // per OID4VC HAIP
+        ) = JwtTokenGenerationService(
+            nonceService = nonceService,
+            publicContext = publicContext,
+            keyMaterial = keyMaterial,
+            issueRefreshToken = issueRefreshTokens,
+        ).let { generationService ->
+            TokenService(
+                generation = generationService,
+                verification = JwtTokenVerificationService(
+                    nonceService = nonceService,
+                    issuerKey = keyMaterial.jsonWebKey,
+                    tokenGenerationService = generationService
+                ),
+                dpopSigningAlgValuesSupportedStrings = verificationAlgorithms.map { it.identifier }.toSet(),
+                supportsRefreshTokens = true,
+            )
+        }
 
         fun bearer(
             nonceService: NonceService = DefaultNonceService(),

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenService.kt
@@ -10,7 +10,8 @@ import at.asitplus.wallet.lib.oidvci.NonceService
 data class TokenService(
     val generation: TokenGenerationService,
     val verification: TokenVerificationService,
-    val dpopSigningAlgValuesSupportedStrings: Set<String>? = null,
+    val dpopSigningAlgValuesSupportedStrings: Set<String>?,
+    val supportsRefreshTokens: Boolean,
 ) {
     companion object {
         fun jwt(
@@ -30,8 +31,8 @@ data class TokenService(
                 nonceService = nonceService,
                 issuerKey = keyMaterial.jsonWebKey,
             ),
-            dpopSigningAlgValuesSupportedStrings = verificationAlgorithms.map { it.identifier }.toSet()
-
+            dpopSigningAlgValuesSupportedStrings = verificationAlgorithms.map { it.identifier }.toSet(),
+            supportsRefreshTokens = true,
         )
 
         fun bearer(
@@ -43,7 +44,8 @@ data class TokenService(
                     nonceService = nonceService,
                     tokenGenerationService = generationService
                 ),
-                dpopSigningAlgValuesSupportedStrings = null
+                dpopSigningAlgValuesSupportedStrings = null,
+                supportsRefreshTokens = false,
             )
         }
     }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ValidatedAccessToken.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ValidatedAccessToken.kt
@@ -3,13 +3,17 @@ package at.asitplus.wallet.lib.oauth2
 import at.asitplus.openid.AuthorizationDetails
 import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.openid.OpenIdAuthorizationDetails
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
+@Serializable
 data class ValidatedAccessToken(
     val token: String,
     val userInfoExtended: OidcUserInfoExtended? = null,
     val authorizationDetails: Set<AuthorizationDetails>? = null,
     val scope: String? = null,
 ) {
+    @Transient
     val validCredentialIdentifiers = authorizationDetails
         ?.filterIsInstance<OpenIdAuthorizationDetails>()
         ?.flatMap { it.credentialIdentifiers ?: setOf() }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialIssuer.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialIssuer.kt
@@ -7,6 +7,8 @@ import at.asitplus.openid.CredentialRequestParameters
 import at.asitplus.openid.CredentialResponseParameters
 import at.asitplus.openid.IssuerMetadata
 import at.asitplus.openid.JwtVcIssuerMetadata
+import at.asitplus.openid.OidcUserInfo
+import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.SupportedAlgorithmsContainer
 import at.asitplus.signum.indispensable.SignatureAlgorithm
@@ -74,7 +76,7 @@ class CredentialIssuer(
         publicContext = publicContext,
         requireKeyAttestation = requireKeyAttestation,
     ),
-    /** Used to verify the access token for [credential]. */
+    @Deprecated("[OAuth2AuthorizationServerAdapter.userInfo] is been used now, which validates tokens")
     private val tokenVerificationService: TokenVerificationService = authorizationService.tokenVerificationService,
 ) {
     private val supportedSigningAlgorithms = cryptoAlgorithms
@@ -164,7 +166,9 @@ class CredentialIssuer(
                                 credentialIdentifier = params.credentialIdentifier,
                                 credentialConfigurationId = params.credentialConfigurationId,
                                 request = request
-                            ).getOrThrow(),
+                            ).getOrThrow().let {
+                                OidcUserInfoExtended.fromJsonObject(it).getOrThrow()
+                            },
                             subjectPublicKey = subjectPublicKey,
                             credentialScheme = first,
                             credentialRepresentation = second,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2AuthorizationServerAdapter.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2AuthorizationServerAdapter.kt
@@ -2,10 +2,9 @@ package at.asitplus.wallet.lib.oidvci
 
 import at.asitplus.KmmResult
 import at.asitplus.openid.OAuth2AuthorizationServerMetadata
-import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.wallet.lib.oauth2.RequestInfo
 import at.asitplus.wallet.lib.oauth2.TokenVerificationService
-import at.asitplus.wallet.lib.openid.AuthenticationResponseResult
+import kotlinx.serialization.json.JsonObject
 
 /**
  * Used in OID4VCI by [CredentialIssuer] to obtain user data when issuing credentials using OID4VCI.
@@ -37,7 +36,7 @@ interface OAuth2AuthorizationServerAdapter {
         credentialIdentifier: String?,
         credentialConfigurationId: String?,
         request: RequestInfo?,
-    ): KmmResult<OidcUserInfoExtended>
+    ): KmmResult<JsonObject>
 
 }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2AuthorizationServerAdapter.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2AuthorizationServerAdapter.kt
@@ -1,7 +1,8 @@
 package at.asitplus.wallet.lib.oidvci
 
 import at.asitplus.KmmResult
-import at.asitplus.openid.*
+import at.asitplus.openid.OAuth2AuthorizationServerMetadata
+import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.wallet.lib.oauth2.RequestInfo
 import at.asitplus.wallet.lib.oauth2.TokenVerificationService
 import at.asitplus.wallet.lib.openid.AuthenticationResponseResult
@@ -9,8 +10,7 @@ import at.asitplus.wallet.lib.openid.AuthenticationResponseResult
 /**
  * Used in OID4VCI by [CredentialIssuer] to obtain user data when issuing credentials using OID4VCI.
  *
- * Could also be a remote service, then the format of the access tokens
- * is especially important, and needs a matching implementation for [TokenVerificationService].
+ * Could also be a remote service, then implementers need to make calls to the remote service.
  */
 interface OAuth2AuthorizationServerAdapter {
 
@@ -18,10 +18,26 @@ interface OAuth2AuthorizationServerAdapter {
     val publicContext: String
 
     /** How to verify the access tokens that [CredentialIssuer] needs to verify before issuing credentials. */
+    @Deprecated("Use [userInfo] instead")
     val tokenVerificationService: TokenVerificationService
 
+    @Deprecated("Use [metadata()] instead")
     /** Provide necessary [OAuth2AuthorizationServerMetadata] JSON for a client to be able to authenticate. */
     val metadata: OAuth2AuthorizationServerMetadata
+
+    /** Provide necessary [OAuth2AuthorizationServerMetadata] JSON for a client to be able to authenticate. */
+    suspend fun metadata(): OAuth2AuthorizationServerMetadata
+
+    /**
+     * Obtains [at.asitplus.openid.OidcUserInfoExtended] from the Authorization Server, for which the AS will
+     * verify the access token sent by the client (either directly, or with a token exchange step before).
+     */
+    suspend fun userInfo(
+        authorizationHeader: String,
+        credentialIdentifier: String?,
+        credentialConfigurationId: String?,
+        request: RequestInfo?,
+    ): KmmResult<OidcUserInfoExtended>
 
 }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletService.kt
@@ -34,10 +34,12 @@ import kotlinx.serialization.json.decodeFromJsonElement
  * , Draft 15, 2024-12-19.
  */
 class WalletService(
-    /** Used to create request parameters, e.g. [AuthenticationRequestParameters], typically a URI. */
+    /** Used to create request parameters, e.g. [AuthenticationRequestParameters], typically a URI.
+     * Must match [OAuth2Client.clientId] in [oauth2Client]. */
     val clientId: String = "https://wallet.a-sit.at/app",
     /** Used to create [AuthenticationRequestParameters] and [TokenRequestParameters]. */
-    private val redirectUrl: String = "$clientId/callback",
+    @Deprecated("Configure oauth2Client instead")
+    val redirectUrl: String = "$clientId/callback",
     /** Used to prove possession of the key material to create [CredentialRequestProof], i.e. the holder key. */
     private val keyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
     /**
@@ -58,7 +60,10 @@ class WalletService(
     /** Algorithm to decrypt credential response encryption, see [requestEncryption]. */
     private val supportedJweEncryptionAlgorithm: JweEncryption = JweEncryption.A256GCM,
     /** OAuth2 client to build authorization requests */
-    val oauth2Client: OAuth2Client = OAuth2Client(clientId, redirectUrl),
+    val oauth2Client: OAuth2Client = OAuth2Client(
+        clientId = clientId,
+        redirectUrl = redirectUrl
+    ),
 ) {
 
     data class KeyAttestationInput(val clientNonce: String?, val supportedAlgorithms: Collection<String>?)

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
@@ -60,12 +60,13 @@ class OAuth2ClientAuthenticationTest : FunSpec({
     }
 
     suspend fun getToken(state: String, code: String): TokenResponseParameters = server.token(
-        client.createTokenRequestParameters(
+        request = client.createTokenRequestParameters(
             state = state,
             authorization = OAuth2Client.AuthorizationForToken.Code(code),
             scope = scope
         ),
-        RequestInfo(
+        authorizationHeader = null,
+        httpRequest = RequestInfo(
             url = "https://example.com/",
             method = HttpMethod.Post,
             dpop = null,
@@ -187,7 +188,7 @@ class OAuth2ClientAuthenticationTest : FunSpec({
             authorization = OAuth2Client.AuthorizationForToken.Code(code),
             scope = scope
         )
-        shouldThrow<OAuth2Exception> { server.token(tokenRequest).getOrThrow() }
+        shouldThrow<OAuth2Exception> { server.token(tokenRequest, null, null).getOrThrow() }
     }
 
 })

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientTest.kt
@@ -38,7 +38,7 @@ class OAuth2ClientTest : FunSpec({
             authorization = OAuth2Client.AuthorizationForToken.PreAuthCode(preAuth),
             scope = scope
         )
-        val token = server.token(tokenRequest).getOrThrow()
+        val token = server.token(tokenRequest, null, null).getOrThrow()
         token.authorizationDetails.shouldBeNull()
     }
 
@@ -51,8 +51,8 @@ class OAuth2ClientTest : FunSpec({
             authorization = OAuth2Client.AuthorizationForToken.PreAuthCode(preAuth),
             scope = scope
         )
-        server.token(tokenRequest).isSuccess shouldBe true
-        server.token(tokenRequest).isFailure shouldBe true
+        server.token(tokenRequest, null, null).isSuccess shouldBe true
+        server.token(tokenRequest, null, null).isFailure shouldBe true
     }
 
     test("process with pushed authorization request") {
@@ -74,7 +74,7 @@ class OAuth2ClientTest : FunSpec({
             authorization = OAuth2Client.AuthorizationForToken.Code(code),
             scope = scope
         )
-        val token = server.token(tokenRequest).getOrThrow()
+        val token = server.token(tokenRequest, null, null).getOrThrow()
         token.authorizationDetails.shouldBeNull()
     }
 
@@ -96,7 +96,7 @@ class OAuth2ClientTest : FunSpec({
             authorization = OAuth2Client.AuthorizationForToken.Code(code),
             scope = scope
         )
-        val token = server.token(tokenRequest).getOrThrow()
+        val token = server.token(tokenRequest, null, null).getOrThrow()
         token.authorizationDetails.shouldBeNull()
     }
 
@@ -118,7 +118,7 @@ class OAuth2ClientTest : FunSpec({
             authorization = OAuth2Client.AuthorizationForToken.Code(code),
             scope = scope
         )
-        val token = server.token(tokenRequest).getOrThrow()
+        val token = server.token(tokenRequest, null, null).getOrThrow()
         token.authorizationDetails.shouldBeNull()
     }
 
@@ -140,7 +140,7 @@ class OAuth2ClientTest : FunSpec({
             scope = scope.reversed() // invalid, not in authn request
         )
         shouldThrow<OAuth2Exception> {
-            server.token(tokenRequest).getOrThrow()
+            server.token(tokenRequest, null, null).getOrThrow()
         }
     }
 
@@ -161,7 +161,7 @@ class OAuth2ClientTest : FunSpec({
             authorization = OAuth2Client.AuthorizationForToken.Code(code),
             scope = null // already specified in authnrequest
         )
-        val token = server.token(tokenRequest).getOrThrow()
+        val token = server.token(tokenRequest, null, null).getOrThrow()
         token.authorizationDetails.shouldBeNull()
         token.scope.shouldBe(scope)
     }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciAttestationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciAttestationTest.kt
@@ -54,7 +54,7 @@ class OidvciAttestationTest : FunSpec({
             scope = scope,
             resource = issuer.metadata.credentialIssuer
         )
-        return authorizationService.token(tokenRequest).getOrThrow()
+        return authorizationService.token(tokenRequest, null, null).getOrThrow()
     }
 
     beforeEach {

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciCodeFlowTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciCodeFlowTest.kt
@@ -84,7 +84,7 @@ class OidvciCodeFlowTest : FreeSpec({
             scope = if (setScopeInTokenRequest) scope else null,
             resource = issuer.metadata.credentialIssuer
         )
-        return authorizationService.token(tokenRequest).getOrThrow()
+        return authorizationService.token(tokenRequest, null, null).getOrThrow()
     }
 
     suspend fun getToken(
@@ -105,7 +105,7 @@ class OidvciCodeFlowTest : FreeSpec({
             authorization = OAuth2Client.AuthorizationForToken.Code(code),
             authorizationDetails = if (setAuthnDetailsInTokenRequest) authorizationDetails else null,
         )
-        return authorizationService.token(tokenRequest).getOrThrow()
+        return authorizationService.token(tokenRequest, null, null).getOrThrow()
     }
 
     fun defectMapStore() = object : MapStore<String, ClientAuthRequest> {
@@ -310,7 +310,7 @@ class OidvciCodeFlowTest : FreeSpec({
             resource = issuer.metadata.credentialIssuer
         )
         shouldThrow<OAuth2Exception> {
-            authorizationService.token(tokenRequest).getOrThrow()
+            authorizationService.token(tokenRequest, null, null).getOrThrow()
         }
     }
 
@@ -392,7 +392,7 @@ class OidvciCodeFlowTest : FreeSpec({
             authorizationDetails = tokenAuthnDetails // this is wrong, should be same as in authn request
         )
         shouldThrow<OAuth2Exception> {
-            authorizationService.token(tokenRequest).getOrThrow()
+            authorizationService.token(tokenRequest, null, null).getOrThrow()
         }
     }
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciEncryptionTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciEncryptionTest.kt
@@ -54,7 +54,7 @@ class OidvciEncryptionTest : FunSpec({
             scope = scope,
             resource = issuer.metadata.credentialIssuer
         )
-        return authorizationService.token(tokenRequest).getOrThrow()
+        return authorizationService.token(tokenRequest, null, null).getOrThrow()
     }
 
     beforeEach {

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciOfferCodeTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciOfferCodeTest.kt
@@ -61,7 +61,7 @@ class OidvciOfferCodeTest : FreeSpec({
             scope = scope,
             resource = issuer.metadata.credentialIssuer
         )
-        return authorizationService.token(tokenRequest).getOrThrow()
+        return authorizationService.token(tokenRequest, null, null).getOrThrow()
     }
 
     suspend fun getToken(
@@ -83,7 +83,7 @@ class OidvciOfferCodeTest : FreeSpec({
             authorization = OAuth2Client.AuthorizationForToken.Code(code),
             authorizationDetails = authorizationDetails,
         )
-        return authorizationService.token(tokenRequest).getOrThrow()
+        return authorizationService.token(tokenRequest, null, null).getOrThrow()
     }
 
     "process with code after credential offer, and scope for one credential" {

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciPreAuthTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciPreAuthTest.kt
@@ -58,7 +58,7 @@ class OidvciPreAuthTest : FreeSpec({
                 issuer.metadata.authorizationServers
             )
         )
-        return authorizationService.token(tokenRequest).getOrThrow()
+        return authorizationService.token(tokenRequest, null, null).getOrThrow()
     }
 
     "process with pre-authorized code, credential offer, and authorization details for one credential" {
@@ -140,7 +140,7 @@ class OidvciPreAuthTest : FreeSpec({
             scope = scope,
             resource = issuer.metadata.credentialIssuer,
         )
-        val token = authorizationService.token(tokenRequest).getOrThrow()
+        val token = authorizationService.token(tokenRequest, null, null).getOrThrow()
         val clientNonce = issuer.nonce().getOrThrow().clientNonce
 
         val credentialRequest = client.createCredentialRequest(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/QtspAuthorizationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/QtspAuthorizationTest.kt
@@ -50,7 +50,7 @@ class QtspAuthorizationTest : FreeSpec({
             ),
             authorizationDetails = credentialAuthReq.authorizationDetails
         )
-        qtspAuthenticationService.token(credentialTokenReq).getOrThrow()
+        qtspAuthenticationService.token(credentialTokenReq, null, null).getOrThrow()
     }
 
 })

--- a/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/helper/SimpleQtspAuthorizationService.kt
+++ b/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/helper/SimpleQtspAuthorizationService.kt
@@ -1,10 +1,6 @@
 package at.asitplus.wallet.lib.rqes.helper
 
-import at.asitplus.wallet.lib.data.ConstantIndex
-import at.asitplus.wallet.lib.oauth2.AuthorizationService
 import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService
-import at.asitplus.wallet.lib.oidvci.CredentialAuthorizationServiceStrategy
-import at.asitplus.wallet.lib.oidvci.OAuth2AuthorizationServerAdapter
 
 /**
  * Potential UC5:


### PR DESCRIPTION
Improves our OAuth2.0 implementation with token exchange.

This allows us to build a RemoteOAuth2AuthorizationServerAdapter for the credential issuer to use an external AS (that is not necessarily our own implementation).

(Tests may fail here, this is just to split up PR #371)