### PR TITLE
JAR Request Parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,15 @@
 # Changelog
 
 Release 5.9.0 (unreleased):
- - Change `TransactionData.credentialIds` to be mandatory 
- - Remove Generics from `OpenId4VpHolder` functions and work directly with `AuthorizationRequestParameters`
- - In `PresentationFactory` replace `RequestParameters` in function signatures to work directly with `AuthorizationRequestParameters`
- - Remove all parameters from `RequestParameters`. Moved into their respective implementing class.
- - Change dependency structure of modules
- - Remove `vck-rqes` module
-   - Relevant classes now in `vck-openid` 
- - Rename `rqes-data-classes` to `csc-data-classes`
-   - Move Dif-related classes to `dif-data-classes`
+ - Remove code elements deprecated in 5.8.0
+ - Gradle modules: 
+   - Change dependency structure of modules
+   - Remove `vck-rqes` module, relevant classes have been moved to `vck-openid` 
+   - Rename `rqes-data-classes` to `csc-data-classes`
+   - Move DIF-related classes to `dif-data-classes`
    - Move OpenId-related classes to `openid-data-classes`
- - Remove `vck-openid` Initializer class
- - Refactor RQES:
+   - Remove class `Initializer` from `vck-openid`
+ - Remote Qualified Electronic Signatures:
    - Remove "UC5-flow" option in RQES flows
    - Remove `transactionData` from `KeyBindingJws`
    - Remove `QesAuthorizationDetails`
@@ -23,8 +20,8 @@ Release 5.9.0 (unreleased):
    - Remove `RequestOptions` interface
    - Rename `OpenIdRequestOptions` to `RequestOptions`
    - Refactor `TransactionData` to sealed class
+   - In `TransactionData` make `credentialIds` mandatory
    - Refactor `RequestParameters` to sealed class
- - Remove code elements deprecated in 5.8.0
  - Validation:
    - Improve validation of JWT VC
    - Remove subclass `InvalidStructure` from `Verifier.VerifyCredentialResult`, is now mapped to `ValidationError`
@@ -48,7 +45,14 @@ Release 5.9.0 (unreleased):
    - `SimpleAuthorizationService` supports token exchange acc. to [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)
    - `SimpleAuthorizationService` supports token introspection acc. to [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662)
    - Implement `RemoteOAuth2AuthorizationServerAdapter` so that credential issuers may be connected to external OAuth2.0 authorization servers
