### PR TITLE
Update OpenID4VCI implementation to Draft 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Release 5.9.0 (unreleased):
    - In `SupportedCredentialFormat` add new property about `CredentialMetadata`, moving `display` and `claims`
    - In `TokenResponseParameters` remove `clientNonce` that has been dropped in OID4VCI draft 14
    - In `CredentialRequestParameters` deprecate `proof`, use `proofs` instead
+   - Use correct error values for `unknown_credential_configuration` and `unknown_credential_identifier`
 
 Release 5.8.0:
  - Refactor `AuthorizationServiceStrategy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ Release 5.9.0 (unreleased):
    - In `TokenResponseParameters` remove `clientNonce` that has been dropped in OID4VCI draft 14
    - In `CredentialRequestParameters` deprecate `proof`, use `proofs` instead
    - Use correct error values for `unknown_credential_configuration` and `unknown_credential_identifier`
+   - In `CredentialIssuer` deprecate constructor parameters `encryptCredentialRequest`, `requireEncryption`, `supportedJweAlgorithms`, `supportedJweEncryptionAlgorithms`
+   - In `CredentialIssuer` introduce constructor parameter `encryptionService` which handles credential request decryption and credential response encryption
+   - In `WalletService` deprecate constructor parameters `requestEncryption`, `decryptionKeyMaterial`, `supportedJweAlgorithm`, `supportedJweEncryptionAlgorithm`
+   - In `WalletService` introduce constructor parameter `encryptionService` which handles credential request encryption and credential response decryption
+   - In `WalletService` add method `parseCredentialResponse` to transform the received credential response from the issuer into `StoreCredentialInput`
 
 Release 5.8.0:
  - Refactor `AuthorizationServiceStrategy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Release 5.9.0 (unreleased):
    - In `WalletService` deprecate constructor parameters `requestEncryption`, `decryptionKeyMaterial`, `supportedJweAlgorithm`, `supportedJweEncryptionAlgorithm`
    - In `WalletService` introduce constructor parameter `encryptionService` which handles credential request encryption and credential response decryption
    - In `WalletService` add method `parseCredentialResponse` to transform the received credential response from the issuer into `StoreCredentialInput`
