### PR TITLE
Introduce unified calculation of Iso DeviceSignature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Release 8.0.0 (unreleased):
 - Credentials:
     - In `SubjectCredentialStore.StoreEntry` make the `schemeIdentifier` non-nullable. Deserialization of old previously stored entries need to be handled by calling applications.
     - Derive SD-JWT Digital Credentials API identifiers from the JWT ID or serialized credential instead of the subject
+- Verifiable Presentations:
+    - Compute ISO mDoc `DeviceAuthentication` signatures automatically using the `calcIsoSessionTranscript` callback instead of requiring `calcIsoDeviceSignaturePlain` 
+    - Replace `PresentationRequestParameters.calcIsoDeviceSignaturePlain` with the PresentationRequestParameters.calcIsoSessionTranscript` callback to return a nullable `SessionTranscript?`. DeviceSignature and DeviceAuth is now calculated based on the Transcript.
+    - Add optional `signDeviceAuthDetached` parameter to `HolderAgent` and `VerifiablePresentationFactory` to centralize ISO mDoc device authentication within the holder
 - OpenID for Verifiable Presentations:
     - Remove support for Presentation Exchange, since OpenID4VP 1.0 only supports DCQL
     - Implement direct presentation requests and responses according to ISO 18013-5 Device Retrieval with new subtypes `CredentialPresentationRequest.IsoDeviceRetrieval`, `CredentialPresentation.IsoDeviceRetrievalPresentation`, `IsoDeviceRetrievalMatchingResult` for `CredentialMatchingResult`, `HolderIsoDeviceRetrievalQueryMatchingResult` for `HolderPresentationRequestMatchingResult`, and `PresentationResponseParameters.DeviceRetrievalParameters`
@@ -32,6 +36,7 @@ Release 8.0.0 (unreleased):
     - Add `VerifyJwsObjectTrusted` and `VerifyCoseSignatureTrusted`, where the supplied keys are the only accepted signers
     - Note that neither builds a certificate path to a trust anchor, they compare public keys
     - In `ValidatorSdJwt.verifyVpSdJwt()` reject presentations whose SD-JWT carries no `cnf`: the key binding JWT used to be verified against a key asserted in its own header in that case, which proves nothing about the holder
+    - Delegate ISO mDoc device authentication calculation directly to the holder during OpenID4VP and DCAPI presentation creation
 - Deprecations:
     - Remove code deprecated in 7.0.0, e.g. various `Iso180137AnnexC*` and related classes
     - Deprecate all classes used for Presentation Exchange requests and so on, e.g., `CredentialPresentationRequest.PresentationExchangeRequest` or `PresentationExchangeCredentialDisclosure` or `CredentialPresentation.PresentationExchangePresentation`
@@ -40,6 +45,9 @@ Release 8.0.0 (unreleased):
     - In `NonceChallengeVerifier` deprecate `verifyPresentationSdJwt()`, `verifyPresentationVcJwt()` and `verifyPresentationIsoMdoc()`, which take the challenge from the presentation itself, to be replaced with `consumeChallenge()` and the returned `ChallengeSession`
     - `NonceChallengeVerifier` does not implement `Verifier` and `NonceService` anymore, so a presentation cannot be verified without accounting for the challenge it answers; use the `ChallengeSession` from `consumeChallenge()`, or the properties `verifier` for challenge-free verification and `nonceService` for raw nonce access
     - Deprecate passing `publicKeyLookup` to `VerifyJwsObject` and `VerifyCoseSignature`, callers are rerouted to the trusted variants, use `VerifyJwsObjectTrusted` resp. `VerifyCoseSignatureTrusted` explicitly, or drop the parameter to keep verifying against the asserted key
+    - Deprecate `PresentationRequestParameters.calcIsoDeviceSignaturePlain` in favor of computing device signatures automatically via `calcIsoSessionTranscript`
+    - Deprecate the `NonceChallengeVerifier.createPresentationRequest()` overload accepting `calcIsoDeviceSignaturePlain`
+    - Deprecate `signDeviceAuthDetached` parameter in `buildEncryptedResponse()`, `OpenId4VpHolder`, and `Iso180137AnnexCHolder`, as device authentication signature functions are now managed internally by the holder
 - Refactorings:
     - In ISO data classes like `DeviceResponse`, `DeviceRequest`, `MobileSecurityObject` replace the String `version` with a typed `parsedVersion` from [kotlin-semver](https://github.com/z4kn4fein/kotlin-semver)
     - In ISO data class `MobileSecurityObject` replace the String `digestAlgorithm` with a typed `digest` from Signum

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/Iso180137AnnexCHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/Iso180137AnnexCHolder.kt
@@ -25,9 +25,18 @@ import kotlin.jvm.JvmOverloads
 class Iso180137AnnexCHolder @JvmOverloads constructor(
     private val keyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
     private val holder: Holder = HolderAgent(keyMaterial),
-    private val signDeviceAuthDetached: SignCoseDetachedFun<ByteArray> =
-        SignCoseDetached(keyMaterial, CoseHeaderNone(), CoseHeaderNone()),
 ) {
+    @Deprecated(
+        message = "signDeviceAuthDetached is no longer explicitly used by " +
+                "IsoMdocDcapiResponseBuilder.buildEncryptedResponse and has been removed",
+        replaceWith = ReplaceWith( expression = "Iso180137AnnexCHolder(keyMaterial, holder)", ),
+    )
+    constructor(keyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
+                holder: Holder = HolderAgent(keyMaterial),
+                signDeviceAuthDetached: SignCoseDetachedFun<ByteArray> = SignCoseDetached(
+                    keyMaterial, CoseHeaderNone(), CoseHeaderNone()
+                )
+    ) : this(keyMaterial, holder)
 
     /** Adapts the Annex C device request to the presentation model used by VC-K's credential matcher. */
     fun createPresentationRequest(
@@ -60,9 +69,7 @@ class Iso180137AnnexCHolder @JvmOverloads constructor(
         IsoMdocDcapiResponseBuilder.buildEncryptedResponse(
             credentialPresentation = credentialPresentation,
             isoMdocWalletRequest = request,
-            keyMaterial = keyMaterial,
             holder = holder,
-            signDeviceAuthDetached = signDeviceAuthDetached,
         )
     }
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/IsoMdocDcapiResponseBuilder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/IsoMdocDcapiResponseBuilder.kt
@@ -49,10 +49,7 @@ object IsoMdocDcapiResponseBuilder {
     suspend fun buildEncryptedResponse(
         credentialPresentation: CredentialPresentation.IsoDeviceRetrievalPresentation,
         isoMdocWalletRequest: RequestParametersFrom.IsoMdocDcApi,
-        keyMaterial: KeyMaterial,
         holder: Holder,
-        signDeviceAuthDetached: SignCoseDetachedFun<ByteArray> =
-            SignCoseDetached(keyMaterial, CoseHeaderNone(), CoseHeaderNone()),
     ): EncryptedResponse {
         val sessionTranscript = sessionTranscriptFor(isoMdocWalletRequest)
         val isoMdocRequest = isoMdocWalletRequest.parameters.isoMdocRequest
@@ -95,4 +92,20 @@ object IsoMdocDcapiResponseBuilder {
         )
         return EncryptedResponse(TYPE_DCAPI, encryptedResponseData)
     }
+
+    @Deprecated(
+        message = "signDeviceAuthDetached and keyMaterial are no longer needed and have been removed" +
+                " because Iso DeviceSignature computation has been moved into Holder's presentation creation.",
+        replaceWith = ReplaceWith(
+            expression = "buildEncryptedResponse(credentialPresentation, isoMdocWalletRequest, holder)",
+        )
+    )
+    suspend fun buildEncryptedResponse(
+        credentialPresentation: CredentialPresentation.IsoDeviceRetrievalPresentation,
+        isoMdocWalletRequest: RequestParametersFrom.IsoMdocDcApi,
+        keyMaterial: KeyMaterial,
+        holder: Holder,
+        signDeviceAuthDetached: SignCoseDetachedFun<ByteArray> =
+            SignCoseDetached(keyMaterial, CoseHeaderNone(), CoseHeaderNone()),
+    ) = buildEncryptedResponse(credentialPresentation, isoMdocWalletRequest, holder)
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/IsoMdocDcapiResponseBuilder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/IsoMdocDcapiResponseBuilder.kt
@@ -5,29 +5,23 @@ import at.asitplus.dcapi.DCAPIHandover.Companion.TYPE_DCAPI
 import at.asitplus.dcapi.DCAPIInfo
 import at.asitplus.dcapi.EncryptedResponse
 import at.asitplus.dcapi.EncryptedResponseData
-import at.asitplus.iso.DeviceAuthentication
 import at.asitplus.iso.SessionTranscript
 import at.asitplus.iso.serializeOrigin
 import at.asitplus.iso.sha256
-import at.asitplus.iso.wrapInCborTag
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.CryptoPublicKey
-import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.supreme.asymmetric.HPKE
 import at.asitplus.wallet.lib.agent.Holder
 import at.asitplus.wallet.lib.agent.KeyMaterial
-import at.asitplus.wallet.lib.agent.PresentationException
 import at.asitplus.wallet.lib.agent.PresentationRequestParameters
 import at.asitplus.wallet.lib.agent.PresentationResponseParameters
 import at.asitplus.wallet.lib.cbor.CoseHeaderNone
 import at.asitplus.wallet.lib.cbor.SignCoseDetached
 import at.asitplus.wallet.lib.cbor.SignCoseDetachedFun
 import at.asitplus.wallet.lib.data.CredentialPresentation
-import io.github.aakira.napier.Napier
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import kotlinx.serialization.builtins.ByteArraySerializer
 import kotlinx.serialization.encodeToByteArray
 
 /** Low-level ISO/IEC 18013-7 Annex C device-response construction used by [Iso180137AnnexCHolder]. */
@@ -65,31 +59,12 @@ object IsoMdocDcapiResponseBuilder {
         val callingOrigin = isoMdocWalletRequest.callingOrigin.serializeOrigin()
             ?: throw IllegalArgumentException("Invalid calling origin")
 
-        val calcSessionTranscript = { sessionTranscript }
         val presentationResult = holder.createPresentation(
             request = PresentationRequestParameters(
                 nonce = isoMdocRequest.encryptionInfo.encryptionParameters.nonce
                     ?.encodeToString(Base64UrlStrict) ?: throw IllegalArgumentException("no nonce"),
                 audience = callingOrigin,
-                calcIsoSessionTranscript = calcSessionTranscript,
-                calcIsoDeviceSignaturePlain = { input ->
-                    val deviceAuthentication = DeviceAuthentication(
-                        type = DeviceAuthentication.TYPE,
-                        sessionTranscript = calcSessionTranscript(),
-                        docType = input.docType,
-                        namespaces = input.deviceNameSpaceBytes
-                    )
-
-                    val deviceAuthenticationBytes = coseCompliantSerializer
-                        .encodeToByteArray(ByteStringWrapper(deviceAuthentication))
-                        .wrapInCborTag(24)
-                    Napier.d("Device authentication signature input is ${deviceAuthenticationBytes.toHexString()}")
-                    signDeviceAuthDetached(null, null, deviceAuthenticationBytes, ByteArraySerializer())
-                        .getOrElse { e ->
-                            Napier.w("Could not create DeviceAuth for presentation", e)
-                            throw PresentationException(e)
-                        }
-                },
+                calcIsoSessionTranscript = { sessionTranscript },
                 returnOneDeviceResponse = true,
             ),
             credentialPresentation = credentialPresentation,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -80,6 +80,9 @@ class OpenId4VpHolder @JvmOverloads constructor(
     /** Advertised in [metadata] and compared against holder's requirements. */
     private val supportedAlgorithms: Set<SignatureAlgorithm> = setOf(SignatureAlgorithm.ECDSAwithSHA256),
     /** Signs the session transcript for mDoc responses. */
+    @Deprecated("signDeviceAuthDetached no longer has any effect because ISO Device signature" +
+            "creation has been moved into Holder's credential presentation. " +
+            "Signing function can be overridden in HolderAgent instead.")
     private val signDeviceAuthDetached: SignCoseDetachedFun<ByteArray> =
         SignCoseDetached(keyMaterial, CoseHeaderNone(), CoseHeaderNone()),
     @Deprecated("Support for SIOPv2 has been removed")
@@ -139,12 +142,8 @@ class OpenId4VpHolder @JvmOverloads constructor(
         encryptResponse = encryptJarm,
         randomSource = randomSource
     )
-    @Suppress("DEPRECATION")
-    private val presentationFactory = PresentationFactory(
-        supportedAlgorithms = supportedAlgorithms,
-        signDeviceAuthDetached = signDeviceAuthDetached,
-        signIdToken = signIdToken
-    )
+
+    private val presentationFactory = PresentationFactory(supportedAlgorithms)
 
     val metadata: OAuth2AuthorizationServerMetadata by lazy {
         OAuth2AuthorizationServerMetadata(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/PresentationFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/PresentationFactory.kt
@@ -3,19 +3,12 @@ package at.asitplus.wallet.lib.openid
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.dif.ClaimFormat
-import at.asitplus.iso.DeviceAuthentication
-import at.asitplus.iso.DeviceNameSpaces
-import at.asitplus.iso.SessionTranscript
-import at.asitplus.iso.wrapInCborTag
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.IdToken
 import at.asitplus.openid.OpenIdConstants.VP_TOKEN
 import at.asitplus.openid.VpFormatsSupported
 import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.cosef.CoseAlgorithm
-import at.asitplus.signum.indispensable.cosef.CoseSigned
-import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
-import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.cosef.toCoseAlgorithm
 import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JwsAlgorithm
@@ -32,12 +25,6 @@ import at.asitplus.wallet.lib.extensions.getEncryptionTargetKey
 import at.asitplus.wallet.lib.jws.SignJwtFun
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.*
-import io.github.aakira.napier.Napier
-import io.matthewnelson.encoding.base16.Base16
-import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import kotlinx.serialization.builtins.ByteArraySerializer
-import kotlinx.serialization.encodeToByteArray
-import kotlin.coroutines.cancellation.CancellationException
 
 internal class PresentationFactory(
     private val supportedAlgorithms: Set<SignatureAlgorithm>,
@@ -83,12 +70,6 @@ internal class PresentationFactory(
             audience = state.audience,
             transactionData = state.request.parameters.transactionData,
             calcIsoSessionTranscript = sessionTranscriptCallback,
-            calcIsoDeviceSignaturePlain = {
-                calcDeviceSignature(
-                    sessionTranscriptCallback = sessionTranscriptCallback,
-                    docType = it.docType,
-                )
-            }
         )
 
         holder.createPresentation(
@@ -110,27 +91,6 @@ internal class PresentationFactory(
             is DeviceRetrievalParameters ->
                 throw InvalidRequest("ISO Device Retrieval responses are not OpenID4VP presentations")
         }
-    }
-
-    /**
-     * Performs calculation of the [SessionTranscript] and [DeviceAuthentication], according to OpenID4VP 1.0
-     */
-    @Throws(PresentationException::class, CancellationException::class)
-    private suspend fun calcDeviceSignature(
-        sessionTranscriptCallback: suspend () -> SessionTranscript,
-        docType: String,
-    ): CoseSigned<ByteArray> = signDeviceAuthDetached(
-        protectedHeader = null,
-        unprotectedHeader = null,
-        payload = DeviceAuthentication(
-            type = DeviceAuthentication.TYPE,
-            sessionTranscript = sessionTranscriptCallback.invoke(),
-            docType = docType,
-            namespaces = ByteStringWrapper(DeviceNameSpaces(mapOf()))
-        ).wrap(),
-        serializer = ByteArraySerializer()
-    ).getOrElse {
-        throw PresentationException("signDeviceAuthDetached failed", it)
     }
 
     internal fun calcSessionTranscript(
@@ -160,13 +120,6 @@ internal class PresentationFactory(
     } else {
         throw PresentationException("Neither dcApiRequest nor clientId is set")
     }
-
-    private fun DeviceAuthentication.wrap(): ByteArray = coseCompliantSerializer
-        .encodeToByteArray(ByteStringWrapper(this))
-        .wrapInCborTag(24)
-        .also {
-            Napier.d("Device authentication signature input is ${it.encodeToString(Base16())}")
-        }
 
     @Throws(OAuth2Exception::class)
     private fun AuthenticationRequestParameters.verifyResponseType() {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/PresentationFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/PresentationFactory.kt
@@ -28,10 +28,18 @@ import at.asitplus.wallet.lib.oidvci.OAuth2Exception.*
 
 internal class PresentationFactory(
     private val supportedAlgorithms: Set<SignatureAlgorithm>,
-    private val signDeviceAuthDetached: SignCoseDetachedFun<ByteArray>,
-    @Deprecated("Support for SIOPv2 has been removed")
-    private val signIdToken: SignJwtFun<IdToken>,
 ) {
+
+    @Deprecated(
+        message = "signDeviceAuthDetached is no longer used, because Iso Device Signature has been moved into" +
+                " Holder's presentation creation. Support for SIOPv2 has been removed",
+        replaceWith = ReplaceWith( expression = "PresentationFactory(supportedAlgorithms)", ),
+    )
+    constructor(
+        supportedAlgorithms: Set<SignatureAlgorithm>,
+        signDeviceAuthDetached:  SignCoseDetachedFun<ByteArray>,
+        signIdToken: SignJwtFun<IdToken>
+    ) : this(supportedAlgorithms)
 
     private val dcApiSessionTranscript = DcApiSessionTranscriptCalculator()
     private val urlSessionTranscript = UrlSessionTranscriptCalculator()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/IsoMdocDcapiResponseBuilderTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/IsoMdocDcapiResponseBuilderTest.kt
@@ -158,7 +158,6 @@ val IsoMdocDcapiResponseBuilderTest by matrixSuite {
             credentialPresentation = fixture.presentationRequestBuilder.toIsoDeviceRetrievalRequest()
                 .toCredentialPresentation() as CredentialPresentation.IsoDeviceRetrievalPresentation,
             isoMdocWalletRequest = fixture.walletRequest,
-            keyMaterial = holderKey,
             holder = holderAgent,
         )
 
@@ -211,7 +210,6 @@ val IsoMdocDcapiResponseBuilderTest by matrixSuite {
             credentialPresentation = fixture.presentationRequestBuilder.toIsoDeviceRetrievalRequest()
                 .toCredentialPresentation() as CredentialPresentation.IsoDeviceRetrievalPresentation,
             isoMdocWalletRequest = fixture.walletRequest,
-            keyMaterial = holderKey,
             holder = holderAgent,
         )
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PresentationFactoryTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PresentationFactoryTest.kt
@@ -11,11 +11,6 @@ import at.asitplus.signum.indispensable.josef.JwsAlgorithm
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
-import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
-import at.asitplus.wallet.lib.cbor.CoseHeaderNone
-import at.asitplus.wallet.lib.cbor.SignCoseDetached
-import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
-import at.asitplus.wallet.lib.jws.SignJwt
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.encodeToHexString
@@ -24,11 +19,8 @@ val PresentationFactoryTest by matrixSuite {
 
     fixture {
         object {
-            private val keyMaterial = EphemeralKeyWithoutCert()
             val presentationFactory = PresentationFactory(
-                supportedAlgorithms = setOf(SignatureAlgorithm.ECDSAwithSHA256),
-                signDeviceAuthDetached = SignCoseDetached(keyMaterial, CoseHeaderNone(), CoseHeaderNone()),
-                signIdToken = SignJwt(keyMaterial, JwsHeaderCertOrJwk())
+                supportedAlgorithms = setOf(SignatureAlgorithm.ECDSAwithSHA256)
             )
         }
     } - {

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -13,6 +13,9 @@ import at.asitplus.signum.indispensable.cosef.toCoseKey
 import at.asitplus.signum.indispensable.pki.X509Certificate
 import at.asitplus.signum.indispensable.pki.leaf
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore.StoreEntry
+import at.asitplus.wallet.lib.cbor.CoseHeaderNone
+import at.asitplus.wallet.lib.cbor.SignCoseDetached
+import at.asitplus.wallet.lib.cbor.SignCoseDetachedFun
 import at.asitplus.wallet.lib.data.CredentialPresentation
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest
 import at.asitplus.wallet.lib.data.CredentialToJsonConverter
@@ -46,13 +49,19 @@ class HolderAgent @JvmOverloads constructor(
     private val signVerifiablePresentation: SignJwtFun<VerifiablePresentationJws> =
         SignJwt(keyMaterial, JwsHeaderCertOrJwk()),
     private val signKeyBinding: SignJwtFun<KeyBindingJws> = SignJwt(keyMaterial, JwsHeaderNone()),
+    private val signDeviceAuthDetached: SignCoseDetachedFun<ByteArray> = SignCoseDetached(
+        keyMaterial = keyMaterial,
+        protectedHeaderModifier = CoseHeaderNone(),
+        unprotectedHeaderModifier = CoseHeaderNone()
+    ),
     private val mdocZkEngine: IsoMdocZkEngine = IsoMdocZkEngine(),
     private val verifiablePresentationFactory: VerifiablePresentationFactory =
         VerifiablePresentationFactory(
             keyMaterial = keyMaterial,
             signVerifiablePresentation = signVerifiablePresentation,
             signKeyBinding = signKeyBinding,
-            mdocZkEngine = mdocZkEngine
+            mdocZkEngine = mdocZkEngine,
+            signDeviceAuthDetached = signDeviceAuthDetached
         ),
     private val difInputEvaluator: PresentationExchangeInputEvaluator = PresentationExchangeInputEvaluator,
 ) : Holder {

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/NonceChallengeVerifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/NonceChallengeVerifier.kt
@@ -45,16 +45,26 @@ class NonceChallengeVerifier @JvmOverloads constructor(
      */
     suspend fun createPresentationRequest(
         transactionData: List<TransactionDataBase64Url>? = null,
-        calcIsoDeviceSignaturePlain: suspend (IsoDeviceSignatureInput) -> CoseSigned<ByteArray>? = { null },
+        calcIsoSessionTranscript: suspend () -> SessionTranscript? = { null },
         returnOneDeviceResponse: Boolean = false,
-        calcIsoSessionTranscript: suspend () -> SessionTranscript = { throw IllegalStateException(
-            "Session transcript calculation callback was not provided. This is required for ISO mDoc presentations.") },
+    ) = PresentationRequestParameters(
+        nonce = nonceService.provideNonce(),
+        audience = verifierId,
+        transactionData = transactionData,
+        calcIsoSessionTranscript = calcIsoSessionTranscript,
+        returnOneDeviceResponse = returnOneDeviceResponse,
+    )
+
+    @Deprecated("Use createPresentationRequest(transactionData, returnOneDeviceResponse, calcIsoSessionTranscript) instead")
+    suspend fun createPresentationRequest(
+        transactionData: List<TransactionDataBase64Url>? = null,
+        calcIsoDeviceSignaturePlain: suspend (IsoDeviceSignatureInput) -> CoseSigned<ByteArray>?,
+        returnOneDeviceResponse: Boolean = false,
     ) = PresentationRequestParameters(
         nonce = nonceService.provideNonce(),
         audience = verifierId,
         transactionData = transactionData,
         calcIsoDeviceSignaturePlain = calcIsoDeviceSignaturePlain,
-        calcIsoSessionTranscript = calcIsoSessionTranscript,
         returnOneDeviceResponse = returnOneDeviceResponse,
     )
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationDataClasses.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationDataClasses.kt
@@ -38,6 +38,7 @@ data class PresentationRequestParameters(
      * Handle calculating device signature for ISO mDocs, as this depends on the transport protocol
      * (OpenID4VP with ISO/IEC 18013-7)
      */
+    @Deprecated("Compute Device Signature using the calcIsoSessionTranscript callback.")
     val calcIsoDeviceSignaturePlain: (suspend (input: IsoDeviceSignatureInput) -> CoseSigned<ByteArray>?) = { null },
     @Deprecated(
         "Only applies to deprecated Presentation Exchange. DCQL uses `DCQLCredentialQuery.multiple`; " +
@@ -46,16 +47,15 @@ data class PresentationRequestParameters(
     val returnOneDeviceResponse: Boolean = false,
 
     /**
-     * Callback to calculate the ISO mDoc Session Transcript.
+     * Handle calculating Session Transcript for ISO mDocs, as this depends on the transport protocol
+     * (OpenID4VP with ISO/IEC 18013-7)
      *
-     * This is a callback because calculating the Session Transcript might fail for non-mDoc presentations.
+     * Deferred because calculation of a Session Transcript might fail for non-mDoc presentations.
      * By using a callback, we ensure that it's only calculated when an ISO mDoc is actually
      * part of the presentation, avoiding unnecessary failures, e.g., for SD-JWT presentations.
      */
-    val calcIsoSessionTranscript: (suspend () -> SessionTranscript) = {
-        throw IllegalStateException("Session transcript calculation callback was not provided. " +
-                "This is required for ISO mDoc presentations.")
-    },
+    val calcIsoSessionTranscript: (suspend () -> SessionTranscript?) = { null },
+
 ) {
     /**
      * According to OID4VP 1.0 B3.3.1 every TransactionData entry may define different Digest algorithms

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -255,6 +255,8 @@ class VerifiablePresentationFactory(
 
         val deviceNameSpaceBytes = ByteStringWrapper(DeviceNameSpaces(mapOf()))
         val input = IsoDeviceSignatureInput(schemeIdentifier, deviceNameSpaceBytes)
+
+        @Suppress("DEPRECATION")
         val deviceSignature = request.calcIsoDeviceSignaturePlain(input) ?: run {
             val sessionTranscript = request.calcIsoSessionTranscript()
                 ?: throw PresentationException("calcIsoSessionTranscript not implemented")

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -17,13 +17,16 @@ package at.asitplus.wallet.lib.agent
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.iso.DeviceAuth
+import at.asitplus.iso.DeviceAuthentication
 import at.asitplus.iso.DeviceNameSpaces
 import at.asitplus.iso.DeviceResponse
 import at.asitplus.iso.DeviceSigned
 import at.asitplus.iso.Document
 import at.asitplus.iso.IssuerSigned
 import at.asitplus.iso.IssuerSignedItem
+import at.asitplus.iso.SessionTranscript
 import at.asitplus.iso.ZkDocument
+import at.asitplus.iso.wrapInCborTag
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
 import at.asitplus.openid.dcql.DCQLClaimsQueryResult
@@ -31,11 +34,16 @@ import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult
 import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult.*
 import at.asitplus.openid.truncateToSeconds
 import at.asitplus.signum.indispensable.Digest
+import at.asitplus.signum.indispensable.cosef.CoseSigned
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
+import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.JwsCompact
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.supreme.hash.digest
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore.StoreEntry
+import at.asitplus.wallet.lib.cbor.CoseHeaderNone
+import at.asitplus.wallet.lib.cbor.SignCoseDetached
+import at.asitplus.wallet.lib.cbor.SignCoseDetachedFun
 import at.asitplus.wallet.lib.data.KeyBindingJws
 import at.asitplus.wallet.lib.data.SdJwtConstants.NAME_SD
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
@@ -52,6 +60,8 @@ import at.asitplus.wallet.lib.jws.SignJwtFun
 import at.asitplus.wallet.lib.zk.iso.IsoMdocZkEngine
 import io.github.aakira.napier.Napier
 import io.github.z4kn4fein.semver.Version
+import kotlinx.serialization.builtins.ByteArraySerializer
+import kotlinx.serialization.encodeToByteArray
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -64,7 +74,12 @@ class VerifiablePresentationFactory(
         SignJwt(keyMaterial, JwsHeaderCertOrJwk()),
     private val signKeyBinding: SignJwtFun<KeyBindingJws> =
         SignJwt(keyMaterial, JwsHeaderNone()),
-    private val mdocZkEngine: IsoMdocZkEngine = IsoMdocZkEngine()
+    private val mdocZkEngine: IsoMdocZkEngine = IsoMdocZkEngine(),
+    private val signDeviceAuthDetached: SignCoseDetachedFun<ByteArray> = SignCoseDetached(
+        keyMaterial = keyMaterial,
+        protectedHeaderModifier = CoseHeaderNone(),
+        unprotectedHeaderModifier = CoseHeaderNone()
+    )
 ) {
     @Deprecated("Use createVerifiablePresentation(request, isoPresentationParameters) instead")
     suspend fun createVerifiablePresentation(
@@ -240,8 +255,11 @@ class VerifiablePresentationFactory(
 
         val deviceNameSpaceBytes = ByteStringWrapper(DeviceNameSpaces(mapOf()))
         val input = IsoDeviceSignatureInput(schemeIdentifier, deviceNameSpaceBytes)
-        val deviceSignature = request.calcIsoDeviceSignaturePlain(input)
-            ?: throw PresentationException("calcIsoDeviceSignature not implemented")
+        val deviceSignature = request.calcIsoDeviceSignaturePlain(input) ?: run {
+            val sessionTranscript = request.calcIsoSessionTranscript()
+                ?: throw PresentationException("calcIsoSessionTranscript not implemented")
+            calculateDeviceSignature(input, sessionTranscript)
+        }
 
         Document(
             docType = schemeIdentifier,
@@ -256,6 +274,31 @@ class VerifiablePresentationFactory(
                 )
             )
         )
+    }
+
+    private suspend fun calculateDeviceSignature(
+        input: IsoDeviceSignatureInput,
+        sessionTranscript: SessionTranscript,
+    ):  CoseSigned<ByteArray> {
+        val deviceAuthentication = DeviceAuthentication(
+            type = DeviceAuthentication.TYPE,
+            sessionTranscript = sessionTranscript,
+            docType = input.docType,
+            namespaces = input.deviceNameSpaceBytes
+        )
+        val deviceAuthenticationBytes = coseCompliantSerializer
+            .encodeToByteArray(ByteStringWrapper(deviceAuthentication))
+            .wrapInCborTag(24)
+        Napier.d("Device authentication signature input is ${deviceAuthenticationBytes.toHexString()}")
+        return signDeviceAuthDetached(
+            protectedHeader = null,
+            unprotectedHeader = null,
+            payload = deviceAuthenticationBytes,
+            serializer = ByteArraySerializer()
+        ).getOrElse { e ->
+            Napier.w("Could not create DeviceAuth for presentation", e)
+            throw PresentationException(e)
+        }
     }
 
     /** Returns map of first element (namespace) to second element (attribute name) */

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentIsoMdocMultipleDocumentsTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentIsoMdocMultipleDocumentsTest.kt
@@ -11,6 +11,7 @@ import at.asitplus.iso.Document
 import at.asitplus.iso.ItemsRequest
 import at.asitplus.iso.ItemsRequestList
 import at.asitplus.iso.MobileSecurityObject
+import at.asitplus.iso.SessionTranscript
 import at.asitplus.iso.SingleItemsRequest
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.jsonpath.core.NormalizedJsonPathSegment.NameSegment
@@ -24,11 +25,9 @@ import at.asitplus.openid.dcql.DCQLIsoMdocClaimsQuery
 import at.asitplus.openid.dcql.DCQLIsoMdocCredentialMetadataAndValidityConstraints
 import at.asitplus.openid.dcql.DCQLIsoMdocCredentialQuery
 import at.asitplus.openid.dcql.DCQLQuery
-import at.asitplus.signum.indispensable.cosef.CoseSigned
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
-import at.asitplus.wallet.lib.cbor.SignCose
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_FAMILY_NAME
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
@@ -52,7 +51,6 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.matchers.types.shouldNotBeInstanceOf
-import kotlinx.serialization.builtins.ByteArraySerializer
 
 val AgentIsoMdocMultipleDocumentsTest by matrixSuite {
 
@@ -105,13 +103,12 @@ val AgentIsoMdocMultipleDocumentsTest by matrixSuite {
                     validatorMdoc = validator,
                 ),
             )
-            val signer = SignCose<ByteArray>(keyMaterial = holderKeyMaterial)
         }
     } - {
 
         test("dcql: multiple credentials should be multiple device responses for remote presentation") { scope ->
             val request = scope.verifier.createPresentationRequest(
-                calcIsoDeviceSignaturePlain = simpleSigner(scope.signer),
+                calcIsoSessionTranscript = simpleTranscriptCallback
             )
             val presentationRequest = CredentialPresentationRequest.DCQLRequest(
                 DCQLQuery(
@@ -171,7 +168,7 @@ val AgentIsoMdocMultipleDocumentsTest by matrixSuite {
 
             val result = scope.holder.createPresentation(
                 request = scope.verifier.createPresentationRequest(
-                    calcIsoDeviceSignaturePlain = simpleSigner(scope.signer),
+                    calcIsoSessionTranscript = simpleTranscriptCallback,
                     returnOneDeviceResponse = true,
                 ),
                 credentialPresentation = PresentationExchangePresentation(presentationRequest),
@@ -184,7 +181,7 @@ val AgentIsoMdocMultipleDocumentsTest by matrixSuite {
 
         test("device retrieval: multiple document requests produce one device response") {
             val request = it.verifier.createPresentationRequest(
-                calcIsoDeviceSignaturePlain = simpleSigner(it.signer),
+                calcIsoSessionTranscript = simpleTranscriptCallback,
             )
             val result = it.holder.createDefaultPresentation(
                 request = request,
@@ -257,15 +254,12 @@ private fun isoMdocCredentialQuery(
     ),
 )
 
-private fun simpleSigner(
-    signer: SignCose<ByteArray>
-): suspend (IsoDeviceSignatureInput) -> CoseSigned<ByteArray>? = { input ->
-    signer(
-        protectedHeader = null,
-        unprotectedHeader = null,
-        payload = input.docType.encodeToByteArray(),
-        serializer = ByteArraySerializer()
-    ).getOrThrow()
+// Simple Session Transcript (mostly empty)
+private val simpleTranscriptCallback: () -> SessionTranscript = {
+    SessionTranscript.forQr(
+        deviceEngagementBytes = byteArrayOf(),
+        eReaderKeyBytes = byteArrayOf(),
+    )
 }
 
 // No OpenID4VP, no need to verify the device signature

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentIsoMdocTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentIsoMdocTest.kt
@@ -7,6 +7,7 @@ import at.asitplus.iso.Document
 import at.asitplus.iso.ItemsRequest
 import at.asitplus.iso.ItemsRequestList
 import at.asitplus.iso.MobileSecurityObject
+import at.asitplus.iso.SessionTranscript
 import at.asitplus.iso.SingleItemsRequest
 import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.openid.dcql.DCQLClaimsPathPointer
@@ -18,13 +19,11 @@ import at.asitplus.openid.dcql.DCQLIsoMdocCredentialMetadataAndValidityConstrain
 import at.asitplus.openid.dcql.DCQLIsoMdocCredentialQuery
 import at.asitplus.openid.dcql.DCQLQuery
 import at.asitplus.signum.indispensable.CryptoPublicKey
-import at.asitplus.signum.indispensable.cosef.CoseSigned
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
 import at.asitplus.wallet.lib.agent.DummyCredentialDataProvider.issueAndStoreIsoMdoc
 import at.asitplus.wallet.lib.agent.validation.TokenStatusResolverImpl
-import at.asitplus.wallet.lib.cbor.SignCose
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_DATE_OF_BIRTH
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
@@ -49,7 +48,6 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.matchers.types.shouldNotBeInstanceOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.LocalDate
-import kotlinx.serialization.builtins.ByteArraySerializer
 
 val AgentIsoMdocTest by matrixSuite {
 
@@ -78,7 +76,7 @@ val AgentIsoMdocTest by matrixSuite {
             if (mode == IsoRevocationMode.STATUS_LIST) {
                 "device retrieval: creates one device response with the requested claim" {
                     val request = it.verifier.createPresentationRequest(
-                        calcIsoDeviceSignaturePlain = simpleSigner(it.signer),
+                        calcIsoSessionTranscript = simpleTranscriptCallback,
                     )
                     val result = it.holder.createDefaultPresentation(
                         request = request,
@@ -99,7 +97,7 @@ val AgentIsoMdocTest by matrixSuite {
                 "device retrieval: rejects a request for a missing data element" {
                     it.holder.createDefaultPresentation(
                         request = it.verifier.createPresentationRequest(
-                            calcIsoDeviceSignaturePlain = simpleSigner(it.signer),
+                            calcIsoSessionTranscript = simpleTranscriptCallback,
                         ),
                         credentialPresentationRequest = CredentialPresentationRequest.IsoDeviceRetrieval(
                             isoDeviceRequest("not_in_the_credential")
@@ -120,7 +118,7 @@ val AgentIsoMdocTest by matrixSuite {
 
                     it.holder.createDefaultPresentation(
                         request = it.verifier.createPresentationRequest(
-                            calcIsoDeviceSignaturePlain = simpleSigner(it.signer),
+                            calcIsoSessionTranscript = simpleTranscriptCallback,
                         ),
                         credentialPresentationRequest = request,
                     ).getOrThrow().shouldBeInstanceOf<PresentationResponseParameters.DeviceRetrievalParameters>()
@@ -196,7 +194,7 @@ val AgentIsoMdocTest by matrixSuite {
 
                     val firstVp = it.createDcqlDeviceResponse(CLAIM_GIVEN_NAME)
                     val secondRequest = it.verifier.createPresentationRequest(
-                        calcIsoDeviceSignaturePlain = simpleSigner(SignCose(keyMaterial = secondHolderKeyMaterial)),
+                        calcIsoSessionTranscript = simpleTranscriptCallback,
                     )
                     val secondVp = PresentedIsoResponse(
                         request = secondRequest,
@@ -286,7 +284,6 @@ private data class IsoMdocFixture(
     val holder: HolderAgent,
     val verifier: NonceChallengeVerifier,
     val verifierId: String,
-    val signer: SignCose<ByteArray>,
 )
 
 private suspend fun createIsoMdocFixture(mode: IsoRevocationMode): IsoMdocFixture {
@@ -329,7 +326,6 @@ private suspend fun createIsoMdocFixture(mode: IsoRevocationMode): IsoMdocFixtur
             verifier = VerifierAgent(identifier = verifierId, validatorMdoc = validator),
         ),
         verifierId = verifierId,
-        signer = SignCose(keyMaterial = holderKeyMaterial),
     )
 }
 
@@ -358,7 +354,7 @@ private data class PresentedIsoResponse(
 )
 
 private suspend fun IsoMdocFixture.createDcqlDeviceResponse(vararg attributeNames: String) =
-    verifier.createPresentationRequest(calcIsoDeviceSignaturePlain = simpleSigner(signer)).let { request ->
+    verifier.createPresentationRequest(calcIsoSessionTranscript = simpleTranscriptCallback).let { request ->
         PresentedIsoResponse(
             request = request,
             response = createDcqlDeviceResponse(
@@ -437,16 +433,12 @@ private fun Verifier.VerifyPresentationResult.SuccessIso.assertRevocationInvalid
         tokenStatusValidationResult.shouldNotBeInstanceOf<TokenStatusValidationResult.Invalid>()
     }
 }
-
-private fun simpleSigner(
-    signer: SignCose<ByteArray>
-): suspend (IsoDeviceSignatureInput) -> CoseSigned<ByteArray>? = { input ->
-    signer(
-        protectedHeader = null,
-        unprotectedHeader = null,
-        payload = input.docType.encodeToByteArray(),
-        serializer = ByteArraySerializer()
-    ).getOrThrow()
+// Simple Session Transcript (mostly empty)
+private val simpleTranscriptCallback: () -> SessionTranscript = {
+    SessionTranscript.forQr(
+        deviceEngagementBytes = byteArrayOf(),
+        eReaderKeyBytes = byteArrayOf(),
+    )
 }
 
 private fun SubjectCredentialStore.StoreEntry.Iso.mdocStatusListIndex(): ULong =

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactoryTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactoryTest.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.lib.agent
 
+import at.asitplus.iso.SessionTranscript
 import at.asitplus.jsonpath.core.NodeListEntry
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.openid.dcql.DCQLClaimsQueryResult.IsoMdocResult
@@ -7,10 +8,6 @@ import at.asitplus.openid.dcql.DCQLClaimsQueryResult.JsonResult
 import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult.*
 import at.asitplus.openid.dcql.DCQLIsoMdocZkSystemSpec
 import at.asitplus.openid.dcql.DCQLIsoMdocZkSystemType
-import at.asitplus.signum.indispensable.CryptoSignature
-import at.asitplus.signum.indispensable.cosef.CoseAlgorithm
-import at.asitplus.signum.indispensable.cosef.CoseHeader
-import at.asitplus.signum.indispensable.cosef.CoseSigned
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
@@ -42,7 +39,6 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.builtins.ByteArraySerializer
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
@@ -314,19 +310,18 @@ val VerifiablePresentationFactoryTest by matrixSuite {
 
     }
 }
+// Simple Session Transcript (mostly empty)
+private val simpleTranscriptCallback: () -> SessionTranscript = {
+    SessionTranscript.forQr(
+        deviceEngagementBytes = byteArrayOf(),
+        eReaderKeyBytes = byteArrayOf(),
+    )
+}
 
 private fun presentationRequest() = PresentationRequestParameters(
     nonce = uuid4().toString(),
     audience = "https://verifier.example.org",
-    calcIsoDeviceSignaturePlain = {
-        CoseSigned.create(
-            CoseHeader(algorithm = CoseAlgorithm.Signature.RS256),
-            null,
-            byteArrayOf(),
-            CryptoSignature.RSA(byteArrayOf()),
-            ByteArraySerializer(),
-        )
-    }
+    calcIsoSessionTranscript = simpleTranscriptCallback,
 )
 
 private fun CreatePresentationResult.SdJwt.disclosedClaimNames(): Set<String> =


### PR DESCRIPTION
- Remove two independent calcDeviceSignature implementations from IsoMdocDcapiResponseBuilder.kt and PresentationFactory.kt
- Enforce calculation of DeviceSignature based on SessionTranscript to increase consistency throughout the codebase
- Update test cases accordingly
- Deprecate `PresentationRequestParameters.calcIsoDeviceSignaturePlain`