-   - Implement `OAuth2KtorClient` to implement a ktor-based client for OAuth 2.0, including [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)
+   - Implement `OAuth2KtorClient` to implement a ktor-based client for OAuth 2.0, including [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)  
+   - Remove generics from methods in `OpenId4VpHolder` and work directly with `AuthorizationRequestParameters`
+   - In `PresentationFactory` replace `RequestParameters` in function signatures to work directly with `AuthorizationRequestParameters`
+   - Remove all parameters from `RequestParameters`, moved into their respective implementing class
+   - Add data class `JarRequestParameters` implementing `RequestParameters` to handle [JWT-secured authorization requests](https://www.rfc-editor.org/rfc/rfc9101.html) explicitly
+   - In `AuthorizationService` and `SimpleAuthorizationService` deprecate method `authorize` with `AuthenticationRequestParameters`, use `RequestParameters` instead
+   - In `AuthorizationService` and `SimpleAuthorizationService` deprecate method `par` with `AuthenticationRequestParameters`, use `RequestParameters` instead
+   - In `OAuth2Client` add method `createAuthRequestJar` to make intent more explicit
  - Cryptography:
    - Use [secure random](https://github.com/KotlinCrypto/random) for source of nonces by default, but also expose constructor parameters to override it
  - Update implementation of [OpenID for Verifiable Credential Issuance](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) to draft 17:

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthenticationRequestParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthenticationRequestParameters.kt
@@ -137,35 +137,6 @@ data class AuthenticationRequestParameters(
     val idTokenHint: String? = null,
 
     /**
-     * OAuth 2.0 JAR: REQUIRED unless `request_uri` is specified. The Request Object that holds authorization request
-     * parameters stated in Section 4 of RFC6749 (OAuth 2.0). If this parameter is present in the authorization request,
-     * `request_uri` MUST NOT be present.
-     */
-    @SerialName("request")
-    val request: String? = null,
-
-    /**
-     * OAuth 2.0 JAR: REQUIRED unless request is specified. The absolute URI, as defined by RFC3986, that is the
-     * Request Object URI referencing the authorization request parameters stated in Section 4 of RFC6749 (OAuth 2.0).
-     * If this parameter is present in the authorization request, `request` MUST NOT be present.
-     */
-    @SerialName("request_uri")
-    val requestUri: String? = null,
-
-    /**
-     * OpenID4VP: OPTIONAL. A string determining the HTTP method to be used when the [requestUri] parameter is included
-     * in the same request. Two case-sensitive valid values are defined in this specification: `get` and `post`.
-     * If [requestUriMethod] value is `get`, the Wallet MUST send the request to retrieve the Request Object using the
-     * HTTP GET method, i.e., as defined in RFC9101. If [requestUriMethod] value is `post`, a supporting Wallet MUST
-     * send the request using the HTTP POST method as detailed in Section 5.11. If the [requestUriMethod] parameter is
-     * not present, the Wallet MUST process the [requestUri] parameter as defined in RFC9101. Wallets not supporting
-     * the post method will send a GET request to the Request URI (default behavior as defined in RFC9101).
-     * [requestUriMethod] parameter MUST NOT be present if a [requestUri] parameter is not present.
-     */
-    @SerialName("request_uri_method")
-    val requestUriMethod: String? = null,
-
-    /**
      * OIDC SIOPv2: OPTIONAL. Space-separated string that specifies the types of ID Token the RP wants to obtain, with
      * the values appearing in order of preference. The allowed individual values are `subject_signed_id_token` and
      * `attester_signed_id_token`. The default value is `attester_signed_id_token`. The RP determines the type if
@@ -445,9 +416,6 @@ data class AuthenticationRequestParameters(
         if (clientMetadata != other.clientMetadata) return false
         if (clientMetadataUri != other.clientMetadataUri) return false
         if (idTokenHint != other.idTokenHint) return false
-        if (request != other.request) return false
-        if (requestUri != other.requestUri) return false
-        if (requestUriMethod != other.requestUriMethod) return false
         if (idTokenType != other.idTokenType) return false
         if (presentationDefinition != other.presentationDefinition) return false
         if (presentationDefinitionUrl != other.presentationDefinitionUrl) return false
@@ -493,9 +461,6 @@ data class AuthenticationRequestParameters(
         result = 31 * result + (clientMetadata?.hashCode() ?: 0)
         result = 31 * result + (clientMetadataUri?.hashCode() ?: 0)
         result = 31 * result + (idTokenHint?.hashCode() ?: 0)
-        result = 31 * result + (request?.hashCode() ?: 0)
-        result = 31 * result + (requestUri?.hashCode() ?: 0)
-        result = 31 * result + (requestUriMethod?.hashCode() ?: 0)
         result = 31 * result + (idTokenType?.hashCode() ?: 0)
         result = 31 * result + (presentationDefinition?.hashCode() ?: 0)
         result = 31 * result + (presentationDefinitionUrl?.hashCode() ?: 0)

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/JarRequestParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/JarRequestParameters.kt
@@ -1,5 +1,6 @@
 package at.asitplus.openid
 
+import io.ktor.http.HttpMethod
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -58,6 +59,11 @@ data class JarRequestParameters(
         @SerialName("get")
         GET,
         @SerialName("post")
-        POST,
+        POST;
+
+        fun toHttpMethod(): HttpMethod = when (this) {
+            POST -> HttpMethod.Post
+            else -> HttpMethod.Get
+        }
     }
 }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/JarRequestParameters.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/JarRequestParameters.kt
@@ -1,0 +1,63 @@
+package at.asitplus.openid
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class JarRequestParameters(
+    /**
+     * OIDC: REQUIRED. OAuth 2.0 Client Identifier valid at the Authorization Server.
+     *
+     * DC API: The client_id parameter MUST be omitted in unsigned requests defined in Appendix
+     * A.3.1. The Wallet MUST ignore any client_id parameter that is present in an unsigned request.
+     * The client_id parameter MUST be present in signed requests defined in Appendix A.3.2,
+     * as it communicates to the wallet which Client Identifier Prefix and Client Identifier to use
+     * when authenticating the client through verification of the request signature or retrieving
+     * client metadata.
+     *
+     * See also [clientIdWithoutPrefix] and the notes there.
+     */
+    @SerialName("client_id")
+    val clientId: String? = null,
+
+    /**
+     * OAuth 2.0 JAR: REQUIRED unless `request_uri` is specified. The Request Object that holds authorization request
+     * parameters stated in Section 4 of RFC6749 (OAuth 2.0). If this parameter is present in the authorization request,
+     * `request_uri` MUST NOT be present.
+     */
+    @SerialName("request")
+    val request: String? = null,
+
+    /**
+     * OAuth 2.0 JAR: REQUIRED unless request is specified. The absolute URI, as defined by RFC3986, that is the
+     * Request Object URI referencing the authorization request parameters stated in Section 4 of RFC6749 (OAuth 2.0).
+     * If this parameter is present in the authorization request, `request` MUST NOT be present.
+     */
+    @SerialName("request_uri")
+    val requestUri: String? = null,
+
+    /**
+     * OpenID4VP: OPTIONAL. A string determining the HTTP method to be used when the [requestUri] parameter is included
+     * in the same request. Two case-sensitive valid values are defined in this specification: `get` and `post`.
+     * If [requestUriMethod] value is `get`, the Wallet MUST send the request to retrieve the Request Object using the
+     * HTTP GET method, i.e., as defined in RFC9101. If [requestUriMethod] value is `post`, a supporting Wallet MUST
+     * send the request using the HTTP POST method as detailed in Section 5.11. If the [requestUriMethod] parameter is
+     * not present, the Wallet MUST process the [requestUri] parameter as defined in RFC9101. Wallets not supporting
+     * the post method will send a GET request to the Request URI (default behavior as defined in RFC9101).
+     * [requestUriMethod] parameter MUST NOT be present if a [requestUri] parameter is not present.
+     */
+    @SerialName("request_uri_method")
+    val requestUriMethod: RequestUriMethod? = null,
+
+    @SerialName("state")
+    val state: String? = null,
+) : RequestParameters() {
+
+    @Serializable
+    enum class RequestUriMethod{
+        @SerialName("get")
+        GET,
+        @SerialName("post")
+        POST,
+    }
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParameterSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParameterSerializer.kt
@@ -14,6 +14,7 @@ object RequestParametersSerializer : JsonContentPolymorphicSerializer<RequestPar
         val parameters = element.jsonObject
         return when {
             "documentDigests" in parameters -> SignatureRequestParameters.serializer()
+            ("request" in parameters) || ("requestUri" in parameters) -> JarRequestParameters.serializer()
             else -> AuthenticationRequestParameters.serializer()
         }
     }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParameterSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParameterSerializer.kt
@@ -14,7 +14,7 @@ object RequestParametersSerializer : JsonContentPolymorphicSerializer<RequestPar
         val parameters = element.jsonObject
         return when {
             "documentDigests" in parameters -> SignatureRequestParameters.serializer()
-            ("request" in parameters) || ("requestUri" in parameters) -> JarRequestParameters.serializer()
+            ("request" in parameters) || ("request_uri" in parameters) -> JarRequestParameters.serializer()
             else -> AuthenticationRequestParameters.serializer()
         }
     }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
@@ -16,10 +16,11 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         @Serializable(JwsSignedSerializer::class)
         val jwsSigned: at.asitplus.signum.indispensable.josef.JwsSigned<T>,
         override val parameters: T,
-        val dcApiRequest: DCAPIRequest? = null
+        val verified: Boolean,
+        val dcApiRequest: DCAPIRequest? = null,
     ) : RequestParametersFrom<T>() {
         override fun toString(): String {
-            return "JwsSigned(jwsSigned=${jwsSigned.serialize()}, parameters=$parameters)"
+            return "JwsSigned(jwsSigned=${jwsSigned.serialize()}, parameters=$parameters, verified=$verified)"
         }
     }
 

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
@@ -343,7 +343,7 @@ class OAuth2KtorClient(
             url(parEndpointUrl)
             method = HttpMethod.Post
             setBody(FormDataContent(parameters {
-                setAuthRequestIntoParams(authRequest)
+                authRequest.encodeToParameters().forEach { append(it.key, it.value) }
                 append(OpenIdConstants.PARAMETER_PROMPT, OpenIdConstants.PARAMETER_PROMPT_LOGIN)
             }))
             applyAuthnForToken(oauthMetadata, popAudience, parEndpointUrl, HttpMethod.Post, false, dpopNonce)()
@@ -359,22 +359,6 @@ class OAuth2KtorClient(
             )
         }
     } ?: throw Exception("No pushedAuthorizationRequestEndpoint in $oauthMetadata")