+   - In `WalletService` deprecate method `createCredentialRequest` and replace it with `createCredential` to handle encryption
 
 Release 5.8.0:
  - Refactor `AuthorizationServiceStrategy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Release 5.9.0 (unreleased):
  - Update implementation of [OpenID for Verifiable Credential Issuance](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) to draft 17:
    - Offer `signedMetadata` in `CredentialIssuer`
    - In `OpenIdAuthorizationDetails` deprecate properties that have been dropped from the spec: `format`, `docType`, `sdJwtVcType` and `credentialDefinition`
+   - In `SupportedCredentialFormat` add new property about `CredentialMetadata`, moving `display` and `claims`
 
 Release 5.8.0:
  - Refactor `AuthorizationServiceStrategy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Release 5.9.0 (unreleased):
    - Use [secure random](https://github.com/KotlinCrypto/random) for source of nonces by default, but also expose constructor parameters to override it
  - Update implementation of [OpenID for Verifiable Credential Issuance](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) to draft 17:
    - Offer `signedMetadata` in `CredentialIssuer`
+   - In `OpenIdAuthorizationDetails` deprecate properties that have been dropped from the spec: `format`, `docType`, `sdJwtVcType` and `credentialDefinition`
 
 Release 5.8.0:
  - Refactor `AuthorizationServiceStrategy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Release 5.9.0 (unreleased):
    - In `OpenIdAuthorizationDetails` deprecate properties that have been dropped from the spec: `format`, `docType`, `sdJwtVcType` and `credentialDefinition`
    - In `SupportedCredentialFormat` add new property about `CredentialMetadata`, moving `display` and `claims`
    - In `TokenResponseParameters` remove `clientNonce` that has been dropped in OID4VCI draft 14
+   - In `CredentialRequestParameters` deprecate `proof`, use `proofs` instead
 
 Release 5.8.0:
  - Refactor `AuthorizationServiceStrategy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Release 5.9.0 (unreleased):
    - Offer `signedMetadata` in `CredentialIssuer`
    - In `OpenIdAuthorizationDetails` deprecate properties that have been dropped from the spec: `format`, `docType`, `sdJwtVcType` and `credentialDefinition`
    - In `SupportedCredentialFormat` add new property about `CredentialMetadata`, moving `display` and `claims`
+   - In `TokenResponseParameters` remove `clientNonce` that has been dropped in OID4VCI draft 14
 
 Release 5.8.0:
  - Refactor `AuthorizationServiceStrategy`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Release 5.9.0 (unreleased):
    - Implement `RemoteOAuth2AuthorizationServerAdapter` so that credential issuers may be connected to external OAuth2.0 authorization servers
  - Cryptography:
    - Use [secure random](https://github.com/KotlinCrypto/random) for source of nonces by default, but also expose constructor parameters to override it
+ - Update implementation of [OpenID for Verifiable Credential Issuance](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) to draft 17:
+   - Offer `signedMetadata` in `CredentialIssuer`
 
 Release 5.8.0:
  - Refactor `AuthorizationServiceStrategy`

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthorizationDetails.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthorizationDetails.kt
@@ -25,28 +25,19 @@ sealed class AuthorizationDetails
 @SerialName("openid_credential")
 data class OpenIdAuthorizationDetails(
     /**
-     * OID4VCI: REQUIRED when [format] parameter is not present. String specifying a unique identifier of the
+     * OID4VCI: REQUIRED. String specifying a unique identifier of the
      * Credential being described in [IssuerMetadata.supportedCredentialConfigurations].
      * The referenced object in [IssuerMetadata.supportedCredentialConfigurations] conveys the details, such as the
-     * format, for issuance of the requested Credential.
+     * format and format-specific parameters like `vct` for SD-JWT VC or `doctype` for ISO mdoc.
      */
     @SerialName("credential_configuration_id")
     val credentialConfigurationId: String? = null,
 
-    /**
-     * OID4VCI: REQUIRED when [credentialConfigurationId] parameter is not present.
-     * String identifying the format of the Credential the Wallet needs.
-     * This Credential format identifier determines further claims in the authorization details object needed to
-     * identify the Credential type in the requested format.
-     */
+    @Deprecated("Removed in OID4VCI draft 16")
     @SerialName("format")
     val format: CredentialFormatEnum? = null,
 
-    /**
-     * OID4VCI: ISO mDL: OPTIONAL. This claim contains the type value the Wallet requests authorization for at the
-     * Credential Issuer. It MUST only be present if the [format] claim is present. It MUST not be present
-     * otherwise.
-     */
+    @Deprecated("Removed in OID4VCI draft 16")
     @SerialName("doctype")
     val docType: String? = null,
 
@@ -57,18 +48,11 @@ data class OpenIdAuthorizationDetails(
     @SerialName("claims")
     val claims: JsonElement? = null,
 
-    /**
-     * OID4VCI: W3C VC: OPTIONAL. Object containing a detailed description of the Credential consisting of the
-     * following parameters, see [SupportedCredentialFormatDefinition].
-     */
+    @Deprecated("Removed in OID4VCI draft 16")
     @SerialName("credential_definition")
     val credentialDefinition: SupportedCredentialFormatDefinition? = null,
 
-    /**
-     * OID4VCI: IETF SD-JWT VC: REQUIRED. String as defined in Appendix A.3.2. This claim contains the type values
-     * the Wallet requests authorization for at the Credential Issuer.
-     * It MUST only be present if the [format] claim is present. It MUST not be present otherwise.
-     */
+    @Deprecated("Removed in OID4VCI draft 16")
     @SerialName("vct")
     val sdJwtVcType: String? = null,
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthorizationDetails.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthorizationDetails.kt
@@ -9,6 +9,7 @@ import at.asitplus.signum.indispensable.asn1.ObjectIdentifierStringSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement
 
@@ -46,7 +47,7 @@ data class OpenIdAuthorizationDetails(
      * OID4VCI: IETF SD-JWT VC: OPTIONAL. An array of claims description objects as defined in Appendix B.2.
      */
     @SerialName("claims")
-    val claims: JsonElement? = null,
+    val claimDescription: Set<ClaimDescription>? = null,
 
     @Deprecated("Removed in OID4VCI draft 16")
     @SerialName("credential_definition")
@@ -74,12 +75,9 @@ data class OpenIdAuthorizationDetails(
     val credentialIdentifiers: Set<String>? = null,
 ) : AuthorizationDetails() {
 
-    val claimDescription: Set<ClaimDescription>?
-        get() = claims?.let {
-            catchingUnwrapped {
-                joseCompliantSerializer.decodeFromJsonElement<Set<ClaimDescription>>(it)
-            }.getOrNull()
-        }
+    @Transient
+    @Deprecated("Use claimDescription instead")
+    val claims: JsonElement? = null
 
 }
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/ClaimDescription.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/ClaimDescription.kt
@@ -6,23 +6,30 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ClaimDescription(
     /**
-     * OID4VCI: REQUIRED. The value MUST be a non-empty array representing a claims path pointer that specifies the
-     * path to a claim within the credential, as defined in Appendix C.
+     * OID4VCI: REQUIRED. The value MUST be a non-empty array representing a claims path pointer that specifies the path
+     * to a claim within the credential, as defined in Appendix C.
      */
     @SerialName("path")
     val path: List<String>,
 
     /**
-     * OID4VCI: OPTIONAL. Boolean which, when set to true, indicates that the Credential Issuer will always include
-     * this claim in the issued Credential. If set to `false`, the claim is not included in the issued Credential if the
-     * wallet did not request the inclusion of the claim, and/or if the Credential Issuer chose to not include the
-     * claim. If the mandatory parameter is omitted, the default value is `false`.
+     * OID4VCI: Issuer Metadata:
+     * OPTIONAL. Boolean which, when set to `true`, indicates that the Credential Issuer will always include this claim
+     * in the issued Credential. If set to `false`, the claim is not included in the issued Credential if the wallet did
+     * not request the inclusion of the claim, and/or if the Credential Issuer chose to not include the claim. If the
+     * mandatory parameter is omitted, the default value is false.
+     *
+     * OID4VCI: Authorization Details:
+     * OPTIONAL. Boolean which, when set to `true`, indicates that the Wallet will only accept a Credential that
+     * includes this claim. If set to `false`, the claim is not required to be included in the Credential. If the
+     * mandatory parameter is omitted, the default value is `false`.
      */
     @SerialName("mandatory")
     val mandatory: Boolean? = null,
 
     /**
-     * OID4VCI: OPTIONAL. Array of objects, where each object contains display properties of a certain claim in the
+     * OID4VCI: Issuer Metadata:
+     * OPTIONAL. A non-empty array of objects, where each object contains display properties of a certain claim in the
      * Credential for a certain language.
      */
     @SerialName("display")

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialMetadata.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialMetadata.kt
@@ -1,0 +1,34 @@
+package at.asitplus.openid
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * OID4VCI: Object containing information relevant to the usage and display of issued Credentials. Credential
+ * Format-specific mechanisms can overwrite the information in this object to convey Credential metadata.
+ * Format-specific mechanisms, such as SD-JWT VC display metadata are always preferred by the Wallet over the
+ * information in this object, which serves as the default fallback.
+ */
+@Serializable
+data class CredentialMetadata(
+    /**
+     * OID4VCI: Issuer Metadata:
+     * A claims description object as used in the Credential Issuer metadata is an object used to describe how a certain
+     * claim in the Credential is displayed to the End-User. It is used in the claims parameter in the Credential Issuer
+     * metadata defined in Appendix A.
+     *
+     * OID4VCI: Authorization Details:
+     * A claims description object as used in authorization details is an object that defines the requirements for the
+     * claims that the Wallet requests to be included in the Credential.
+     */
+    @SerialName("claims")
+    val claimDescription: Set<ClaimDescription>? = null,
+
+    /**
+     * OID4VCI: OPTIONAL. A non-empty array of objects, where each object contains the display properties of the
+     * supported Credential for a certain language.
+     */
+    @SerialName("display")
+    val display: Set<DisplayProperties>? = null,
+)

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialRequestParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialRequestParameters.kt
@@ -26,7 +26,7 @@ data class CredentialRequestParameters(
     val credentialConfigurationId: String? = null,
 
     /**
-     * OID4VCI:  OPTIONAL. Object containing information for encrypting the Credential Response. If this request element
+     * OID4VCI: OPTIONAL. Object containing information for encrypting the Credential Response. If this request element
      * is not present, the corresponding credential response returned is not encrypted.
      */
     @SerialName("credential_response_encryption")
@@ -39,18 +39,15 @@ data class CredentialRequestParameters(
     @SerialName("credential_definition")
     val credentialDefinition: SupportedCredentialFormatDefinition? = null,
 
-    /**
-     * OID4VCI: OPTIONAL. Object providing a single proof of possession of the cryptographic key material to which the
-     * issued Credential instance will be bound to. [proof] parameter MUST NOT be present if [proofs] parameter is used.
-     */
     @SerialName("proof")
+    @Deprecated("Removed in OID4VCI draft 16, use `proofs` instead", ReplaceWith("proofs"))
     val proof: CredentialRequestProof? = null,
 
     /**
      * OID4VCI: OPTIONAL. Object providing one or more proof of possessions of the cryptographic key material to which
-     * the issued Credential instances will be bound to. The [proofs] parameter MUST NOT be present if [proof] parameter
-     * is used. [proofs] object contains exactly one parameter named as the proof type in Section 7.2.1, the value set
-     * for this parameter is an array containing parameters as defined by the corresponding proof type.
+     * the issued Credential instances will be bound to. The [proofs] parameter contains exactly one parameter named as
+     * the proof type in Appendix F, the value set for this parameter is a non-empty array containing parameters as
+     * defined by the corresponding proof type.
      */
     @SerialName("proofs")
     val proofs: CredentialRequestProofContainer? = null,

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialRequestParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialRequestParameters.kt
@@ -32,11 +32,8 @@ data class CredentialRequestParameters(
     @SerialName("credential_response_encryption")
     val credentialResponseEncryption: CredentialResponseEncryption? = null,
 
-    /**
-     * OID4VCI: W3C VC: OPTIONAL. Object containing a detailed description of the Credential consisting of the
-     * following parameters. see [SupportedCredentialFormatDefinition].
-     */
     @SerialName("credential_definition")
+    @Deprecated("Removed in OID4VCI draft 16")
     val credentialDefinition: SupportedCredentialFormatDefinition? = null,
 
     @SerialName("proof")

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialResponseParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialResponseParameters.kt
@@ -11,33 +11,48 @@ import kotlin.time.Duration
 data class CredentialResponseParameters(
 
     /**
-     * OID4VCI: Contains an array of one or more issued Credentials. It MUST NOT be used if the `transaction_id`
+     * OID4VCI: Contains an array of one or more issued Credentials. It MUST NOT be used if the [transactionId]
      * parameter is present. The elements of the array MUST be objects.
      */
     @SerialName("credentials")
     val credentials: Set<CredentialResponseSingleCredential>? = null,
 
     /**
-     * OID4CI:
-     * OPTIONAL. A JSON string containing a security token subsequently used to obtain a Credential. MUST be present
-     * when credential is not returned.
+     * OID4VCI: OPTIONAL. String identifying a Deferred Issuance transaction. This parameter is contained in the
+     * response if the Credential Issuer cannot immediately issue the Credential. The value is subsequently used to
+     * obtain the respective Credential with the Deferred Credential Endpoint (see Section 9). It MUST not be used if
+     * the [credentials] parameter is present. It MUST be invalidated after the Credential for which it was meant has
+     * been obtained by the Wallet.
      */
+    @SerialName("transaction_id")
+    val transactionId: String? = null,
+
+    /**
+     * OID4VCI: REQUIRED if [transactionId] is present. Contains a positive number that represents the minimum amount
+     * of time in seconds that the Wallet SHOULD wait after receiving the response before sending a new request to the
+     * Deferred Credential Endpoint. It MUST NOT be used if the [credentials] parameter is present.
+     */
+    @SerialName("interval")
+    @Serializable(with = DurationSecondsIntSerializer::class)
+    val interval: Duration? = null,
+
+    /**
+     * OID4VCI: OPTIONAL. String identifying one or more Credentials issued in one Credential Response.
+     * It MUST be included in the Notification Request as defined in Section 10.1.
+     * It MUST not be used if the [credentials] parameter is not present.
+     */
+    @SerialName("notificationId")
+    val notificationId: String? = null,
+
+    @Deprecated("Removed in OID4VCI draft 12")
     @SerialName("acceptance_token")
     val acceptanceToken: String? = null,
 
-    /**
-     * OID4VCI:
-     * OPTIONAL. JSON string containing a nonce to be used to create a proof of possession of key material when
-     * requesting a Credential. When received, the Wallet MUST use this nonce value for its subsequent credential
-     * requests until the Credential Issuer provides a fresh nonce.
-     */
+    @Deprecated("Removed in OID4VCI draft 15")
     @SerialName("c_nonce")
     val clientNonce: String? = null,
 
-    /**
-     * OID4VCI:
-     * OPTIONAL. JSON integer denoting the lifetime in seconds of the c_nonce.
-     */
+    @Deprecated("Removed in OID4VCI draft 15")
     @SerialName("c_nonce_expires_in")
     @Serializable(with = DurationSecondsIntSerializer::class)
     val clientNonceExpiresIn: Duration? = null,

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/DisplayLogoProperties.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/DisplayLogoProperties.kt
@@ -8,20 +8,13 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class DisplayLogoProperties(
-    /**
-     * OID4VCI: REQUIRED. String value that contains a URI where the Wallet can obtain the logo of the Credential from
-     * the Credential Issuer.
-     *
-     * Due to inconsistent examples, we've also implemented [uri].
-     */
     @SerialName("url")
+    @Deprecated("Use `uri` instead", ReplaceWith("uri"))
     val url: String? = null,
 
     /**
      * OID4VCI: REQUIRED. String value that contains a URI where the Wallet can obtain the logo of the Credential from
      * the Credential Issuer.
-     *
-     * Due to inconsistent examples, we've also implemented [url].
      */
     @SerialName("uri")
     val uri: String? = null,

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/DisplayProperties.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/DisplayProperties.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * OID4VCI: OPTIONAL. Array of objects, where each object contains the display properties of the supported Credential
- * for a certain language.
+ * OID4VCI: OPTIONAL. A non-empty array of objects, where each object contains the display properties of the
+ * supported Credential for a certain language.
  */
 @Serializable
 data class DisplayProperties(
@@ -16,8 +16,9 @@ data class DisplayProperties(
     val name: String? = null,
 
     /**
-     * OID4VCI: OPTIONAL. String value that identifies language of this object represented as language tag values
-     * defined in BCP47 (RFC5646). There MUST be only one object with the same language identifier.
+     * OID4VCI: OPTIONAL. String value that identifies the language of this object represented as a language tag taken
+     * from values defined in BCP47 (RFC5646). Multiple display objects MAY be included for separate languages. There
+     * MUST be only one object for each language identifier.
      */
     @SerialName("locale")
     val locale: String? = null,

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/IssuerMetadata.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/IssuerMetadata.kt
@@ -7,7 +7,9 @@ import kotlinx.serialization.Serializable
  * Metadata about the credential issuer in
  * [OpenID4VCI](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html)
  *
- * To be serialized into `/.well-known/openid-credential-issuer`.
+ * Credential Issuers publishing metadata MUST make a JSON document available at the path formed by inserting the string
+ * `/.well-known/openid-credential-issuer` into the Credential Issuer Identifier between the host component and the path
+ * component, if any.
  */
 @Serializable
 data class IssuerMetadata(

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/IssuerMetadata.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/IssuerMetadata.kt
@@ -78,6 +78,13 @@ data class IssuerMetadata(
     val credentialResponseEncryption: SupportedAlgorithmsContainer? = null,
 
     /**
+     * OID4VCI: OPTIONAL. Object containing information about whether the Credential Issuer supports encryption of the
+     * Credential Request on top of TLS.
+     */
+    @SerialName("credential_request_encryption")
+    val credentialRequestEncryption: SupportedAlgorithmsContainer? = null,
+
+    /**
      * OID4VCI: OPTIONAL. Object containing information about the Credential Issuer's supports for batch issuance of
      * Credentials on the Credential Endpoint. The presence of this parameter means that the issuer supports the proofs
      * parameter in the Credential Request so can issue more than one Verifiable Credential for the same Credential
@@ -85,22 +92,6 @@ data class IssuerMetadata(
      */
     @SerialName("batch_credential_issuance")
     val batchCredentialIssuance: BatchCredentialIssuanceMetadata? = null,
-
-    /**
-     * OPTIONAL. String that is a signed JWT. This JWT contains Credential Issuer metadata parameters as claims. The
-     * signed metadata MUST be secured using JSON Web Signature (JWS) (`RFC7515`) and MUST contain an `iat` (Issued At)
-     * claim, an `iss` (Issuer) claim denoting the party attesting to the claims in the signed metadata, and `sub`
-     * (Subject) claim matching the Credential Issuer identifier. If the Wallet supports signed metadata, metadata
-     * values conveyed in the signed JWT MUST take precedence over the corresponding values conveyed using plain JSON
-     * elements. If the Credential Issuer wants to enforce use of signed metadata, it omits the respective metadata
-     * parameters from the unsigned part of the Credential Issuer metadata. A [signedMetadata] metadata value MUST NOT
-     * appear as a claim in the JWT. The Wallet MUST establish trust in the signer of the metadata, and obtain the keys
-     * to validate the signature before processing the metadata. The concrete mechanism how to do that is out of scope
-     * of this specification and MAY be defined in the profiles of this specification.
-     */
-    // TODO Analyze usage
-    @SerialName("signed_metadata")
-    val signedMetadata: String? = null,
 
     /**
      * OID4VCI: OPTIONAL. An array of objects, where each object contains display properties of a Credential Issuer for
@@ -117,4 +108,6 @@ data class IssuerMetadata(
      */
     @SerialName("credential_configurations_supported")
     val supportedCredentialConfigurations: Map<String, SupportedCredentialFormat>? = null,
+
+
 )

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
@@ -424,8 +424,14 @@ object OpenIdConstants {
         /** RFC9396 Invalid Authorization Details */
         const val INVALID_AUTHDETAILS = "invalid_authorization_details"
 
-        /** Unsupported credential type in OpenID4VCI: `unsupported_credential_type`. */
-        const val UNSUPPORTED_CREDENTIAL_TYPE = "unsupported_credential_type"
+        /** Credential request is malformed  in OpenID4VCI: `invalid_credential_request`. */
+        const val INVALID_CREDENTIAL_REQUEST = "invalid_credential_request"
+
+        /** Requested credential configuration is unknown in OpenID4VCI: `unknown_credential_configuration`. */
+        const val UNKNOWN_CREDENTIAL_CONFIGURATION = "unknown_credential_configuration"
+
+        /** Requested credential identifier is unknown in OpenID4VCI: `unknown_credential_identifier`. */
+        const val UNKNOWN_CREDENTIAL_IDENTIFIER = "unknown_credential_identifier"
 
         /** Credential request denied in OpenID4VCI: `credential_request_denied`. */
         const val CREDENTIAL_REQUEST_DENIED = "credential_request_denied"

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
@@ -436,6 +436,9 @@ object OpenIdConstants {
         /** Credential request denied in OpenID4VCI: `credential_request_denied`. */
         const val CREDENTIAL_REQUEST_DENIED = "credential_request_denied"
 
+        /** Encryption parameters invalid or missing on OpenID4VCI: `invalid_encryption_parameters`. */
+        const val INVALID_ENCRYPTION_PARAMETERS = "invalid_encryption_parameters"
+
         /** Invalid client nonce in OpenID4VCI: `invalid_nonce`. */
         const val INVALID_NONCE = "invalid_nonce"
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/SupportedAlgorithmsContainer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/SupportedAlgorithmsContainer.kt
@@ -1,7 +1,9 @@
 package at.asitplus.openid
 
 import at.asitplus.signum.indispensable.josef.JsonWebAlgorithm
+import at.asitplus.signum.indispensable.josef.JsonWebKeySet
 import at.asitplus.signum.indispensable.josef.JweAlgorithm
+import at.asitplus.signum.indispensable.josef.JweEncryption
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -32,6 +34,16 @@ data class SupportedAlgorithmsContainer(
      */
     @SerialName("encryption_required")
     val encryptionRequired: Boolean? = null,
+
+    /**
+     * OID4VCI: REQUIRED for [IssuerMetadata.credentialRequestEncryption].
+     * A JSON Web Key Set, as defined in [RFC7591](https://datatracker.ietf.org/doc/html/rfc7591),
+     * that contains one or more public keys, to be used by the Wallet as an input to a key agreement for encryption
+     * of the Credential Request.
+     * Each JWK in the set MUST have a kid (Key ID) parameter that uniquely identifies the key.
+     */
+    @SerialName("jwks")
+    val jsonWebKeySet: JsonWebKeySet? = null,
 ) {
 
     /**
@@ -49,6 +61,6 @@ data class SupportedAlgorithmsContainer(
      * in a JWT (RFC7519).
      */
     @Transient
-    val supportedEncryptionAlgorithms: Set<JweAlgorithm>? = supportedEncryptionAlgorithmsStrings
-        ?.mapNotNull { s -> JweAlgorithm.entries.firstOrNull { it.identifier == s } }?.toSet()
+    val supportedEncryptionAlgorithms: Set<JweEncryption>? = supportedEncryptionAlgorithmsStrings
+        ?.mapNotNull { s -> JweEncryption.entries.firstOrNull { it.identifier == s } }?.toSet()
 }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TokenResponseParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/TokenResponseParameters.kt
@@ -47,16 +47,6 @@ data class TokenResponseParameters(
 
     /**
      * OID4VCI:
-     * OPTIONAL String containing a nonce to be used to create a proof of possession of key material when requesting a
-     * Credential. When received, the Wallet MUST use this nonce value for its subsequent credential requests until the
-     * Credential Issuer provides a fresh nonce.
-     */
-    @SerialName("c_nonce")
-    @Deprecated("Removed in OID4VCI draft 14, see ClientNonceResponse")
-    val clientNonce: String? = null,
-
-    /**
-     * OID4VCI:
      * OPTIONAL, In the Pre-Authorized Code Flow, the Token Request is still pending as the Credential Issuer is waiting
      * for the End-User interaction to complete. The client SHOULD repeat the Token Request. Before each new request,
      * the client MUST wait at least the number of seconds specified by the interval response parameter.

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/MediaTypes.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/MediaTypes.kt
@@ -3,12 +3,29 @@ package at.asitplus.wallet.lib.data
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.MediaTypes
 
 data object MediaTypes {
-    const val AUTHZ_REQ_JWT = "application/oauth-authz-req+jwt";
+    /** `statuslist+jwt` */
     const val STATUSLIST_JWT = MediaTypes.STATUSLIST_JWT
+
     data object Application {
+        /** `application/oauth-authz-req+jwt` */
+        const val AUTHZ_REQ_JWT = "application/oauth-authz-req+jwt";
+
+        /** `application/statuslist+jwt` */
         const val STATUSLIST_JWT = MediaTypes.Application.STATUSLIST_JWT
+
+        /** `application/statuslist+json` */
         const val STATUSLIST_JSON = MediaTypes.Application.STATUSLIST_JSON
+
+        /** `application/statuslist+cwt` */
         const val STATUSLIST_CWT = MediaTypes.Application.STATUSLIST_CWT
+
+        /** `application/statuslist+cbor` */
         const val STATUSLIST_CBOR = MediaTypes.Application.STATUSLIST_CBOR
+
+        /** `application/json` */
+        const val JSON = "application/json"
+
+        /** `application/jwt` */
+        const val JWT = "application/jwt"
     }
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialAuthorizationServiceStrategy.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialAuthorizationServiceStrategy.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.oidvci
 
 import at.asitplus.openid.AuthorizationDetails
 import at.asitplus.openid.OpenIdAuthorizationDetails
+import at.asitplus.openid.SupportedCredentialFormat
 import at.asitplus.openid.TokenRequestParameters
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.oauth2.AuthorizationServiceStrategy
@@ -59,6 +60,7 @@ class CredentialAuthorizationServiceStrategy(
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun AuthorizationDetails.validateAndTransform() = when (this) {
         is OpenIdAuthorizationDetails -> when {
             credentialConfigurationId != null -> filterCredentialConfigurationId()
@@ -69,12 +71,11 @@ class CredentialAuthorizationServiceStrategy(
         else -> throw InvalidAuthorizationDetails("Wrong type for issuance: $this")
     }
 
+    @Suppress("DEPRECATION")
+    @Deprecated("Removed in OID4VCI draft 16")
     private fun OpenIdAuthorizationDetails.filterFormat(): OpenIdAuthorizationDetails? =
         supportedCredentialSchemes.entries.firstOrNull {
-            it.value.format == format &&
-                    it.value.docType == docType &&
-                    it.value.sdJwtVcType == sdJwtVcType &&
-                    it.value.credentialDefinition == credentialDefinition
+            matchesFormat(it.value)
         }?.let { matchingCredential ->
             copy(credentialIdentifiers = setOf(matchingCredential.key))
         }
@@ -92,14 +93,29 @@ class CredentialAuthorizationServiceStrategy(
  * i.e. it has either the same [OpenIdAuthorizationDetails.credentialConfigurationId]
  * or the same [OpenIdAuthorizationDetails.format] plus format-specific properties.
  */
+@Suppress("DEPRECATION")
 fun OpenIdAuthorizationDetails.matches(other: AuthorizationDetails): Boolean = when {
     other !is OpenIdAuthorizationDetails -> false
     credentialConfigurationId != null -> other.credentialConfigurationId == credentialConfigurationId
-    format != null -> other.format == format
-            && other.docType == docType
-            && other.sdJwtVcType == sdJwtVcType
-            && other.credentialDefinition == credentialDefinition
+    format != null -> matchesFormat(other)
 
     else -> false
 }
 
+@Suppress("DEPRECATION")
+@Deprecated("Removed in OID4VCI draft 16")
+private fun OpenIdAuthorizationDetails.matchesFormat(
+    other: OpenIdAuthorizationDetails,
+): Boolean = (other.format == format
+        && other.docType == docType
+        && other.sdJwtVcType == sdJwtVcType
+        && other.credentialDefinition == credentialDefinition)
+
+@Suppress("DEPRECATION")
+@Deprecated("Removed in OID4VCI draft 16")
+private fun OpenIdAuthorizationDetails.matchesFormat(
+    other: SupportedCredentialFormat,
+): Boolean = other.format == format &&
+        other.docType == docType &&
+        other.sdJwtVcType == sdJwtVcType &&
+        other.credentialDefinition == credentialDefinition

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/Extensions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/Extensions.kt
@@ -47,9 +47,6 @@ suspend fun Issuer.IssuedCredential.toCredentialResponseParameters(
 /**
  * @param transformer may be used to encrypt the credentials before serializing
  */
-// TODO In 5.4.0, use DC_SD_JWT instead of VC_SD_JWT
-// TODO After 5.5.0, drop "credential", use only "credentials"
-@Suppress("DEPRECATION")
 suspend fun Collection<Issuer.IssuedCredential>.toCredentialResponseParameters(
     transformer: (suspend (String) -> String) = { it },
 ) = if (size == 1) {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/IssuerEncryptionService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/IssuerEncryptionService.kt
@@ -1,0 +1,100 @@
+package at.asitplus.wallet.lib.oidvci
+
+import at.asitplus.KmmResult
+import at.asitplus.catching
+import at.asitplus.openid.CredentialRequestParameters
+import at.asitplus.openid.SupportedAlgorithmsContainer
+import at.asitplus.signum.indispensable.josef.JsonWebKeySet
+import at.asitplus.signum.indispensable.josef.JweAlgorithm
+import at.asitplus.signum.indispensable.josef.JweEncrypted
+import at.asitplus.signum.indispensable.josef.JweEncryption
+import at.asitplus.signum.indispensable.josef.JweHeader
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.agent.KeyMaterial
+import at.asitplus.wallet.lib.jws.DecryptJwe
+import at.asitplus.wallet.lib.jws.DecryptJweFun
+import at.asitplus.wallet.lib.jws.EncryptJwe
+import at.asitplus.wallet.lib.jws.EncryptJweFun
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidEncryptionParameters
+import io.github.aakira.napier.Napier
+
+/**
+ * Server implementation to handle credential request decryption and credential response encryption using OID4VCI.
+ *
+ * Implemented from
+ * [OpenID for Verifiable Credential Issuance](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html)
+ * , Draft 17, 2025-08-17.
+ */
+class IssuerEncryptionService(
+    /** Encrypt credential response, if requested by client or [requireResponseEncryption] is set. */
+    private val encryptCredentialResponse: EncryptJweFun = EncryptJwe(EphemeralKeyWithoutCert()),
+    /** Whether to indicate in [metadataCredentialResponseEncryption] if credential response encryption is required. */
+    internal val requireResponseEncryption: Boolean = false,
+    /** Algorithms to indicate support for credential response encryption. */
+    private val supportedJweAlgorithms: Set<JweAlgorithm> = setOf(JweAlgorithm.ECDH_ES),
+    /** Algorithms to indicate support for credential response encryption. */
+    private val supportedJweEncryptionAlgorithms: Set<JweEncryption> = setOf(JweEncryption.A256GCM),
+    /** Whether credential request encryption is required, also needs [decryptionKeyMaterial]. */
+    internal val requireRequestEncryption: Boolean = false,
+    /** Key to offer for credential request encryption. */
+    private val decryptionKeyMaterial: KeyMaterial? = null,
+    /** Used to decrypt the credential request sent by the client. */
+    private val decryptCredentialRequest: DecryptJweFun? = decryptionKeyMaterial?.let { DecryptJwe(it) },
+) {
+
+    val metadataCredentialRequestEncryption = decryptionKeyMaterial?.let {
+        SupportedAlgorithmsContainer(
+            supportedAlgorithmsStrings = supportedJweAlgorithms.map { it.identifier }.toSet(),
+            supportedEncryptionAlgorithmsStrings = supportedJweEncryptionAlgorithms.map { it.identifier }.toSet(),
+            encryptionRequired = requireRequestEncryption,
+            jsonWebKeySet = JsonWebKeySet(listOf(decryptionKeyMaterial.jsonWebKey))
+        )
+    }
+
+    val metadataCredentialResponseEncryption = SupportedAlgorithmsContainer(
+        supportedAlgorithmsStrings = supportedJweAlgorithms.map { it.identifier }.toSet(),
+        supportedEncryptionAlgorithmsStrings = supportedJweEncryptionAlgorithms.map { it.identifier }.toSet(),
+        encryptionRequired = requireResponseEncryption,
+    )
+
+    /** Decrypts credential requests from the client. */
+    internal suspend fun decrypt(
+        input: String,
+    ): KmmResult<CredentialRequestParameters> = catching {
+        if (decryptCredentialRequest == null)
+            throw InvalidEncryptionParameters("Client sent encrypted request, we can't decode it")
+        val jwe = JweEncrypted.deserialize(input).getOrElse {
+            throw InvalidEncryptionParameters("Parsing of JWE failed", it)
+        }.also { Napier.d("decrypt got $it") }
+        val decrypted = decryptCredentialRequest(jwe).getOrElse {
+            throw InvalidEncryptionParameters("Decryption of request failed", it)
+        }.also { Napier.d("decrypt got $it") }
+        joseCompliantSerializer.decodeFromString<CredentialRequestParameters>(decrypted.payload)
+    }
+
+    /** Encrypts the issued credential, if requested so by the client, or required by [requireResponseEncryption]. */
+    internal fun encryptResponseIfNecessary(
+        parameters: CredentialRequestParameters,
+    ): (suspend (String) -> String) = { input: String ->
+        parameters.credentialResponseEncryption?.let {
+            it.jweEncryption?.let { jweEncryption ->
+                Napier.d("encrypting response for ${it.jsonWebKey.keyId}")
+                encryptCredentialResponse(
+                    header = JweHeader(
+                        algorithm = it.jweAlgorithm,
+                        encryption = jweEncryption,
+                        keyId = it.jsonWebKey.keyId,
+                    ),
+                    payload = input,
+                    recipientKey = it.jsonWebKey,
+                ).getOrThrow().serialize()
+            } ?: throw InvalidEncryptionParameters("Unsupported enc: ${it.jweEncryptionString}")
+        } ?: run {
+            if (requireResponseEncryption)
+                throw InvalidEncryptionParameters("Response encryption required, no params sent")
+            else input
+        }
+    }
+
+}

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2Error.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2Error.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.Serializable
  * OpenID for Verifiable Credential Issuance
  * Published: 3 February 2023
  */
-
 @Serializable
 data class OAuth2Error(
     @SerialName("error")

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2Exception.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2Exception.kt
@@ -71,10 +71,22 @@ sealed class OAuth2Exception(
     ) : OAuth2Exception(OpenIdConstants.Errors.INVALID_DPOP_PROOF, description)
 
     @Serializable
-    class UnsupportedCredentialType(
+    class InvalidCredentialRequest(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.UNSUPPORTED_CREDENTIAL_TYPE, description)
+    ) : OAuth2Exception(OpenIdConstants.Errors.INVALID_CREDENTIAL_REQUEST, description)
+
+    @Serializable
+    class UnknownCredentialConfiguration(
+        @Transient val description: String? = null,
+        @Transient override val cause: Throwable? = null
+    ) : OAuth2Exception(OpenIdConstants.Errors.UNKNOWN_CREDENTIAL_CONFIGURATION, description)
+
+    @Serializable
+    class UnknownCredentialIdentifier(
+        @Transient val description: String? = null,
+        @Transient override val cause: Throwable? = null
+    ) : OAuth2Exception(OpenIdConstants.Errors.UNKNOWN_CREDENTIAL_IDENTIFIER, description)
 
     @Serializable
     class CredentialRequestDenied(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2Exception.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2Exception.kt
@@ -1,6 +1,23 @@
 package at.asitplus.wallet.lib.oidvci
 
 import at.asitplus.openid.OpenIdConstants
+import at.asitplus.openid.OpenIdConstants.Errors.ACCESS_DENIED
+import at.asitplus.openid.OpenIdConstants.Errors.CREDENTIAL_REQUEST_DENIED
+import at.asitplus.openid.OpenIdConstants.Errors.INVALID_AUTHDETAILS
+import at.asitplus.openid.OpenIdConstants.Errors.INVALID_CLIENT
+import at.asitplus.openid.OpenIdConstants.Errors.INVALID_CODE
+import at.asitplus.openid.OpenIdConstants.Errors.INVALID_CREDENTIAL_REQUEST
+import at.asitplus.openid.OpenIdConstants.Errors.INVALID_DPOP_PROOF
+import at.asitplus.openid.OpenIdConstants.Errors.INVALID_GRANT
+import at.asitplus.openid.OpenIdConstants.Errors.INVALID_NONCE
+import at.asitplus.openid.OpenIdConstants.Errors.INVALID_PROOF
+import at.asitplus.openid.OpenIdConstants.Errors.INVALID_REQUEST
+import at.asitplus.openid.OpenIdConstants.Errors.INVALID_SCOPE
+import at.asitplus.openid.OpenIdConstants.Errors.INVALID_TOKEN
+import at.asitplus.openid.OpenIdConstants.Errors.REGISTRATION_VALUE_NOT_SUPPORTED
+import at.asitplus.openid.OpenIdConstants.Errors.UNKNOWN_CREDENTIAL_CONFIGURATION
+import at.asitplus.openid.OpenIdConstants.Errors.UNKNOWN_CREDENTIAL_IDENTIFIER
+import at.asitplus.openid.OpenIdConstants.Errors.USER_CANCELLED
 import at.asitplus.wallet.lib.data.vckJsonSerializer
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.Serializable
@@ -16,108 +33,127 @@ sealed class OAuth2Exception(
 
     fun serialize() = vckJsonSerializer.encodeToString(OAuth2ExceptionSerializer, this)
 
+    /**
+     * [RFC6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1): The request is missing a required
+     * parameter, includes an unsupported parameter or parameter value, repeats the same parameter, uses more than one
+     * method for including an access token, or is otherwise malformed.  The resource server SHOULD respond with the
+     * HTTP 400 (Bad Request) status code.
+     */
     @Serializable
     class InvalidRequest(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.INVALID_REQUEST, description)
+    ) : OAuth2Exception(INVALID_REQUEST, description)
 
     @Serializable
     class InvalidClient(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.INVALID_CLIENT, description)
+    ) : OAuth2Exception(INVALID_CLIENT, description)
 
     @Serializable
     class InvalidScope(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.INVALID_SCOPE, description)
+    ) : OAuth2Exception(INVALID_SCOPE, description)
 
     @Serializable
     class InvalidGrant(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.INVALID_GRANT, description)
+    ) : OAuth2Exception(INVALID_GRANT, description)
 
     @Serializable
     class InvalidCode(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.INVALID_CODE, description)
+    ) : OAuth2Exception(INVALID_CODE, description)
 
+    /**
+     * [RFC6750](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1): The access token provided is expired,
+     * revoked, malformed, or invalid for other reasons.  The resource SHOULD respond with the HTTP 401 (Unauthorized)
+     * status code.  The client MAY request a new access token and retry the protected resource request.
+     */
     @Serializable
     class InvalidToken(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.INVALID_TOKEN, description)
+    ) : OAuth2Exception(INVALID_TOKEN, description), OAuthAuthorizationError
 
     @Serializable
     class InvalidProof(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.INVALID_PROOF, description)
+    ) : OAuth2Exception(INVALID_PROOF, description)
 
     @Serializable
     class UserCancelled(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.USER_CANCELLED, description)
+    ) : OAuth2Exception(USER_CANCELLED, description)
 
     @Serializable
     class InvalidDpopProof(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.INVALID_DPOP_PROOF, description)
+    ) : OAuth2Exception(INVALID_DPOP_PROOF, description), OAuthAuthorizationError
 
     @Serializable
     class InvalidCredentialRequest(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.INVALID_CREDENTIAL_REQUEST, description)
+    ) : OAuth2Exception(INVALID_CREDENTIAL_REQUEST, description)
 
     @Serializable
     class UnknownCredentialConfiguration(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.UNKNOWN_CREDENTIAL_CONFIGURATION, description)
+    ) : OAuth2Exception(UNKNOWN_CREDENTIAL_CONFIGURATION, description)
 
     @Serializable
     class UnknownCredentialIdentifier(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.UNKNOWN_CREDENTIAL_IDENTIFIER, description)
+    ) : OAuth2Exception(UNKNOWN_CREDENTIAL_IDENTIFIER, description)
 
     @Serializable
     class CredentialRequestDenied(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.CREDENTIAL_REQUEST_DENIED, description)
+    ) : OAuth2Exception(CREDENTIAL_REQUEST_DENIED, description)
 
     @Serializable
     class InvalidNonce(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.INVALID_NONCE, description)
+    ) : OAuth2Exception(INVALID_NONCE, description)
 
     @Serializable
     class AccessDenied(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.ACCESS_DENIED, description)
+    ) : OAuth2Exception(ACCESS_DENIED, description)
 
     @Serializable
     class RegistrationValueNotSupported(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.REGISTRATION_VALUE_NOT_SUPPORTED, description)
+    ) : OAuth2Exception(REGISTRATION_VALUE_NOT_SUPPORTED, description)
 
     @Serializable
     class InvalidAuthorizationDetails(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
-    ) : OAuth2Exception(OpenIdConstants.Errors.INVALID_AUTHDETAILS, description)
+    ) : OAuth2Exception(INVALID_AUTHDETAILS, description)
+
+    fun toOAuth2Error(): OAuth2Error = OAuth2Error(
+        error = error,
+        errorDescription = errorDescription ?: message,
+    )
 }
+
+interface OAuthAuthorizationError {}
+
 object OAuth2ExceptionSerializer : JsonContentPolymorphicSerializer<OAuth2Exception>(OAuth2Exception::class) {
     override fun selectDeserializer(element: JsonElement): DeserializationStrategy<OAuth2Exception> {
         throw NotImplementedError("Deserialization not supported")

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2Exception.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2Exception.kt
@@ -8,6 +8,7 @@ import at.asitplus.openid.OpenIdConstants.Errors.INVALID_CLIENT
 import at.asitplus.openid.OpenIdConstants.Errors.INVALID_CODE
 import at.asitplus.openid.OpenIdConstants.Errors.INVALID_CREDENTIAL_REQUEST
 import at.asitplus.openid.OpenIdConstants.Errors.INVALID_DPOP_PROOF
+import at.asitplus.openid.OpenIdConstants.Errors.INVALID_ENCRYPTION_PARAMETERS
 import at.asitplus.openid.OpenIdConstants.Errors.INVALID_GRANT
 import at.asitplus.openid.OpenIdConstants.Errors.INVALID_NONCE
 import at.asitplus.openid.OpenIdConstants.Errors.INVALID_PROOF
@@ -121,6 +122,12 @@ sealed class OAuth2Exception(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
     ) : OAuth2Exception(CREDENTIAL_REQUEST_DENIED, description)
+
+    @Serializable
+    class InvalidEncryptionParameters(
+        @Transient val description: String? = null,
+        @Transient override val cause: Throwable? = null
+    ) : OAuth2Exception(INVALID_ENCRYPTION_PARAMETERS, description)
 
     @Serializable
     class InvalidNonce(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/ProofValidator.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/ProofValidator.kt
@@ -79,6 +79,7 @@ class ProofValidator(
         )
     }
 
+    @Suppress("DEPRECATION")
     suspend fun validateProofExtractSubjectPublicKeys(
         params: CredentialRequestParameters,
     ): Collection<CryptoPublicKey> = params.proof?.validateProof()

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/ProofValidator.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/ProofValidator.kt
@@ -87,7 +87,7 @@ class ProofValidator(
         params: CredentialRequestParameters,
     ): Collection<CryptoPublicKey> = params.proof?.validateProof()
         ?: params.proofs?.validateProof()
-        ?: throw InvalidRequest("invalid proof")
+        ?: throw InvalidProof("proof not contained in request")
             .also { Napier.w("credential: client did not provide proof of possession in $params") }
 
     private suspend fun CredentialRequestProof.validateProof() = when (proofType) {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/ProofValidator.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/ProofValidator.kt
@@ -31,7 +31,7 @@ import kotlin.time.Duration.Companion.minutes
  *
  * Implemented from
  * [OpenID for Verifiable Credential Issuance](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html)
- * , Draft 15, 2024-12-19.
+ * , Draft 17, 2025-08-17.
  */
 class ProofValidator(
     /** Used in several fields in [IssuerMetadata], to provide endpoint URLs to clients. */

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletEncryptionService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletEncryptionService.kt
@@ -1,0 +1,108 @@
+package at.asitplus.wallet.lib.oidvci
+
+import at.asitplus.KmmResult
+import at.asitplus.catching
+import at.asitplus.openid.CredentialRequestParameters
+import at.asitplus.openid.CredentialResponseEncryption
+import at.asitplus.openid.CredentialResponseParameters
+import at.asitplus.openid.IssuerMetadata
+import at.asitplus.openid.SupportedAlgorithmsContainer
+import at.asitplus.signum.indispensable.josef.JweAlgorithm
+import at.asitplus.signum.indispensable.josef.JweEncrypted
+import at.asitplus.signum.indispensable.josef.JweEncryption
+import at.asitplus.signum.indispensable.josef.JweHeader
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.signum.indispensable.symmetric.isAuthenticated
+import at.asitplus.signum.indispensable.symmetric.requiresNonce
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.agent.KeyMaterial
+import at.asitplus.wallet.lib.jws.DecryptJwe
+import at.asitplus.wallet.lib.jws.DecryptJweFun
+import at.asitplus.wallet.lib.jws.EncryptJwe
+import at.asitplus.wallet.lib.jws.EncryptJweFun
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidEncryptionParameters
+import io.github.aakira.napier.Napier
+
+/**
+ * Wallet implementation to handle credential request encryption and credential response decryption using OID4VCI.
+ *
+ * Implemented from
+ * [OpenID for Verifiable Credential Issuance](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html)
+ * , Draft 17, 2025-08-17.
+ */
+class WalletEncryptionService(
+    /** Whether to request credential response encryption */
+    private val requestEncryption: Boolean = false,
+    /** Encrypt credential request, if requested by the issuer or [requestEncryption] is set. */
+    private val encryptCredentialRequest: EncryptJweFun = EncryptJwe(EphemeralKeyWithoutCert()),
+    /** Algorithms to indicate support for credential response encryption. */
+    private val supportedJweAlgorithm: JweAlgorithm = JweAlgorithm.ECDH_ES,
+    /** Algorithms to indicate support for credential response encryption. */
+    private val supportedJweEncryptionAlgorithm: JweEncryption = JweEncryption.A256GCM,
+    /** Key to offer for credential response encryption. */
+    private val decryptionKeyMaterial: KeyMaterial? = null,
+    /** Used to decrypt the credential response sent by the issuer. */
+    private val decryptCredentialResponse: DecryptJweFun? = decryptionKeyMaterial?.let { DecryptJwe(it) },
+) {
+
+    /** Encrypts the credential request. */
+    internal suspend fun encrypt(
+        input: CredentialRequestParameters,
+        metadata: IssuerMetadata,
+    ): KmmResult<JweEncrypted> = catching {
+        val recipientKey = metadata.credentialRequestEncryption?.jsonWebKeySet?.keys?.firstOrNull()
+            ?: throw InvalidEncryptionParameters("No recipient key found in metadata")
+        encryptCredentialRequest(
+            header = JweHeader(
+                algorithm = metadata.credentialRequestEncryption.selectAlgorithm(),
+                encryption = metadata.credentialRequestEncryption.selectEncryption()
+            ),
+            payload = joseCompliantSerializer.encodeToString(input),
+            recipientKey = recipientKey
+        ).getOrElse {
+            throw InvalidEncryptionParameters("Failed to encrypt", it)
+        }
+    }
+
+    /** Fallback to [supportedJweAlgorithm] and let's see if issuer can decrypt it. */
+    private fun SupportedAlgorithmsContainer?.selectAlgorithm(): JweAlgorithm =
+        this?.supportedAlgorithms?.filterIsInstance<JweAlgorithm>()?.firstOrNull {
+            it == supportedJweAlgorithm
+        } ?: supportedJweAlgorithm
+
+    /** Fallback to [supportedJweEncryptionAlgorithm] and let's see if issuer can decrypt it. */
+    private fun SupportedAlgorithmsContainer?.selectEncryption(): JweEncryption =
+        this?.supportedEncryptionAlgorithms?.firstOrNull {
+            it == supportedJweEncryptionAlgorithm
+        } ?: this?.supportedEncryptionAlgorithms?.firstOrNull {
+            it.algorithm.requiresNonce() && it.algorithm.isAuthenticated()
+        } ?: supportedJweEncryptionAlgorithm
+
+    /** Appends credential response encryption information to the request. */
+    internal fun credentialResponseEncryption(metadata: IssuerMetadata): CredentialResponseEncryption? =
+        if (requestEncryption && decryptionKeyMaterial != null && metadata.credentialResponseEncryption != null) {
+            CredentialResponseEncryption(
+                jsonWebKey = decryptionKeyMaterial.jsonWebKey,
+                jweAlgorithm = supportedJweAlgorithm,
+                jweEncryptionString = supportedJweEncryptionAlgorithm.identifier,
+            )
+        } else null
+
+    /** Decrypts encrypted credentials (strings in the credential response) from the issuer. */
+    internal suspend fun decrypt(
+        input: String,
+    ): KmmResult<String> = catching {
+        if (input.count { it == '.' } != 4)
+            return@catching input
+        if (decryptCredentialResponse == null)
+            throw InvalidEncryptionParameters("Issuer sent encrypted response, we can't decode it")
+        val jwe = JweEncrypted.deserialize(input).getOrElse {
+            throw InvalidEncryptionParameters("Parsing of JWE failed", it)
+        }.also { Napier.d("decrypt got $it") }
+        val decrypted = decryptCredentialResponse(jwe).getOrElse {
+            throw InvalidEncryptionParameters("Decryption of response failed", it)
+        }.also { Napier.d("decrypt got $it") }
+        decrypted.payload
+    }
+
+}

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletEncryptionService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletEncryptionService.kt
@@ -32,7 +32,7 @@ import io.github.aakira.napier.Napier
  */
 class WalletEncryptionService(
     /** Whether to request credential response encryption */
-    private val requestEncryption: Boolean = false,
+    internal val requestEncryption: Boolean = false,
     /** Encrypt credential request, if requested by the issuer or [requestEncryption] is set. */
     private val encryptCredentialRequest: EncryptJweFun = EncryptJwe(EphemeralKeyWithoutCert()),
     /** Algorithms to indicate support for credential response encryption. */

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletService.kt
@@ -205,12 +205,11 @@ class WalletService(
             throw IllegalArgumentException("Can't parse tokenResponse: $tokenResponse")
         }
         requests.map {
-            @Suppress("DEPRECATION")
             it.copy(
                 proof = createCredentialRequestProof(
                     metadata = metadata,
                     credentialFormat = credentialFormat,
-                    clientNonce = clientNonce ?: tokenResponse.clientNonce,
+                    clientNonce = clientNonce,
                     clock = clock
                 ),
                 credentialResponseEncryption = metadata.credentialResponseEncryption()

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
@@ -107,7 +107,7 @@ class RequestParser(
     ): RemoteResourceRetrieverInput = RemoteResourceRetrieverInput(
         url = uri,
         method = requestUriMethod.toHttpMethod(),
-        headers = mapOf(HttpHeaders.Accept to MediaTypes.AUTHZ_REQ_JWT),
+        headers = mapOf(HttpHeaders.Accept to MediaTypes.Application.AUTHZ_REQ_JWT),
         requestObjectParameters = buildRequestObjectParameters.invoke()
     )
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciCodeFlowTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciCodeFlowTest.kt
@@ -129,8 +129,10 @@ class OidvciCodeFlowTest : FreeSpec({
                 it.supportedSigningAlgorithms.shouldNotBeNull().shouldNotBeEmpty()
                 it.supportedProofTypes.shouldNotBeNull().shouldNotBeEmpty()
                 it.supportedBindingMethods.shouldNotBeNull().shouldNotBeEmpty()
-                if (it.format != CredentialFormatEnum.JWT_VC)
+                if (it.format != CredentialFormatEnum.JWT_VC) {
                     it.claimDescription.shouldNotBeNull().shouldNotBeEmpty()
+                    it.credentialMetadata.shouldNotBeNull().claimDescription.shouldNotBeNull().shouldNotBeEmpty()
+                }
             }
         }
         strategy.validAuthorizationDetails().shouldNotBeEmpty().forEach {

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciEncryptionTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciEncryptionTest.kt
@@ -6,17 +6,14 @@ import at.asitplus.openid.TokenResponseParameters
 import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JweEncrypted
 import at.asitplus.signum.indispensable.josef.JweHeader
-import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.agent.Holder
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.RandomSource
 import at.asitplus.wallet.lib.data.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex
-import at.asitplus.wallet.lib.data.VerifiableCredentialJws
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.PLAIN_JWT
 import at.asitplus.wallet.lib.data.rfc3986.toUri
-import at.asitplus.wallet.lib.data.vckJsonSerializer
-import at.asitplus.wallet.lib.jws.DecryptJwe
-import at.asitplus.wallet.lib.jws.DecryptJweFun
 import at.asitplus.wallet.lib.jws.EncryptJweFun
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
 import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService
@@ -24,9 +21,9 @@ import at.asitplus.wallet.lib.openid.AuthenticationResponseResult
 import at.asitplus.wallet.lib.openid.DummyUserProvider
 import at.asitplus.wallet.lib.openid.DummyOAuth2IssuerCredentialDataProvider
 import com.benasher44.uuid.uuid4
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.types.shouldBeInstanceOf
 
@@ -36,7 +33,6 @@ class OidvciEncryptionTest : FunSpec({
     lateinit var issuer: CredentialIssuer
     lateinit var client: WalletService
     lateinit var state: String
-    lateinit var decryptJwe: DecryptJweFun
 
     suspend fun getToken(scope: String): TokenResponseParameters {
         val authnRequest = client.oauth2Client.createAuthRequest(
@@ -69,18 +65,71 @@ class OidvciEncryptionTest : FunSpec({
                 randomSource = RandomSource.Default
             ),
             credentialSchemes = setOf(ConstantIndex.AtomicAttribute2023),
-            requireEncryption = true, // this is important, to require encryption
+            encryptionService = IssuerEncryptionService(
+                requireResponseEncryption = true, // this is important
+                decryptionKeyMaterial = EphemeralKeyWithoutCert()
+            ),
         )
         state = uuid4().toString()
-        val decryptionKeyMaterial = EphemeralKeyWithoutCert()
         client = WalletService(
-            requestEncryption = true, // this is important
-            decryptionKeyMaterial = decryptionKeyMaterial // this is important
+            encryptionService = WalletEncryptionService(
+                requestEncryption = true, // this is important
+                decryptionKeyMaterial = EphemeralKeyWithoutCert() // this is important
+            )
         )
-        decryptJwe = DecryptJwe(decryptionKeyMaterial)
     }
 
-    test("issuer fails to encrypt") {
+    test("wallet encrypts credential request and decrypts credential response") {
+        val requestOptions = WalletService.RequestOptions(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
+        val credentialFormat = client.selectSupportedCredentialFormat(requestOptions, issuer.metadata).shouldNotBeNull()
+        val scope = credentialFormat.scope.shouldNotBeNull()
+        val token = getToken(scope)
+
+        client.createEncryptedCredentialRequest(
+            tokenResponse = token,
+            metadata = issuer.metadata,
+            credentialFormat = credentialFormat,
+            clientNonce = issuer.nonce().getOrThrow().clientNonce
+        ).getOrThrow().forEach {
+            issuer.credentialEncryptedRequest(
+                authorizationHeader = token.toHttpHeaderValue(),
+                input = it,
+                credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
+            ).getOrThrow().let { credential ->
+                client.parseCredentialResponse(credential, PLAIN_JWT, ConstantIndex.AtomicAttribute2023)
+                    .getOrThrow().first().shouldBeInstanceOf<Holder.StoreCredentialInput.Vc>().apply {
+                        signedVcJws.payload.vc.credentialSubject.shouldBeInstanceOf<AtomicAttribute2023>()
+                    }
+            }
+        }
+    }
+
+    test("wallet does not encrypt credential request and decrypts credential response") {
+        val requestOptions = WalletService.RequestOptions(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
+        val credentialFormat = client.selectSupportedCredentialFormat(requestOptions, issuer.metadata).shouldNotBeNull()
+        val scope = credentialFormat.scope.shouldNotBeNull()
+        val token = getToken(scope)
+
+        client.createCredentialRequest(
+            tokenResponse = token,
+            metadata = issuer.metadata,
+            credentialFormat = credentialFormat,
+            clientNonce = issuer.nonce().getOrThrow().clientNonce
+        ).getOrThrow().forEach {
+            issuer.credential(
+                authorizationHeader = token.toHttpHeaderValue(),
+                params = it,
+                credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
+            ).getOrThrow().let { credential ->
+                client.parseCredentialResponse(credential, PLAIN_JWT, ConstantIndex.AtomicAttribute2023)
+                    .getOrThrow().first().shouldBeInstanceOf<Holder.StoreCredentialInput.Vc>().apply {
+                        signedVcJws.payload.vc.credentialSubject.shouldBeInstanceOf<AtomicAttribute2023>()
+                    }
+            }
+        }
+    }
+
+    test("wallet does not encrypt credential request but issuer requires this") {
         issuer = CredentialIssuer(
             authorizationService = authorizationService,
             issuer = IssuerAgent(
@@ -88,27 +137,66 @@ class OidvciEncryptionTest : FunSpec({
                 randomSource = RandomSource.Default
             ),
             credentialSchemes = setOf(ConstantIndex.AtomicAttribute2023),
-            requireEncryption = true, // this is important, to require encryption
-            encryptCredentialRequest = object : EncryptJweFun {
-                override suspend fun invoke(
-                    header: JweHeader,
-                    payload: String,
-                    recipientKey: JsonWebKey,
-                ): KmmResult<JweEncrypted> = KmmResult.catching {
-                    TODO("issuer fails to encrypt")
-                }
-            }
+            encryptionService = IssuerEncryptionService(
+                requireResponseEncryption = true,
+                decryptionKeyMaterial = EphemeralKeyWithoutCert(),
+                requireRequestEncryption = true, // this is important for this test
+            ),
         )
-        val requestOptions = WalletService.RequestOptions(
-            ConstantIndex.AtomicAttribute2023,
-            ConstantIndex.CredentialRepresentation.PLAIN_JWT
-        )
+
+        val requestOptions = WalletService.RequestOptions(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
         val credentialFormat = client.selectSupportedCredentialFormat(requestOptions, issuer.metadata).shouldNotBeNull()
         val scope = credentialFormat.scope.shouldNotBeNull()
         val token = getToken(scope)
-        val clientNonce = issuer.nonce().getOrThrow().clientNonce
 
-        client.createCredentialRequest(token, issuer.metadata, credentialFormat, clientNonce).getOrThrow().forEach {
+        client.createCredentialRequest(
+            tokenResponse = token,
+            metadata = issuer.metadata,
+            credentialFormat = credentialFormat,
+            clientNonce = issuer.nonce().getOrThrow().clientNonce
+        ).getOrThrow().forEach {
+            shouldThrow<OAuth2Exception.InvalidEncryptionParameters> {
+                issuer.credential(
+                    authorizationHeader = token.toHttpHeaderValue(),
+                    params = it,
+                    credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
+                ).getOrThrow()
+            }
+        }
+    }
+
+    test("issuer fails to encrypt response") {
+        issuer = CredentialIssuer(
+            authorizationService = authorizationService,
+            issuer = IssuerAgent(
+                identifier = "https://issuer.example.com".toUri(),
+                randomSource = RandomSource.Default
+            ),
+            credentialSchemes = setOf(ConstantIndex.AtomicAttribute2023),
+            encryptionService = IssuerEncryptionService(
+                requireResponseEncryption = true,
+                encryptCredentialResponse = object : EncryptJweFun {
+                    override suspend fun invoke(
+                        header: JweHeader,
+                        payload: String,
+                        recipientKey: JsonWebKey,
+                    ): KmmResult<JweEncrypted> = KmmResult.catching {
+                        TODO("issuer fails to encrypt")
+                    }
+                }
+            ),
+        )
+        val requestOptions = WalletService.RequestOptions(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
+        val credentialFormat = client.selectSupportedCredentialFormat(requestOptions, issuer.metadata).shouldNotBeNull()
+        val scope = credentialFormat.scope.shouldNotBeNull()
+        val token = getToken(scope)
+
+        client.createCredentialRequest(
+            tokenResponse = token,
+            metadata = issuer.metadata,
+            credentialFormat = credentialFormat,
+            clientNonce = issuer.nonce().getOrThrow().clientNonce
+        ).getOrThrow().forEach {
             shouldThrowAny {
                 issuer.credential(
                     authorizationHeader = token.toHttpHeaderValue(),
@@ -119,35 +207,5 @@ class OidvciEncryptionTest : FunSpec({
         }
     }
 
-    test("decrypt received credential") {
-        val requestOptions = WalletService.RequestOptions(
-            ConstantIndex.AtomicAttribute2023,
-            ConstantIndex.CredentialRepresentation.PLAIN_JWT
-        )
-        val credentialFormat =
-            client.selectSupportedCredentialFormat(requestOptions, issuer.metadata).shouldNotBeNull()
-        val scope = credentialFormat.scope.shouldNotBeNull()
-        val token = getToken(scope)
-        val clientNonce = issuer.nonce().getOrThrow().clientNonce
-
-        client.createCredentialRequest(token, issuer.metadata, credentialFormat, clientNonce).getOrThrow().forEach {
-            val credential = issuer.credential(
-                token.toHttpHeaderValue(),
-                it,
-                credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
-            ).getOrThrow()
-            val serializedCredential = credential.credentials.shouldNotBeEmpty()
-                .first().credentialString.shouldNotBeNull()
-            val jwe = JweEncrypted.Companion.deserialize(serializedCredential).getOrThrow()
-            val plain = decryptJwe(jwe).getOrThrow().payload
-
-            JwsSigned.Companion.deserialize<VerifiableCredentialJws>(
-                VerifiableCredentialJws.Companion.serializer(),
-                plain,
-                vckJsonSerializer
-            ).getOrThrow()
-                .payload.vc.credentialSubject.shouldBeInstanceOf<AtomicAttribute2023>()
-        }
-    }
 
 })

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciEncryptionTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciEncryptionTest.kt
@@ -85,15 +85,16 @@ class OidvciEncryptionTest : FunSpec({
         val scope = credentialFormat.scope.shouldNotBeNull()
         val token = getToken(scope)
 
-        client.createEncryptedCredentialRequest(
+        client.createCredential(
             tokenResponse = token,
             metadata = issuer.metadata,
             credentialFormat = credentialFormat,
             clientNonce = issuer.nonce().getOrThrow().clientNonce
         ).getOrThrow().forEach {
+            it.shouldBeInstanceOf<WalletService.CredentialRequest.Encrypted>()
             issuer.credentialEncryptedRequest(
                 authorizationHeader = token.toHttpHeaderValue(),
-                input = it,
+                input = it.request.serialize(),
                 credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
             ).getOrThrow().let { credential ->
                 client.parseCredentialResponse(credential, PLAIN_JWT, ConstantIndex.AtomicAttribute2023)
@@ -110,7 +111,7 @@ class OidvciEncryptionTest : FunSpec({
         val scope = credentialFormat.scope.shouldNotBeNull()
         val token = getToken(scope)
 
-        client.createCredentialRequest(
+        client.createCredential(
             tokenResponse = token,
             metadata = issuer.metadata,
             credentialFormat = credentialFormat,
@@ -149,7 +150,7 @@ class OidvciEncryptionTest : FunSpec({
         val scope = credentialFormat.scope.shouldNotBeNull()
         val token = getToken(scope)
 
-        client.createCredentialRequest(
+        client.createCredential(
             tokenResponse = token,
             metadata = issuer.metadata,
             credentialFormat = credentialFormat,
@@ -191,7 +192,7 @@ class OidvciEncryptionTest : FunSpec({
         val scope = credentialFormat.scope.shouldNotBeNull()
         val token = getToken(scope)
 
-        client.createCredentialRequest(
+        client.createCredential(
             tokenResponse = token,
             metadata = issuer.metadata,
             credentialFormat = credentialFormat,

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciOfferCodeTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciOfferCodeTest.kt
@@ -98,7 +98,7 @@ class OidvciOfferCodeTest : FreeSpec({
         val token = getToken(credentialOffer, credentialFormat.scope.shouldNotBeNull())
         val clientNonce = issuer.nonce().getOrThrow().clientNonce
 
-        val credentialRequest = client.createCredentialRequest(
+        val credentialRequest = client.createCredential(
             tokenResponse = token,
             metadata = issuer.metadata,
             credentialFormat = credentialFormat,
@@ -145,7 +145,7 @@ class OidvciOfferCodeTest : FreeSpec({
 
         val clientNonce = issuer.nonce().getOrThrow().clientNonce
 
-        val credentialRequest = client.createCredentialRequest(
+        val credentialRequest = client.createCredential(
             tokenResponse = token,
             metadata = issuer.metadata,
             credentialFormat = credentialFormat,

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciPreAuthTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciPreAuthTest.kt
@@ -77,7 +77,7 @@ class OidvciPreAuthTest : FreeSpec({
             .first().shouldBeInstanceOf<OpenIdAuthorizationDetails>()
         val clientNonce = issuer.nonce().getOrThrow().clientNonce
 
-        val credentialRequest = client.createCredentialRequest(
+        val credentialRequest = client.createCredential(
             tokenResponse = token,
             metadata = issuer.metadata,
             credentialFormat = credentialFormat,
@@ -109,7 +109,7 @@ class OidvciPreAuthTest : FreeSpec({
             it.shouldBeInstanceOf<OpenIdAuthorizationDetails>()
             val credentialFormat =
                 issuer.metadata.supportedCredentialConfigurations!![it.credentialIdentifiers!!.first()].shouldNotBeNull()
-            val credentialRequest = client.createCredentialRequest(
+            val credentialRequest = client.createCredential(
                 tokenResponse = token,
                 metadata = issuer.metadata,
                 credentialFormat = credentialFormat,
@@ -147,7 +147,7 @@ class OidvciPreAuthTest : FreeSpec({
         val token = authorizationService.token(tokenRequest, null).getOrThrow()
         val clientNonce = issuer.nonce().getOrThrow().clientNonce
 
-        val credentialRequest = client.createCredentialRequest(
+        val credentialRequest = client.createCredential(
             tokenResponse = token,
             metadata = issuer.metadata,
             credentialFormat = supportedCredentialFormat,

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/SerializationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/SerializationTest.kt
@@ -55,6 +55,7 @@ class SerializationTest : FunSpec({
         interval = Random.nextInt(1, Int.MAX_VALUE).seconds,
     )
 
+    @Suppress("DEPRECATION")
     fun createCredentialRequest() = CredentialRequestParameters(
         credentialIdentifier = randomString(),
         credentialConfigurationId = randomString(),
@@ -63,7 +64,13 @@ class SerializationTest : FunSpec({
         ),
         proof = CredentialRequestProof(
             proofType = OpenIdConstants.ProofType.Other(randomString()),
-            jwt = randomString()
+            jwt = randomString(),
+            attestation = randomString(),
+        ),
+        proofs = CredentialRequestProofContainer(
+            proofType = OpenIdConstants.ProofType.Other(randomString()),
+            jwt = setOf(randomString()),
+            attestation = setOf(randomString()),
         )
     )
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/SerializationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/SerializationTest.kt
@@ -76,9 +76,8 @@ class SerializationTest : FunSpec({
 
     fun createCredentialResponse() = CredentialResponseParameters(
         credentials = setOf(CredentialResponseSingleCredential(JsonPrimitive(randomString()))),
-        acceptanceToken = randomString(),
-        clientNonce = randomString(),
-        clientNonceExpiresIn = Random.nextInt(1, Int.MAX_VALUE).seconds,
+        transactionId = randomString(),
+        notificationId = randomString(),
     )
 
     test("createAuthorizationRequest as GET") {

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/SerializationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/SerializationTest.kt
@@ -59,9 +59,6 @@ class SerializationTest : FunSpec({
     fun createCredentialRequest() = CredentialRequestParameters(
         credentialIdentifier = randomString(),
         credentialConfigurationId = randomString(),
-        credentialDefinition = SupportedCredentialFormatDefinition(
-            types = setOf(randomString(), randomString()),
-        ),
         proof = CredentialRequestProof(
             proofType = OpenIdConstants.ProofType.Other(randomString()),
             jwt = randomString(),
@@ -128,18 +125,6 @@ class SerializationTest : FunSpec({
         json shouldContain "\"token_type\":"
         json shouldContain "\"expires_in\":"
         val parsed: TokenResponseParameters = vckJsonSerializer.decodeFromString(json)
-        parsed shouldBe params
-    }
-
-    test("createCredentialRequest as JSON") {
-        val params = createCredentialRequest()
-
-        val json = vckJsonSerializer.encodeToString(params)
-
-        json shouldContain "\"type\":["
-        json shouldContain "\"${params.credentialDefinition?.types?.first()}\""
-        val parsed: CredentialRequestParameters =
-            vckJsonSerializer.decodeFromString<CredentialRequestParameters>(json)
         parsed shouldBe params
     }
 


### PR DESCRIPTION
Part 1: Apply changes from draft 16, since our implementation was previously on draft 15: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-17.html#appendix-L-4

Mainly updated data classes