-
-    private fun ParametersBuilder.setAuthRequestIntoParams(authRequest: RequestParameters) {
-        when (authRequest) {
-            is AuthenticationRequestParameters -> authRequest.encodeToParameters<AuthenticationRequestParameters>()
-                .forEach { append(it.key, it.value) }
-
-            is JarRequestParameters -> authRequest.encodeToParameters<JarRequestParameters>()
-                .forEach { append(it.key, it.value) }
-
-            is RequestObjectParameters -> authRequest.encodeToParameters<RequestObjectParameters>()
-                .forEach { append(it.key, it.value) }
-
-            is SignatureRequestParameters -> authRequest.encodeToParameters<SignatureRequestParameters>()
-                .forEach { append(it.key, it.value) }
-        }
-    }
 
     /**
      * Sets the appropriate headers when accessing [resourceUrl], by reading data from [tokenResponse],

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
@@ -37,7 +37,7 @@ import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.cookies.*
 import io.ktor.client.request.*
-import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.Serializable
@@ -488,7 +488,7 @@ sealed interface CredentialIssuanceResult {
 
     /**
      * Open the [url] in a browser (so the user can authenticate at the AS), and store [context] to use in next call
-     * to [at.asitplus.wallet.lib.ktor.openid.OpenId4VciClient.resumeWithAuthCode].
+     * to [OpenId4VciClient.resumeWithAuthCode].
      */
     data class OpenUrlForAuthnRequest(
         val url: String,

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClientTest.kt
@@ -6,6 +6,7 @@ import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.PushedAuthenticationResponseParameters
+import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenRequestParameters
 import at.asitplus.openid.TokenResponseParameters
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
@@ -128,9 +129,9 @@ class OAuth2KtorClientTest : FunSpec() {
                     val requestBody = request.body.toByteArray().decodeToString()
                     val queryParameters: Map<String, String> =
                         request.url.parameters.toMap().entries.associate { it.key to it.value.first() }
-                    val authnRequest: AuthenticationRequestParameters =
-                        if (requestBody.isEmpty()) queryParameters.decodeFromUrlQuery<AuthenticationRequestParameters>()
-                        else requestBody.decodeFromPostBody<AuthenticationRequestParameters>()
+                    val authnRequest: RequestParameters =
+                        if (requestBody.isEmpty()) queryParameters.decodeFromUrlQuery()
+                        else requestBody.decodeFromPostBody()
                     authorizationService.authorize(authnRequest) { catching { dummyUser() } }.fold(
                         onSuccess = { respondRedirect(it.url) },
                         onFailure = { respondOAuth2Error(it) }

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientExternalAuthorizationServerTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientExternalAuthorizationServerTest.kt
@@ -15,6 +15,7 @@ import at.asitplus.openid.OpenIdConstants.PATH_WELL_KNOWN_CREDENTIAL_ISSUER
 import at.asitplus.openid.OpenIdConstants.PATH_WELL_KNOWN_OAUTH_AUTHORIZATION_SERVER
 import at.asitplus.openid.OpenIdConstants.PATH_WELL_KNOWN_OPENID_CONFIGURATION
 import at.asitplus.openid.PushedAuthenticationResponseParameters
+import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenIntrospectionRequest
 import at.asitplus.openid.TokenIntrospectionResponse
 import at.asitplus.openid.TokenRequestParameters
@@ -302,9 +303,9 @@ class OpenId4VciClientExternalAuthorizationServerTest : FunSpec() {
                     val requestBody = request.body.toByteArray().decodeToString()
                     val queryParameters: Map<String, String> =
                         request.url.parameters.toMap().entries.associate { it.key to it.value.first() }
-                    val authnRequest: AuthenticationRequestParameters =
-                        if (requestBody.isEmpty()) queryParameters.decodeFromUrlQuery<AuthenticationRequestParameters>()
-                        else requestBody.decodeFromPostBody<AuthenticationRequestParameters>()
+                    val authnRequest: RequestParameters =
+                        if (requestBody.isEmpty()) queryParameters.decodeFromUrlQuery()
+                        else requestBody.decodeFromPostBody()
                     externalAuthorizationServer.authorize(authnRequest) { catching { dummyUser() } }.fold(
                         onSuccess = { respondRedirect(it.url) },
                         onFailure = { respondOAuth2Error(it) }

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
@@ -13,6 +13,7 @@ import at.asitplus.openid.OidcUserInfo
 import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.PushedAuthenticationResponseParameters
+import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenRequestParameters
 import at.asitplus.openid.TokenResponseParameters
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
@@ -292,9 +293,9 @@ class OpenId4VciClientTest : FunSpec() {
                     val requestBody = request.body.toByteArray().decodeToString()
                     val queryParameters: Map<String, String> =
                         request.url.parameters.toMap().entries.associate { it.key to it.value.first() }
-                    val authnRequest: AuthenticationRequestParameters =
-                        if (requestBody.isEmpty()) queryParameters.decodeFromUrlQuery<AuthenticationRequestParameters>()
-                        else requestBody.decodeFromPostBody<AuthenticationRequestParameters>()
+                    val authnRequest: RequestParameters =
+                        if (requestBody.isEmpty()) queryParameters.decodeFromUrlQuery()
+                        else requestBody.decodeFromPostBody()
                     authorizationService.authorize(authnRequest) { catching { dummyUser() } }.fold(
                         onSuccess = { respondRedirect(it.url) },
                         onFailure = { respondOAuth2Error(it) }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AuthorizationService.kt
@@ -73,24 +73,31 @@ interface AuthorizationService {
         httpRequest: RequestInfo? = null,
     ): KmmResult<PushedAuthenticationResponseParameters>
 
-    /**
-     * Builds the authentication response for this specific user from [loadUserFun]
-     * (called when request has been validated).
-     * Send this result as HTTP Header `Location` in a 302 response to the client.
-     * @return URL built from client's `redirect_uri` with `code` parameter, [KmmResult] may contain a [OAuth2Exception]
-     */
+    @Deprecated(
+        "Use authorize with RequestParameters instead",
+        ReplaceWith("authorize(input, RequestInfo(loadUserFun))")
+    )
     suspend fun authorize(
         input: JarRequestParameters,
+        loadUserFun: OAuth2LoadUserFun,
+    ): KmmResult<AuthenticationResponseResult.Redirect>
+
+    @Deprecated(
+        "Use authorize with RequestParameters instead",
+        ReplaceWith("authorize(input, RequestInfo(loadUserFun))")
+    )
+    suspend fun authorize(
+        input: AuthenticationRequestParameters,
         loadUserFun: OAuth2LoadUserFun,
     ): KmmResult<AuthenticationResponseResult.Redirect>
 
     /**
      * Builds the authentication response for this specific user from [loadUserFun].
      * Send this result as HTTP Header `Location` in a 302 response to the client.
-     * @return [KmmResult] may contain a [OAuth2Exception]
+     * @return URL built from client's `redirect_uri` with `code` parameter, [KmmResult] may contain a [OAuth2Exception]
      */
     suspend fun authorize(
-        input: AuthenticationRequestParameters,
+        input: RequestParameters,
         loadUserFun: OAuth2LoadUserFun,
     ): KmmResult<AuthenticationResponseResult.Redirect>
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AuthorizationService.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.oauth2
 
 import at.asitplus.KmmResult
 import at.asitplus.openid.AuthenticationRequestParameters
+import at.asitplus.openid.JarRequestParameters
 import at.asitplus.openid.PushedAuthenticationResponseParameters
 import at.asitplus.openid.TokenIntrospectionRequest
 import at.asitplus.openid.TokenIntrospectionResponse
@@ -54,6 +55,22 @@ interface AuthorizationService {
         httpRequest: RequestInfo? = null,
     ): KmmResult<PushedAuthenticationResponseParameters>
 
+
+    /**
+     * Pushed authorization request endpoint as defined in [RFC 9126](https://www.rfc-editor.org/rfc/rfc9126.html).
+     * Clients send their authorization request as HTTP `POST` with `application/x-www-form-urlencoded` to the AS.
+     *
+     * Responses have to be sent with HTTP status code `201`.
+     *
+     * @param request as sent from the client as `POST`
+     * @param httpRequest information about the HTTP request from the client to validate authentication
+     * @return [KmmResult] may contain a [OAuth2Exception]
+     */
+    suspend fun par(
+        request: JarRequestParameters,
+        httpRequest: RequestInfo? = null,
+    ): KmmResult<PushedAuthenticationResponseParameters>
+
     /**
      * Pushed authorization request endpoint as defined in [RFC 9126](https://www.rfc-editor.org/rfc/rfc9126.html).
      * Clients send their authorization request as HTTP `POST` with `application/x-www-form-urlencoded` to the AS.
@@ -74,6 +91,16 @@ interface AuthorizationService {
      * (called when request has been validated).
      * Send this result as HTTP Header `Location` in a 302 response to the client.
      * @return URL built from client's `redirect_uri` with `code` parameter, [KmmResult] may contain a [OAuth2Exception]
+     */
+    suspend fun authorize(
+        input: JarRequestParameters,
+        loadUserFun: OAuth2LoadUserFun,
+    ): KmmResult<AuthenticationResponseResult.Redirect>
+
+    /**
+     * Builds the authentication response for this specific user from [loadUserFun].
+     * Send this result as HTTP Header `Location` in a 302 response to the client.
+     * @return [KmmResult] may contain a [OAuth2Exception]
      */
     suspend fun authorize(
         input: AuthenticationRequestParameters,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AuthorizationService.kt
@@ -3,7 +3,6 @@ package at.asitplus.wallet.lib.oauth2
 
 import at.asitplus.KmmResult
 import at.asitplus.openid.AuthenticationRequestParameters
-import at.asitplus.openid.JarRequestParameters
 import at.asitplus.openid.PushedAuthenticationResponseParameters
 import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenIntrospectionRequest
@@ -72,15 +71,6 @@ interface AuthorizationService {
         request: RequestParameters,
         httpRequest: RequestInfo? = null,
     ): KmmResult<PushedAuthenticationResponseParameters>
-
-    @Deprecated(
-        "Use authorize with RequestParameters instead",
-        ReplaceWith("authorize(input, RequestInfo(loadUserFun))")
-    )
-    suspend fun authorize(
-        input: JarRequestParameters,
-        loadUserFun: OAuth2LoadUserFun,
-    ): KmmResult<AuthenticationResponseResult.Redirect>
 
     @Deprecated(
         "Use authorize with RequestParameters instead",

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AuthorizationService.kt
@@ -1,9 +1,11 @@
 package at.asitplus.wallet.lib.oauth2
 
+
 import at.asitplus.KmmResult
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.JarRequestParameters
 import at.asitplus.openid.PushedAuthenticationResponseParameters
+import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenIntrospectionRequest
 import at.asitplus.openid.TokenIntrospectionResponse
 import at.asitplus.openid.TokenRequestParameters
@@ -67,22 +69,7 @@ interface AuthorizationService {
      * @return [KmmResult] may contain a [OAuth2Exception]
      */
     suspend fun par(
-        request: JarRequestParameters,
-        httpRequest: RequestInfo? = null,
-    ): KmmResult<PushedAuthenticationResponseParameters>
-
-    /**
-     * Pushed authorization request endpoint as defined in [RFC 9126](https://www.rfc-editor.org/rfc/rfc9126.html).
-     * Clients send their authorization request as HTTP `POST` with `application/x-www-form-urlencoded` to the AS.
-     *
-     * Responses have to be sent with HTTP status code `201`.
-     *
-     * @param request as sent from the client as `POST`
-     * @param httpRequest information about the HTTP request from the client to validate authentication
-     * @return [KmmResult] may contain a [OAuth2Exception]
-     */
-    suspend fun par(
-        request: AuthenticationRequestParameters,
+        request: RequestParameters,
         httpRequest: RequestInfo? = null,
     ): KmmResult<PushedAuthenticationResponseParameters>
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2Client.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2Client.kt
@@ -9,6 +9,7 @@ import at.asitplus.openid.CredentialOfferGrantsAuthCode
 import at.asitplus.openid.CredentialOfferGrantsPreAuthCode
 import at.asitplus.openid.CredentialRequestProof
 import at.asitplus.openid.IssuerMetadata
+import at.asitplus.openid.JarRequestParameters
 import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.OpenIdConstants.CODE_CHALLENGE_METHOD_SHA256
@@ -89,17 +90,13 @@ class OAuth2Client(
      * @param resource from RFC 8707 Resource Indicators for OAuth 2.0, in OID4VCI flows the value
      * of [IssuerMetadata.credentialIssuer]
      * @param issuerState for OID4VCI flows the value from [CredentialOfferGrantsAuthCode.issuerState]
-     * @param audience for PAR the value of the `issuer` of the Authorization Server
-     * @param wrapAsJar whether to wrap the request as a JAR (i.e. a signed JWS with the authn request as payload)
      */
     suspend fun createAuthRequest(
         state: String,
         authorizationDetails: Set<AuthorizationDetails>? = null,
         scope: String? = null,
         resource: String? = null,
-        issuerState: String? = null,
-        audience: String? = null,
-        wrapAsJar: Boolean = true,
+        issuerState: String? = null
     ) = AuthenticationRequestParameters(
         responseType = GRANT_TYPE_CODE,
         state = state,
@@ -111,27 +108,30 @@ class OAuth2Client(
         redirectUrl = redirectUrl,
         codeChallenge = generateCodeVerifier(state),
         codeChallengeMethod = CODE_CHALLENGE_METHOD_SHA256
-    ).wrapIfNecessary(wrapAsJar, audience)
-
-    private suspend fun AuthenticationRequestParameters.wrapIfNecessary(wrapAsJar: Boolean, audience: String?) =
-        if (signPushedAuthorizationRequest != null && wrapAsJar)
-            wrapInJar(signPushedAuthorizationRequest, audience)
-        else this
-
-    private suspend fun AuthenticationRequestParameters.wrapInJar(
-        signAuthorizationRequest: SignJwtFun<AuthenticationRequestParameters>,
-        audience: String?,
-    ) = AuthenticationRequestParameters(
-        clientId = clientId,
-        request = signAuthorizationRequest(
-            JwsContentTypeConstants.OAUTH_AUTHZ_REQUEST,
-            this.copy(
-                audience = audience,
-                issuer = this.clientId,
-            ),
-            AuthenticationRequestParameters.serializer(),
-        ).getOrThrow().serialize()
     )
+
+    suspend fun createAuthRequestJar(
+        state: String,
+        authorizationDetails: Set<AuthorizationDetails>? = null,
+        scope: String? = null,
+        resource: String? = null,
+        issuerState: String? = null,
+        audience: String? = null,
+    ) = signPushedAuthorizationRequest?.let { signJwtFun ->
+        createAuthRequest(state, authorizationDetails, scope, resource, issuerState).let {
+            JarRequestParameters(
+                clientId = clientId,
+                request = signPushedAuthorizationRequest(
+                    JwsContentTypeConstants.OAUTH_AUTHZ_REQUEST,
+                    it.copy(
+                        audience = audience,
+                        issuer = it.clientId,
+                    ),
+                    AuthenticationRequestParameters.serializer(),
+                ).getOrThrow().serialize()
+            )
+        }
+    } ?: throw Exception("SignPushedAuthorizationRequest is null.")
 
     /**
      * Send the result as parameters to the server at [OAuth2AuthorizationServerMetadata.authorizationEndpoint].
@@ -142,7 +142,7 @@ class OAuth2Client(
      */
     suspend fun createAuthRequestAfterPar(
         parResponse: PushedAuthenticationResponseParameters,
-    ) = AuthenticationRequestParameters(
+    ) = JarRequestParameters(
         clientId = clientId,
         requestUri = parResponse.requestUri,
     )

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -292,7 +292,7 @@ class SimpleAuthorizationService(
     private suspend fun RequestParameters.extractPushedRequestParams() = when (this) {
         is JarRequestParameters -> run {
             require(requestUri == null) { "request_uri must not be set for PAR" }
-            requestParser.extractRequestParameterFromJAR(this)?.parameters as? AuthenticationRequestParameters
+            requestParser.extractRequest(this)?.parameters as? AuthenticationRequestParameters
                 ?: throw InvalidRequest("request must contain valid authorization request parameters")
         }
 
@@ -377,11 +377,11 @@ class SimpleAuthorizationService(
                 if (clientId != input.clientId)
                     throw InvalidRequest("client_id not matching from par: ${input.clientId} vs $clientId")
             }
-        } ?: (requestParser.extractRequestParameterFromJAR(input)?.parameters as? AuthenticationRequestParameters)
+        } ?: (requestParser.extractRequest(input)?.parameters as? AuthenticationRequestParameters)
         ?: throw InvalidRequest("could not parse request object from request")
 
-        is RequestObjectParameters -> TODO()
-        is SignatureRequestParameters -> TODO()
+        is RequestObjectParameters -> throw InvalidRequest("could not parse request object from request")
+        is SignatureRequestParameters -> throw InvalidRequest("could not parse request object from request")
     }
 
     /**

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -290,7 +290,7 @@ class SimpleAuthorizationService(
     }
 
     private suspend fun RequestParameters.extractPushedRequestParams() = when (this) {
-        is JarRequestParameters -> run {
+        is JarRequestParameters -> {
             require(requestUri == null) { "request_uri must not be set for PAR" }
             requestParser.extractRequest(this)?.parameters as? AuthenticationRequestParameters
                 ?: throw InvalidRequest("request must contain valid authorization request parameters")

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -18,10 +18,10 @@ import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH
 import at.asitplus.openid.PushedAuthenticationResponseParameters
 import at.asitplus.openid.RequestObjectParameters
-import at.asitplus.openid.TokenIntrospectionRequest
-import at.asitplus.openid.TokenIntrospectionResponse
 import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.SignatureRequestParameters
+import at.asitplus.openid.TokenIntrospectionRequest
+import at.asitplus.openid.TokenIntrospectionResponse
 import at.asitplus.openid.TokenRequestParameters
 import at.asitplus.openid.TokenResponseParameters
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
@@ -325,15 +325,6 @@ class SimpleAuthorizationService(
     )
     override suspend fun authorize(
         input: AuthenticationRequestParameters,
-        loadUserFun: OAuth2LoadUserFun,
-    ) = authorize(input as RequestParameters, loadUserFun)
-
-    @Deprecated(
-        "Use authorize with RequestParameters instead",
-        replaceWith = ReplaceWith("authorize(input, RequestInfo(loadUserFun))")
-    )
-    override suspend fun authorize(
-        input: JarRequestParameters,
         loadUserFun: OAuth2LoadUserFun,
     ) = authorize(input as RequestParameters, loadUserFun)
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
@@ -41,7 +41,7 @@ internal class AuthenticationResponseFactory(
         Fragment, null -> authnResponseFragment(request, response)
         DcApi -> responseDcApi(request, response, false)
         DcApiJwt -> responseDcApi(request, response, true)
-        is Other -> TODO()
+        is Other -> throw IllegalArgumentException("Unsupported response mode: ${request.parameters.responseMode}")
     }
 
     @Throws(OAuth2Exception::class, CancellationException::class)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthorizationResponsePreparationState.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthorizationResponsePreparationState.kt
@@ -9,5 +9,7 @@ import kotlinx.serialization.Serializable
 data class AuthorizationResponsePreparationState(
     val credentialPresentationRequest: CredentialPresentationRequest?,
     val clientMetadata: RelyingPartyMetadata?,
-    val oid4vpDCAPIRequest: Oid4vpDCAPIRequest?
+    val oid4vpDCAPIRequest: Oid4vpDCAPIRequest?,
+    /** Whether the request object has been verified (if it was signed at all) */
+    val requestObjectVerified: Boolean?,
 )

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -378,31 +378,16 @@ class OpenId4VpHolder(
             ?.let { remoteResourceRetriever(RemoteResourceRetrieverInput(it)) }
             ?.let { joseCompliantSerializer.decodeFromString(it) }
 
-    private suspend fun RequestParameters.loadCredentialRequest(): CredentialPresentationRequest? = when (this) {
-        is AuthenticationRequestParameters -> this.loadCredentialRequest()
-        else -> null
-    }
-
     private suspend fun AuthenticationRequestParameters.loadCredentialRequest(): CredentialPresentationRequest? =
         if (responseType?.contains(VP_TOKEN) == true) {
             loadPresentationDefinition()?.let { CredentialPresentationRequest.PresentationExchangeRequest(it) }
                 ?: dcqlQuery?.let { CredentialPresentationRequest.DCQLRequest(it) }
         } else null
 
-    private suspend fun RequestParameters.loadPresentationDefinition(): PresentationDefinition? = when (this) {
-        is AuthenticationRequestParameters -> this.loadPresentationDefinition()
-        else -> null
-    }
-
     private suspend fun AuthenticationRequestParameters.loadPresentationDefinition(): PresentationDefinition? =
         presentationDefinition ?: presentationDefinitionUrl
             ?.let { remoteResourceRetriever(RemoteResourceRetrieverInput(it)) }
             ?.let { vckJsonSerializer.decodeFromString(it) }
-
-    private suspend fun RequestParameters.loadClientMetadata(): RelyingPartyMetadata? = when (this) {
-        is AuthenticationRequestParameters -> this.loadClientMetadata()
-        else -> null
-    }
 
     private suspend fun AuthenticationRequestParameters.loadClientMetadata(): RelyingPartyMetadata? =
         clientMetadata ?: clientMetadataUri

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -24,6 +24,9 @@ import at.asitplus.openid.AuthenticationResponseParameters
 import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.openid.IdToken
 import at.asitplus.openid.IdTokenType
+import at.asitplus.openid.JarRequestParameters
+import at.asitplus.openid.JarRequestParameters.RequestUriMethod
+import at.asitplus.openid.JarRequestParameters.RequestUriMethod.POST
 import at.asitplus.openid.JwtVcIssuerMetadata
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.RelyingPartyMetadata
@@ -70,13 +73,13 @@ import io.ktor.http.*
 import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import kotlin.time.Clock
 import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.encodeToByteArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Clock
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -178,7 +181,7 @@ class OpenId4VpVerifier(
         data class RequestByReference(
             val walletUrl: String,
             val requestUrl: String,
-            val requestUrlMethod: String = "post",
+            val requestUrlMethod: RequestUriMethod = POST,
         ) : CreationOptions()
 
         /** Appends authentication request as signed object to [walletUrl] */
@@ -191,7 +194,7 @@ class OpenId4VpVerifier(
         data class SignedRequestByReference(
             val walletUrl: String,
             val requestUrl: String,
-            val requestUrlMethod: String = "post",
+            val requestUrlMethod: RequestUriMethod = POST,
         ) : CreationOptions()
     }
 
@@ -222,7 +225,7 @@ class OpenId4VpVerifier(
             is CreationOptions.RequestByReference -> {
                 require(clientIdScheme !is ClientIdScheme.CertificateSanDns) // per OpenID4VP d23 5.10.4
                 URLBuilder(creationOptions.walletUrl).apply {
-                    AuthenticationRequestParameters(
+                    JarRequestParameters(
                         clientId = clientIdScheme.clientId,
                         requestUri = creationOptions.requestUrl,
                         requestUriMethod = creationOptions.requestUrlMethod,
@@ -238,7 +241,7 @@ class OpenId4VpVerifier(
             is CreationOptions.SignedRequestByValue -> {
                 require(clientIdScheme !is ClientIdScheme.RedirectUri) // per OpenID4VP d23 5.10.4
                 URLBuilder(creationOptions.walletUrl).apply {
-                    AuthenticationRequestParameters(
+                    JarRequestParameters(
                         clientId = clientIdScheme.clientId,
                         request = createAuthnRequestAsSignedRequestObject(requestOptions).getOrThrow().serialize(),
                     ).encodeToParameters()
@@ -249,7 +252,7 @@ class OpenId4VpVerifier(
             is CreationOptions.SignedRequestByReference -> {
                 require(clientIdScheme !is ClientIdScheme.RedirectUri) // per OpenID4VP d23 5.10.4
                 URLBuilder(creationOptions.walletUrl).apply {
-                    AuthenticationRequestParameters(
+                    JarRequestParameters(
                         clientId = clientIdScheme.clientId,
                         requestUri = creationOptions.requestUrl,
                         requestUriMethod = creationOptions.requestUrlMethod,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesWalletService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesWalletService.kt
@@ -141,12 +141,10 @@ class RqesWalletService(
      */
     suspend fun createServiceAuthenticationRequest(
         redirectUrl: String = this.redirectUrl,
-        wrapAsPar: Boolean = false,
         optionalParameters: OAuth2RqesParameters.Optional? = null,
     ): AuthenticationRequestParameters = oauth2Client.createAuthRequest(
         state = uuid4().toString(),
         scope = RqesOauthScope.SERVICE.value,
-        wrapAsJar = wrapAsPar,
     ).enrichAuthRequest(
         redirectUrl = redirectUrl,
         optionalParameters = optionalParameters
@@ -160,13 +158,11 @@ class RqesWalletService(
         documentDigests: Collection<OAuthDocumentDigest>,
         redirectUrl: String = this.redirectUrl,
         hashAlgorithm: Digest,
-        wrapAsPar: Boolean = false,
         optionalParameters: OAuth2RqesParameters.Optional? = null,
         documentLocation: Collection<DocumentLocation>? = null,
     ): AuthenticationRequestParameters = oauth2Client.createAuthRequest(
         state = uuid4().toString(),
-        authorizationDetails = setOf(getCscAuthenticationDetails(documentDigests, hashAlgorithm, documentLocation)),
-        wrapAsJar = wrapAsPar,
+        authorizationDetails = setOf(getCscAuthenticationDetails(documentDigests, hashAlgorithm, documentLocation))
     ).enrichAuthRequest(
         redirectUrl = redirectUrl,
         optionalParameters = optionalParameters

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
@@ -4,6 +4,7 @@ import at.asitplus.catching
 import at.asitplus.openid.OidcUserInfo
 import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.openid.PushedAuthenticationResponseParameters
+import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenIntrospectionRequest
 import at.asitplus.openid.TokenResponseParameters
 import at.asitplus.signum.indispensable.josef.JsonWebToken
@@ -99,7 +100,7 @@ class OAuth2ClientAuthenticationTest : FunSpec({
         ).getOrThrow()
             .shouldBeInstanceOf<PushedAuthenticationResponseParameters>()
         val authnResponse = server
-            .authorize(client.createAuthRequestAfterPar(parResponse)) { catching { user } }
+            .authorize(client.createAuthRequestAfterPar(parResponse) as RequestParameters) { catching { user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code
@@ -196,7 +197,7 @@ class OAuth2ClientAuthenticationTest : FunSpec({
             scope = scope,
         )
 
-        val authnResponse = server.authorize(authnRequest) { catching { user } }
+        val authnResponse = server.authorize(authnRequest as RequestParameters) { catching { user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code
@@ -226,7 +227,7 @@ class OAuth2ClientAuthenticationTest : FunSpec({
             state = state,
             scope = scope,
         )
-        val authnResponse = server.authorize(authnRequest) { catching { user } }
+        val authnResponse = server.authorize(authnRequest as RequestParameters) { catching { user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
@@ -84,7 +84,7 @@ class OAuth2ClientAuthenticationTest : FunSpec({
 
     test("pushed authorization request") {
         val state = uuid4().toString()
-        val authnRequest = client.createAuthRequest(
+        val authnRequest = client.createAuthRequestJar(
             state = state,
             scope = scope,
         )
@@ -124,7 +124,7 @@ class OAuth2ClientAuthenticationTest : FunSpec({
 
     test("pushed authorization request with wrong client attestation JWT") {
         val state = uuid4().toString()
-        val authnRequest = client.createAuthRequest(
+        val authnRequest = client.createAuthRequestJar(
             state = state,
             scope = scope,
         )
@@ -151,10 +151,11 @@ class OAuth2ClientAuthenticationTest : FunSpec({
 
     test("pushed authorization request with client attestation JWT not trusted") {
         val state = uuid4().toString()
-        val authnRequest = client.createAuthRequest(
+        val authnRequest = client.createAuthRequestJar(
             state = state,
             scope = scope,
         )
+
         server = SimpleAuthorizationService(
             strategy = DummyAuthorizationServiceStrategy(scope),
             clientAuthenticationService = ClientAuthenticationService(
@@ -178,10 +179,11 @@ class OAuth2ClientAuthenticationTest : FunSpec({
 
     test("pushed authorization request without client authentication") {
         val state = uuid4().toString()
-        val authnRequest = client.createAuthRequest(
+        val authnRequest = client.createAuthRequestJar(
             state = state,
             scope = scope,
         )
+
         shouldThrow<OAuth2Exception> {
             server.par(authnRequest).getOrThrow()
         }
@@ -189,10 +191,11 @@ class OAuth2ClientAuthenticationTest : FunSpec({
 
     test("authorization code flow and client authentication") {
         val state = uuid4().toString()
-        val authnRequest = client.createAuthRequest(
+        val authnRequest = client.createAuthRequestJar(
             state = state,
             scope = scope,
         )
+
         val authnResponse = server.authorize(authnRequest) { catching { user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
@@ -219,7 +222,7 @@ class OAuth2ClientAuthenticationTest : FunSpec({
 
     test("authorization code flow without client authentication") {
         val state = uuid4().toString()
-        val authnRequest = client.createAuthRequest(
+        val authnRequest = client.createAuthRequestJar(
             state = state,
             scope = scope,
         )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientDPoPTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientDPoPTest.kt
@@ -4,6 +4,7 @@ import at.asitplus.catching
 import at.asitplus.openid.OidcUserInfo
 import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.openid.OpenIdConstants.TOKEN_TYPE_DPOP
+import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenIntrospectionRequest
 import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
@@ -57,7 +58,7 @@ class OAuth2ClientDPoPTest : FunSpec({
             state = state,
             scope = scope,
         )
-        val authnResponse = server.authorize(authnRequest) { catching { user } }
+        val authnResponse = server.authorize(authnRequest as RequestParameters) { catching { user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientDPoPTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientDPoPTest.kt
@@ -53,7 +53,7 @@ class OAuth2ClientDPoPTest : FunSpec({
     }
 
     suspend fun getCode(state: String): String {
-        val authnRequest = client.createAuthRequest(
+        val authnRequest = client.createAuthRequestJar(
             state = state,
             scope = scope,
         )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientTest.kt
@@ -57,7 +57,7 @@ class OAuth2ClientTest : FunSpec({
 
     test("process with pushed authorization request") {
         val state = uuid4().toString()
-        val authnRequest = client.createAuthRequest(
+        val authnRequest = client.createAuthRequestJar(
             state = state,
             scope = scope,
         )
@@ -87,10 +87,9 @@ class OAuth2ClientTest : FunSpec({
 
     test("process with authorization code flow, and PAR") {
         val state = uuid4().toString()
-        val authnRequest = client.createAuthRequest(
+        val authnRequest = client.createAuthRequestJar(
             state = state,
             scope = scope,
-            wrapAsJar = true
         )
         val authnResponse = server.authorize(authnRequest) { catching { user } }
             .getOrThrow()
@@ -118,8 +117,7 @@ class OAuth2ClientTest : FunSpec({
         val state = uuid4().toString()
         val authnRequest = client.createAuthRequest(
             state = state,
-            scope = scope,
-            wrapAsJar = false
+            scope = scope
         )
         val authnResponse = server.authorize(authnRequest) { catching { user } }
             .getOrThrow()
@@ -138,7 +136,7 @@ class OAuth2ClientTest : FunSpec({
 
     test("process with authorization code flow, authn request must contain scope from token request") {
         val state = uuid4().toString()
-        val authnRequest = client.createAuthRequest(
+        val authnRequest = client.createAuthRequestJar(
             state = state,
             scope = scope,
         )
@@ -160,7 +158,7 @@ class OAuth2ClientTest : FunSpec({
 
     test("process with authorization code flow, no scope in token request") {
         val state = uuid4().toString()
-        val authnRequest = client.createAuthRequest(
+        val authnRequest = client.createAuthRequestJar(
             state = state,
             scope = scope,
         )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientTest.kt
@@ -63,7 +63,8 @@ class OAuth2ClientTest : FunSpec({
         )
         val parResponse = server.par(authnRequest).getOrThrow()
             .shouldBeInstanceOf<PushedAuthenticationResponseParameters>()
-        val authnResponse = server.authorize(client.createAuthRequestAfterPar(parResponse)) { catching { user } }
+        val input = client.createAuthRequestAfterPar(parResponse) as RequestParameters
+        val authnResponse = server.authorize(input) { catching { user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code
@@ -91,7 +92,7 @@ class OAuth2ClientTest : FunSpec({
             state = state,
             scope = scope,
         )
-        val authnResponse = server.authorize(authnRequest) { catching { user } }
+        val authnResponse = server.authorize(authnRequest as RequestParameters) { catching { user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code
@@ -119,7 +120,7 @@ class OAuth2ClientTest : FunSpec({
             state = state,
             scope = scope
         )
-        val authnResponse = server.authorize(authnRequest) { catching { user } }
+        val authnResponse = server.authorize(authnRequest as RequestParameters) { catching { user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code
@@ -140,7 +141,7 @@ class OAuth2ClientTest : FunSpec({
             state = state,
             scope = scope,
         )
-        val authnResponse = server.authorize(authnRequest) { catching { user } }
+        val authnResponse = server.authorize(authnRequest as RequestParameters) { catching { user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code
@@ -162,7 +163,7 @@ class OAuth2ClientTest : FunSpec({
             state = state,
             scope = scope,
         )
-        val authnResponse = server.authorize(authnRequest) { catching { user } }
+        val authnResponse = server.authorize(authnRequest as RequestParameters) { catching { user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciAttestationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciAttestationTest.kt
@@ -40,7 +40,7 @@ class OidvciAttestationTest : FunSpec({
     lateinit var state: String
 
     suspend fun getToken(scope: String): TokenResponseParameters {
-        val authnRequest = client.oauth2Client.createAuthRequest(
+        val authnRequest = client.oauth2Client.createAuthRequestJar(
             state = state,
             scope = scope,
             resource = issuer.metadata.credentialIssuer

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciAttestationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciAttestationTest.kt
@@ -3,6 +3,7 @@ package at.asitplus.wallet.lib.oidvci
 import at.asitplus.catching
 import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.openid.OpenIdConstants
+import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenResponseParameters
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.signum.indispensable.josef.KeyAttestationJwt
@@ -45,7 +46,8 @@ class OidvciAttestationTest : FunSpec({
             scope = scope,
             resource = issuer.metadata.credentialIssuer
         )
-        val authnResponse = authorizationService.authorize(authnRequest) { catching { dummyUser() } }
+        val input = authnRequest as RequestParameters
+        val authnResponse = authorizationService.authorize(input) { catching { dummyUser() } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciCodeFlowTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciCodeFlowTest.kt
@@ -73,7 +73,7 @@ class OidvciCodeFlowTest : FreeSpec({
     }
 
     suspend fun getToken(scope: String, setScopeInTokenRequest: Boolean = true): TokenResponseParameters {
-        val authnRequest = client.oauth2Client.createAuthRequest(
+        val authnRequest = client.oauth2Client.createAuthRequestJar(
             state = state,
             scope = scope,
             resource = issuer.metadata.credentialIssuer
@@ -97,7 +97,7 @@ class OidvciCodeFlowTest : FreeSpec({
         authorizationDetails: Set<AuthorizationDetails>,
         setAuthnDetailsInTokenRequest: Boolean = true,
     ): TokenResponseParameters {
-        val authnRequest = client.oauth2Client.createAuthRequest(
+        val authnRequest = client.oauth2Client.createAuthRequestJar(
             state = state,
             authorizationDetails = authorizationDetails
         )
@@ -300,7 +300,7 @@ class OidvciCodeFlowTest : FreeSpec({
         val tokenScope =
             client.selectSupportedCredentialFormat(RequestOptions(AtomicAttribute2023, ISO_MDOC), issuer.metadata)
                 ?.scope.shouldNotBeNull()
-        val authnRequest = client.oauth2Client.createAuthRequest(
+        val authnRequest = client.oauth2Client.createAuthRequestJar(
             state = state,
             scope = authCodeScope,
             resource = issuer.metadata.credentialIssuer
@@ -383,7 +383,7 @@ class OidvciCodeFlowTest : FreeSpec({
             credentialConfigurationId = AtomicAttribute2023.toCredentialIdentifier(ISO_MDOC),
             authorizationServers = issuer.metadata.authorizationServers
         )
-        val authnRequest = client.oauth2Client.createAuthRequest(
+        val authnRequest = client.oauth2Client.createAuthRequestJar(
             state = state,
             authorizationDetails = authCodeAuthnDetails
         )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciCodeFlowTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciCodeFlowTest.kt
@@ -8,6 +8,7 @@ import at.asitplus.openid.CredentialRequestParameters
 import at.asitplus.openid.CredentialRequestProofContainer
 import at.asitplus.openid.CredentialResponseSingleCredential
 import at.asitplus.openid.OpenIdAuthorizationDetails
+import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.SupportedCredentialFormat
 import at.asitplus.openid.TokenResponseParameters
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
@@ -78,7 +79,8 @@ class OidvciCodeFlowTest : FreeSpec({
             scope = scope,
             resource = issuer.metadata.credentialIssuer
         )
-        val authnResponse = authorizationService.authorize(authnRequest) { catching { DummyUserProvider.user } }
+        val input = authnRequest as RequestParameters
+        val authnResponse = authorizationService.authorize(input) { catching { DummyUserProvider.user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code
@@ -101,7 +103,8 @@ class OidvciCodeFlowTest : FreeSpec({
             state = state,
             authorizationDetails = authorizationDetails
         )
-        val authnResponse = service.authorize(authnRequest) { catching { DummyUserProvider.user } }
+        val input = authnRequest as RequestParameters
+        val authnResponse = service.authorize(input) { catching { DummyUserProvider.user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code
@@ -305,7 +308,8 @@ class OidvciCodeFlowTest : FreeSpec({
             scope = authCodeScope,
             resource = issuer.metadata.credentialIssuer
         )
-        val authnResponse = authorizationService.authorize(authnRequest) { catching { DummyUserProvider.user } }
+        val input = authnRequest as RequestParameters
+        val authnResponse = authorizationService.authorize(input) { catching { DummyUserProvider.user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code
@@ -387,7 +391,8 @@ class OidvciCodeFlowTest : FreeSpec({
             state = state,
             authorizationDetails = authCodeAuthnDetails
         )
-        val authnResponse = authorizationService.authorize(authnRequest) { catching { DummyUserProvider.user } }
+        val input = authnRequest as RequestParameters
+        val authnResponse = authorizationService.authorize(input) { catching { DummyUserProvider.user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciEncryptionTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciEncryptionTest.kt
@@ -35,7 +35,7 @@ class OidvciEncryptionTest : FunSpec({
     lateinit var state: String
 
     suspend fun getToken(scope: String): TokenResponseParameters {
-        val authnRequest = client.oauth2Client.createAuthRequest(
+        val authnRequest = client.oauth2Client.createAuthRequestJar(
             state = state,
             scope = scope,
             resource = issuer.metadata.credentialIssuer

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciEncryptionTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciEncryptionTest.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.oidvci
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
+import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenResponseParameters
 import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JweEncrypted
@@ -40,7 +41,8 @@ class OidvciEncryptionTest : FunSpec({
             scope = scope,
             resource = issuer.metadata.credentialIssuer
         )
-        val authnResponse = authorizationService.authorize(authnRequest) { catching { DummyUserProvider.user } }
+        val input = authnRequest as RequestParameters
+        val authnResponse = authorizationService.authorize(input) { catching { DummyUserProvider.user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciOfferCodeTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciOfferCodeTest.kt
@@ -48,7 +48,7 @@ class OidvciOfferCodeTest : FreeSpec({
         credentialOffer: CredentialOffer,
         scope: String,
     ): TokenResponseParameters {
-        val authnRequest = client.oauth2Client.createAuthRequest(
+        val authnRequest = client.oauth2Client.createAuthRequestJar(
             state = state,
             scope = scope,
             resource = issuer.metadata.credentialIssuer,
@@ -72,7 +72,7 @@ class OidvciOfferCodeTest : FreeSpec({
         credentialOffer: CredentialOffer,
         authorizationDetails: Set<AuthorizationDetails>,
     ): TokenResponseParameters {
-        val authnRequest = client.oauth2Client.createAuthRequest(
+        val authnRequest = client.oauth2Client.createAuthRequestJar(
             state = state,
             authorizationDetails = authorizationDetails,
             issuerState = credentialOffer.grants?.authorizationCode.shouldNotBeNull().issuerState
@@ -118,7 +118,7 @@ class OidvciOfferCodeTest : FreeSpec({
         val credentialIdToRequest = credentialOffer.configurationIds.first()
         val credentialFormat =
             issuer.metadata.supportedCredentialConfigurations!![credentialIdToRequest].shouldNotBeNull()
-        val authnRequest = client.oauth2Client.createAuthRequest(
+        val authnRequest = client.oauth2Client.createAuthRequestJar(
             state = state,
             scope = credentialFormat.scope.shouldNotBeNull(),
             resource = issuer.metadata.credentialIssuer,

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciOfferCodeTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciOfferCodeTest.kt
@@ -3,6 +3,7 @@ package at.asitplus.wallet.lib.oidvci
 import at.asitplus.catching
 import at.asitplus.openid.AuthorizationDetails
 import at.asitplus.openid.CredentialOffer
+import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenResponseParameters
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.RandomSource
@@ -54,7 +55,8 @@ class OidvciOfferCodeTest : FreeSpec({
             resource = issuer.metadata.credentialIssuer,
             issuerState = credentialOffer.grants?.authorizationCode.shouldNotBeNull().issuerState
         )
-        val authnResponse = authorizationService.authorize(authnRequest) { catching { DummyUserProvider.user } }
+        val input = authnRequest as RequestParameters
+        val authnResponse = authorizationService.authorize(input) { catching { DummyUserProvider.user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code
@@ -77,7 +79,8 @@ class OidvciOfferCodeTest : FreeSpec({
             authorizationDetails = authorizationDetails,
             issuerState = credentialOffer.grants?.authorizationCode.shouldNotBeNull().issuerState
         )
-        val authnResponse = authorizationService.authorize(authnRequest) { catching { DummyUserProvider.user } }
+        val input = authnRequest as RequestParameters
+        val authnResponse = authorizationService.authorize(input) { catching { DummyUserProvider.user } }
             .getOrThrow()
             .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
         val code = authnResponse.params.code
@@ -126,7 +129,7 @@ class OidvciOfferCodeTest : FreeSpec({
         )
         shouldThrow<OAuth2Exception> {
             authorizationService
-                .authorize(authnRequest) { catching { DummyUserProvider.user } }
+                .authorize(authnRequest as RequestParameters) { catching { DummyUserProvider.user } }
                 .getOrThrow()
         }
     }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.openid
 
 import at.asitplus.dif.DifInputDescriptor
 import at.asitplus.openid.AuthenticationRequestParameters
+import at.asitplus.openid.JarRequestParameters
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.HolderAgent
@@ -75,7 +76,7 @@ class AuthenticationRequestParameterFromSerializerTest : FreeSpec({
             val authnRequestUrl = verifierOid4vp.createAuthnRequest(
                 reqOptions, OpenId4VpVerifier.CreationOptions.SignedRequestByValue(walletUrl)
             ).getOrThrow().url
-            val interim1: AuthenticationRequestParameters =
+            val interim1: JarRequestParameters =
                 Url(authnRequestUrl).encodedQuery.decodeFromUrlQuery()
             interim1.clientId shouldBe clientId
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.openid
 
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.AuthenticationResponseParameters
+import at.asitplus.openid.JarRequestParameters
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.josef.JwsSigned
@@ -190,7 +191,7 @@ class PreRegisteredClientTest : FreeSpec({
         val authnRequestUrl = verifierOid4vp.createAuthnRequest(
             defaultRequestOptions, OpenId4VpVerifier.CreationOptions.SignedRequestByValue(walletUrl)
         ).getOrThrow().url
-        val authnRequest: AuthenticationRequestParameters =
+        val authnRequest: JarRequestParameters =
             Url(authnRequestUrl).encodedQuery.decodeFromUrlQuery()
         authnRequest.clientId shouldBe clientId
         val jar = authnRequest.request

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/QtspAuthorizationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/QtspAuthorizationTest.kt
@@ -3,6 +3,7 @@ package io.kotest.provided.at.asitplus.wallet.lib.rqes
 import at.asitplus.catching
 import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.openid.OpenIdAuthorizationDetails
+import at.asitplus.openid.RequestParameters
 import at.asitplus.signum.indispensable.Digest
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
@@ -31,7 +32,7 @@ class QtspAuthorizationTest : FreeSpec({
             authorizationDetails = setOf(OpenIdAuthorizationDetails())
         )
         shouldThrow<OAuth2Exception.InvalidAuthorizationDetails> {
-            qtspAuthenticationService.authorize(serviceAuthReq) { catching { dummyUser() } }
+            qtspAuthenticationService.authorize(serviceAuthReq as RequestParameters) { catching { dummyUser() } }
                 .getOrThrow()
         }
     }
@@ -41,8 +42,10 @@ class QtspAuthorizationTest : FreeSpec({
             documentDigests = dummyDataProvider.buildDocumentDigests(),
             hashAlgorithm = Digest.SHA256
         )
-        val redirectUrlParam = Url(qtspAuthenticationService.authorize(credentialAuthReq) { catching { dummyUser() } }
-            .getOrThrow().url).parameters
+        val authorize =
+            qtspAuthenticationService.authorize(credentialAuthReq as RequestParameters) { catching { dummyUser() } }
+                .getOrThrow()
+        val redirectUrlParam = Url(authorize.url).parameters
         val credentialTokenReq = walletService.createOAuth2TokenRequest(
             state = redirectUrlParam["state"] ?: throw Exception("No state in URL"),
             authorization = OAuth2Client.AuthorizationForToken.Code(

--- a/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesOpenId4VpHolder.kt
+++ b/vck-rqes/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/RqesOpenId4VpHolder.kt
@@ -131,12 +131,10 @@ class RqesOpenId4VpHolder(
      */
     suspend fun createServiceAuthenticationRequest(
         redirectUrl: String = this.redirectUrl,
-        wrapAsPar: Boolean = false,
         optionalParameters: OAuth2RqesParameters.Optional? = null,
     ): AuthenticationRequestParameters = oauth2Client.createAuthRequest(
         state = uuid4().toString(),
         scope = RqesOauthScope.SERVICE.value,
-        wrapAsJar = wrapAsPar,
     ).enrichAuthRequest(
         redirectUrl = redirectUrl,
         optionalParameters = optionalParameters
@@ -156,7 +154,6 @@ class RqesOpenId4VpHolder(
     ): AuthenticationRequestParameters = oauth2Client.createAuthRequest(
         state = uuid4().toString(),
         authorizationDetails = setOf(getCscAuthenticationDetails(documentDigests, hashAlgorithm, documentLocation)),
-        wrapAsJar = wrapAsPar,
     ).enrichAuthRequest(
         redirectUrl = redirectUrl,
         optionalParameters = optionalParameters


### PR DESCRIPTION
Introduces `JarRequestParameters` to distinguish between an authn request by value (existing `AuthenticationRequestParameters`, containing the parameters directly) and an authn request by reference (the new class `JarRequestParameters`).

Work mainly done by @n0900, rebased from https://github.com/a-sit-plus/vck/pull/373

See also https://github.com/a-sit-plus/vck/pull/400