### PR TITLE
OAuth: Attestation Based Client Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Release 8.0.0 (unreleased):
     - `RequestParser` no longer verifies anything and lost its `requestObjectJwsVerifier` parameter, so parsing a request is purely parsing. Consequently `RequestParametersSigned.verified` is removed, with the `verified` property of `Jws`, `OpenId4VpDcApiSigned` and `OpenId4VpDcApiMultiSigned` and its serialized form. Stored JSON still carrying `"verified"` deserializes fine, as unknown keys are ignored
 - OAuth 2.0:
     - Update implementation of [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html) to Draft 10 from 2026-07-06
+    - Add method `attestationChallenge()` to `SimpleAuthorizationService` to deliver challenges for Attestation-Based Client Authentication
 - Deprecations:
     - Remove code deprecated in 7.0.0, e.g. various `Iso180137AnnexC*` and related classes
     - Deprecate all classes used for Presentation Exchange requests and so on, e.g., `CredentialPresentationRequest.PresentationExchangeRequest` or `PresentationExchangeCredentialDisclosure` or `CredentialPresentation.PresentationExchangePresentation`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Release 8.0.0 (unreleased):
 - OAuth 2.0:
     - Update implementation of [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html) to Draft 10 from 2026-07-06
     - Add method `attestationChallenge()` to `SimpleAuthorizationService` to deliver challenges for Attestation-Based Client Authentication
+    - Support `use_client_attestation` errors and parse challenges from `OAuth-Client-Attestation-Challenge` in `OAuth2KtorClient`
 - Deprecations:
     - Remove code deprecated in 7.0.0, e.g. various `Iso180137AnnexC*` and related classes
     - Deprecate all classes used for Presentation Exchange requests and so on, e.g., `CredentialPresentationRequest.PresentationExchangeRequest` or `PresentationExchangeCredentialDisclosure` or `CredentialPresentation.PresentationExchangePresentation`

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AttestationChallengeResponse.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AttestationChallengeResponse.kt
@@ -1,0 +1,23 @@
+package at.asitplus.openid
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Challenges for
+ * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html#name-challenges)
+ */
+@Serializable
+data class AttestationChallengeResponse(
+    /**
+     * REQUIRED if the Authorization Server or Resource Server supports Client Attestations and server-provided
+     * challenges as described in
+     * [this document](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html#name-challenges)
+     * .
+     * String containing a Challenge to be used in the Client Attestation PoP JWT or DPoP Proof as defined in Section 5.
+     * The intention of this element not being required in other circumstances is to preserve the ability for the
+     * challenge endpoint to be used in other applications unrelated to client attestations.
+     */
+    @SerialName("attestation_challenge")
+    val attestationChallenge: String,
+)

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/ClientNonceResponse.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/ClientNonceResponse.kt
@@ -3,8 +3,10 @@ package at.asitplus.openid
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-// TODO Copy for Attestation Challenge Response
-
+/**
+ * Nonces for
+ * [OpenID for Verifiable Credential Issuance](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-nonce-endpoint)
+ */
 @Serializable
 data class ClientNonceResponse(
     /**

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OAuth2AuthorizationServerMetadata.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OAuth2AuthorizationServerMetadata.kt
@@ -363,7 +363,13 @@ data class OAuth2AuthorizationServerMetadata(
     @SerialName("code_challenge_methods_supported")
     val codeChallengeMethodsSupported: Set<String>? = null,
 
-    // TODO Support for challenge endpoint and pop methods
+    /**
+     * URL of the authorization server's challenge endpoint which is used to obtain a fresh challenge for usage in
+     * client authentication methods such as client attestation. See
+     * [OAuth2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html#name-oauth-authorization-server-)
+     */
+    @SerialName("challenge_endpoint")
+    val challengeEndpoint: String? = null,
 
     /**
      * The Authorization Server SHOULD communicate supported algorithms for client attestations by using
@@ -394,6 +400,20 @@ data class OAuth2AuthorizationServerMetadata(
      */
     @SerialName("client_attestation_signing_alg_values_supported")
     val clientAttestationSigningAlgValuesSupportedStrings: Set<String>? = null,
+
+    /**
+     * OAuth2.0 Attestation-Based Client Authentication registers the following Proof of Possession methods:
+     * * `attestation_pop_jwt`: The Proof of Possession is a dedicated Client Attestation PoP JWT as defined in
+     * Section 5.1 ("normal mode").
+     * * `dpop_combined`: The Proof of Possession is a DPoP proof serving as the combined Proof of Possession as
+     * defined in Section 5.2 ("DPoP combined mode").
+     * * `none`: No Client Attestation is required. A server includes this value to signal that the Client MAY omit
+     * the Client Attestation.
+     * See
+     * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html#name-client-attestation-as-an-ad)
+     */
+    @SerialName("client_attestation_pop_methods_supported")
+    val clientAttestationPopMethodsSupported: Set<OpenIdConstants.ClientAttestationPopMethod>? = null,
 ) {
 
     /**

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
@@ -477,6 +477,9 @@ object OpenIdConstants {
         /** Use a fresh DPoP nonce (RFC 9449): `use_dpop_nonce`.*/
         const val USE_DPOP_NONCE = "use_dpop_nonce"
 
+        /** Use a fresh attestation challenge (OA-ABCA Draft 10): `use_attestation_challenge`.*/
+        const val USE_ATTESTATION_CHALLENGE = "use_attestation_challenge"
+
         /** Invalid request in general: `invalid_request`. */
         const val INVALID_REQUEST = "invalid_request"
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
@@ -477,8 +477,11 @@ object OpenIdConstants {
         /** Use a fresh DPoP nonce (RFC 9449): `use_dpop_nonce`.*/
         const val USE_DPOP_NONCE = "use_dpop_nonce"
 
-        /** Use a fresh attestation challenge (OA-ABCA Draft 10): `use_attestation_challenge`.*/
+        /** Attestation challenge not valid (OA-ABCA Draft 10): `use_attestation_challenge`.*/
         const val USE_ATTESTATION_CHALLENGE = "use_attestation_challenge"
+
+        /** Use a fresh client attestation JWT (OA-ABCA Draft 10): `use_fresh_attestation`.*/
+        const val USE_FRESH_ATTESTATION = "use_fresh_attestation"
 
         /** Invalid request in general: `invalid_request`. */
         const val INVALID_REQUEST = "invalid_request"

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
@@ -122,6 +122,7 @@ object OpenIdConstants {
     object ProofTypes {
         /** `jwt` */
         const val JWT = "jwt"
+
         /** `attestation` */
         const val ATTESTATION = "attestation"
     }
@@ -394,6 +395,70 @@ object OpenIdConstants {
      */
     object VerifierInfo {
         const val REGISTRATION_CERT_FORMAT = "registration_cert"
+    }
+
+
+    /**
+     * See
+     * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html#name-client-attestation-as-an-ad)
+     */
+    @Serializable(with = ClientAttestationPopMethod.Serializer::class)
+    sealed class ClientAttestationPopMethod(
+        val stringRepresentation: String
+    ) {
+        /**
+         * The Proof of Possession is a dedicated Client Attestation PoP JWT as defined in
+         * Section 5.1 ("normal mode").
+         */
+        object AttestationPopJwt : ClientAttestationPopMethod(STRING_ATTESTATION_POP_JWT)
+
+        /**
+         * The Proof of Possession is a DPoP proof serving as the combined Proof of Possession as defined in
+         * Section 5.2 ("DPoP combined mode").
+         */
+        object DpopCombined : ClientAttestationPopMethod(STRING_DPOP_COMBINED)
+
+        /**
+         * No Client Attestation is required. A server includes this value to signal that the Client MAY omit the
+         * Client Attestation.
+         */
+        object None : ClientAttestationPopMethod(STRING_NONE)
+
+        /**
+         * Any not natively supported PoP method, so it can still be parsed
+         */
+        class Other(stringRepresentation: String) : ClientAttestationPopMethod(stringRepresentation)
+
+        companion object {
+            private const val STRING_ATTESTATION_POP_JWT = "attestation_pop_jwt"
+            private const val STRING_DPOP_COMBINED = "dpop_combined"
+            private const val STRING_NONE = "none"
+
+            val entries by lazy {
+                setOf(
+                    AttestationPopJwt,
+                    DpopCombined,
+                    None
+                )
+            }
+        }
+
+        object Serializer : KSerializer<ClientAttestationPopMethod> {
+            override val descriptor: SerialDescriptor =
+                PrimitiveSerialDescriptor("ClientAttestationPopMethod", PrimitiveKind.STRING)
+
+            override fun deserialize(decoder: Decoder): ClientAttestationPopMethod =
+                when (val string = decoder.decodeString()) {
+                    STRING_ATTESTATION_POP_JWT -> AttestationPopJwt
+                    STRING_DPOP_COMBINED -> DpopCombined
+                    STRING_NONE -> None
+                    else -> Other(string)
+                }
+
+            override fun serialize(encoder: Encoder, value: ClientAttestationPopMethod) {
+                encoder.encodeString(value.stringRepresentation)
+            }
+        }
     }
 
     /**

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/Extensions.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/Extensions.kt
@@ -1,11 +1,13 @@
 package at.asitplus.wallet.lib.ktor.openid
 
 import at.asitplus.catchingUnwrapped
+import at.asitplus.openid.OpenIdConstants.Errors.USE_ATTESTATION_CHALLENGE
 import at.asitplus.openid.OpenIdConstants.Errors.USE_DPOP_NONCE
 import at.asitplus.wallet.lib.oauth2.DPoPNonce
+import at.asitplus.wallet.lib.oauth2.OAuthClientAttestationChallenge
 import at.asitplus.wallet.lib.oauth2.RequestInfo
 import at.asitplus.wallet.lib.oidvci.OAuth2Error
-import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.coroutines.CoroutineScope
@@ -24,7 +26,17 @@ fun OAuth2Error?.dpopNonce(response: HttpResponse) = catchingUnwrapped {
     authorizationServerProvidedNonce(response) ?: resourceServerProvidedNonce(response)
 }.getOrNull()
 
+/** Extracts the header `DPoP-Nonce` if the error is `use_dpop_nonce`. */
 fun HttpErrorResponseException.dpopNonce() = oauth2Error.dpopNonce(response)
+
+/** Extracts the header `OAuth-Client-Attestation-Challenge` if the error is `use_attestation_challenge`. */
+fun OAuth2Error?.attestationChallenge(response: HttpResponse) = catchingUnwrapped {
+    authorizationServerProvidedAttestationChallenge(response)
+}.getOrNull()
+
+/** Extracts the header `DPoP-Nonce` if the error is `use_dpop_nonce`. */
+fun HttpErrorResponseException.attestationChallenge() = oauth2Error.attestationChallenge(response)
+
 
 /** [RFC 9449 8.](https://datatracker.ietf.org/doc/html/rfc9449#name-authorization-server-provid) */
 private fun OAuth2Error?.authorizationServerProvidedNonce(response: HttpResponse): String? =
@@ -35,6 +47,11 @@ private fun resourceServerProvidedNonce(response: HttpResponse): String? =
     response.takeIf {
         response.headers.getAll(HttpHeaders.WWWAuthenticate)?.any { it.contains(USE_DPOP_NONCE) } == true
     }?.let { response.headers[HttpHeaders.DPoPNonce] }
+
+/** [OA-ABCA 6.2](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html#challenge-in-response) */
+private fun OAuth2Error?.authorizationServerProvidedAttestationChallenge(response: HttpResponse): String? =
+    this?.error.takeIf { it == USE_ATTESTATION_CHALLENGE }
+        ?.let { response.headers[HttpHeaders.OAuthClientAttestationChallenge] }
 
 fun HttpRequestData.toRequestInfo(): RequestInfo = RequestInfo(
     url = url.toString(),

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
@@ -123,7 +123,21 @@ class OAuth2KtorClient(
     /** Store the latest attestation challenge per origin (if the AS supports challenges) */
     private val attestationChallengeByOrigin = AtomicReference(mapOf<String, String>())
 
-    private fun currentAttestationChallenge(url: String) = attestationChallengeByOrigin.load()[url.origin()]
+    /**
+     * Consumes the challenge that the AS provided in a previous response, see
+     * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html)
+     * 6.2. A challenge is single-use, so reusing it would get the next request rejected with
+     * `use_attestation_challenge`.
+     */
+    private fun takeAttestationChallenge(url: String): String? {
+        val origin = url.origin()
+        var challenge: String? = null
+        attestationChallengeByOrigin.update {
+            challenge = it[origin]
+            it - origin
+        }
+        return challenge
+    }
 
     private fun updateAttestationChallenge(url: String, challenge: String?) =
         challenge?.takeIf { it.isNotBlank() }?.let {
@@ -560,7 +574,7 @@ class OAuth2KtorClient(
         issuerMetadata: IssuerMetadata? = null,
     ): HttpRequestBuilder.() -> Unit {
         val (clientAttJwt, clientAttPop) = if (loadInstanceAttestation != null && oauthMetadata.supportsClientAuth()) {
-            val wia = loadInstanceAttestation.invoke(
+            val wia = loadInstanceAttestation(
                 LoadInstanceAttestationInput(
                     authorizationServer = authorizationServer,
                     credentialIssuer = issuerMetadata?.credentialIssuer ?: authorizationServer,
@@ -578,13 +592,12 @@ class OAuth2KtorClient(
             }
 
             val pop = catching {
-                BuildClientAttestationPoPJwt.invoke(
+                BuildClientAttestationPoPJwt(
                     signJwt = SignJwt(keyMaterial, JwsHeaderNone()),
-                    clientId = oAuth2Client.clientId,
                     audience = authorizationServer,
                     // nonce support must not be implemented by the AS, so we keep it optional
-                    nonce = currentAttestationChallenge(resourceUrl)
-                        ?: fetchAttestationChallenge(resourceUrl, oauthMetadata),
+                    nonce = takeAttestationChallenge(resourceUrl)
+                        ?: fetchAttestationChallenge(oauthMetadata),
                 )
             }.getOrThrow()
             wia.jws to pop.jws
@@ -609,13 +622,12 @@ class OAuth2KtorClient(
         }
     }
 
+    /** Not cached: the challenge is used for the request being built right now, and is single-use. */
     private suspend fun fetchAttestationChallenge(
-        resourceUrl: String,
         oauthMetadata: OAuth2AuthorizationServerMetadata
     ): String? = oauthMetadata.challengeEndpoint?.let { url ->
         catchingUnwrapped {
             client.post(url).body<AttestationChallengeResponse>().attestationChallenge
-                .let { updateAttestationChallenge(resourceUrl, it) }
         }.getOrNull()
     }
 

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
@@ -3,6 +3,7 @@ package at.asitplus.wallet.lib.ktor.openid
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.catchingUnwrapped
+import at.asitplus.openid.AttestationChallengeResponse
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.AuthenticationResponseParameters
 import at.asitplus.openid.IssuerMetadata
@@ -36,6 +37,7 @@ import at.asitplus.wallet.lib.oauth2.DPoPNonce
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
 import at.asitplus.wallet.lib.oauth2.OAuth2Client.AuthorizationForToken
 import at.asitplus.wallet.lib.oauth2.OAuthClientAttestation
+import at.asitplus.wallet.lib.oauth2.OAuthClientAttestationChallenge
 import at.asitplus.wallet.lib.oauth2.OAuthClientAttestationPop
 import at.asitplus.wallet.lib.oidvci.BuildClientAttestationPoPJwt
 import at.asitplus.wallet.lib.oidvci.BuildDPoPHeader
@@ -55,6 +57,9 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.update
 import kotlin.time.Duration
 
 /**
@@ -68,6 +73,7 @@ import kotlin.time.Duration
  *  * [JSON Web Token (JWT) Response for OAuth Token Introspection](https://datatracker.ietf.org/doc/html/rfc9701)
  *  * [EUDI TS3 Wallet Unit Attestation 1.5.2](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md)
  */
+@OptIn(ExperimentalAtomicApi::class)
 class OAuth2KtorClient(
     /** ktor engine to use to make requests to issuing service. */
     engine: HttpClientEngine,
@@ -114,22 +120,35 @@ class OAuth2KtorClient(
         val preferredClientStatusPeriod: Duration?,
     )
 
-    // TODO: Also need to store challenge from Attestation-Based Client Auth
+    /** Store the latest attestation challenge per origin (if the AS supports challenges) */
+    private val attestationChallengeByOrigin = AtomicReference(mapOf<String, String>())
+
+    private fun currentAttestationChallenge(url: String) = attestationChallengeByOrigin.load()[url.origin()]
+
+    private fun updateAttestationChallenge(url: String, challenge: String?) =
+        challenge?.takeIf { it.isNotBlank() }?.let {
+            attestationChallengeByOrigin.update { it + (url.origin() to challenge) }
+            challenge
+        }
 
     /**
      * Stores the latest DPoP nonce per origin. RFC 9449 requires using only the most recent nonce
      * issued by the server that provided it.
      */
-    private val dpopNonceByContext: MutableMap<String, String> = mutableMapOf()
+    // TODO Evaluate DPoP combined mode
+    private val dpopNonceByOriginRef = AtomicReference(mapOf<String, String>())
 
-    private fun String.dpopContext(): String = Url(this).let { parsed ->
+    private fun String.origin(): String = Url(this).let { parsed ->
         "${parsed.protocol.name}://${parsed.host}:${parsed.port}"
     }
 
-    private fun currentDpopNonce(url: String): String? = dpopNonceByContext[url.dpopContext()]
+    private fun currentDpopNonce(url: String): String? = dpopNonceByOriginRef.load()[url.origin()]
 
     private fun updateDpopNonce(url: String, nonce: String?): String? =
-        nonce?.takeIf { it.isNotBlank() }?.let { dpopNonceByContext[url.dpopContext()] = nonce; nonce }
+        nonce?.takeIf { it.isNotBlank() }?.let { nonce ->
+            dpopNonceByOriginRef.update { it + (url.origin() to nonce) }
+            nonce
+        }
 
     internal val client = buildHttpClient(engine, cookiesStorage, httpClientConfig)
 
@@ -305,13 +324,17 @@ class OAuth2KtorClient(
                 )()
             }
         } catch (error: HttpErrorResponseException) {
-            return@let error.updateDpopNonceAndRetry(url, retryCount) {
+            return@let error.updateDpopNonceOrAttestationChallengeAndRetry(url, retryCount) {
                 postToken(oauthMetadata, request, popAudience, retryCount + 1, issuerMetadata)
             }
         }
-        val dpopNonce = response.dpopNonce
-        updateDpopNonce(url, dpopNonce)
-        TokenResponseWithDpopNonce(response.body(), dpopNonce)
+        updateDpopNonce(url, response.headers[HttpHeaders.DPoPNonce])
+        updateAttestationChallenge(url, response.headers[HttpHeaders.OAuthClientAttestationChallenge])
+        TokenResponseWithDpopNonce(
+            response.body(),
+            response.headers[HttpHeaders.DPoPNonce],
+            response.headers[HttpHeaders.OAuthClientAttestationChallenge]
+        )
     } ?: throw IllegalArgumentException("No tokenEndpoint in $oauthMetadata")
 
     /**
@@ -420,11 +443,12 @@ class OAuth2KtorClient(
                 )()
             }
         } catch (error: HttpErrorResponseException) {
-            return@let error.updateDpopNonceAndRetry(url, retryCount) {
+            return@let error.updateDpopNonceOrAttestationChallengeAndRetry(url, retryCount) {
                 pushAuthorizationRequest(oauthMetadata, authRequest, state, popAudience, retryCount + 1, issuerMetadata)
             }
         }
-        updateDpopNonce(url, response.dpopNonce)
+        updateDpopNonce(url, response.headers[HttpHeaders.DPoPNonce])
+        updateAttestationChallenge(url, response.headers[HttpHeaders.OAuthClientAttestationChallenge])
         JarRequestParameters(
             clientId = oAuth2Client.clientId,
             requestUri = response.body<PushedAuthenticationResponseParameters>().requestUri
@@ -462,11 +486,12 @@ class OAuth2KtorClient(
                 )()
             }
         } catch (error: HttpErrorResponseException) {
-            return@let error.updateDpopNonceAndRetry(url, retryCount) {
+            return@let error.updateDpopNonceOrAttestationChallengeAndRetry(url, retryCount) {
                 callTokenIntrospection(oauthMetadata, request, token, popAudience, retryCount + 1)
             }
         }
-        updateDpopNonce(url, response.dpopNonce)
+        updateDpopNonce(url, response.headers[HttpHeaders.DPoPNonce])
+        updateAttestationChallenge(url, response.headers[HttpHeaders.OAuthClientAttestationChallenge])
         parseTokenIntrospectionResponse(
             body = response.bodyAsText(),
             verifyTokenIntrospectionJwt = verifyTokenIntrospectionJwt,
@@ -478,15 +503,19 @@ class OAuth2KtorClient(
         }
     } ?: throw InvalidToken("No introspection endpoint found in Authorization Server metadata")
 
-    /** Store the DPoP nonce if it is set, and retry the previous action */
-    private suspend fun <T> HttpErrorResponseException.updateDpopNonceAndRetry(
+    /** Store the DPoP nonce or attestation challenge if it is set (optional by AS!), and retry the previous action */
+    private suspend fun <T> HttpErrorResponseException.updateDpopNonceOrAttestationChallengeAndRetry(
         url: String,
         retryCount: Int,
         action: suspend () -> T
-    ): T = dpopNonce()
+    ): T = (dpopNonce()
         ?.let { updateDpopNonce(url, it) }
         ?.takeIf { retryCount == 0 }
-        ?.let { action() }
+        ?.let { action() })
+        ?: (attestationChallenge()
+            ?.let { updateAttestationChallenge(url, it) }
+            ?.takeIf { retryCount == 0 }
+            ?.let { action() })
         ?: throw this
 
     /**
@@ -553,7 +582,9 @@ class OAuth2KtorClient(
                     signJwt = SignJwt(keyMaterial, JwsHeaderNone()),
                     clientId = oAuth2Client.clientId,
                     audience = authorizationServer,
-                    nonce = null // TODO: Read challenge like for DPoP
+                    // nonce support must not be implemented by the AS, so we keep it optional
+                    nonce = currentAttestationChallenge(resourceUrl)
+                        ?: fetchAttestationChallenge(resourceUrl, oauthMetadata),
                 )
             }.getOrThrow()
             wia.jws to pop.jws
@@ -578,16 +609,26 @@ class OAuth2KtorClient(
         }
     }
 
+    private suspend fun fetchAttestationChallenge(
+        resourceUrl: String,
+        oauthMetadata: OAuth2AuthorizationServerMetadata
+    ): String? = oauthMetadata.challengeEndpoint?.let { url ->
+        catchingUnwrapped {
+            client.post(url).body<AttestationChallengeResponse>().attestationChallenge
+                .let { updateAttestationChallenge(resourceUrl, it) }
+        }.getOrNull()
+    }
+
     private fun OAuth2AuthorizationServerMetadata.supportsClientAuth(): Boolean =
         tokenEndPointAuthMethodsSupported?.contains(AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH) == true
 }
 
-private val HttpResponse.dpopNonce: String?
-    get() = headers[HttpHeaders.DPoPNonce]
-
 data class TokenResponseWithDpopNonce(
     val params: TokenResponseParameters,
+    /** Value from header `DPoP-Nonce` */
     val dpopNonce: String?,
+    /** Value from header `OAuth-Client-Attestation-Challenge` */
+    val attestationChallenge: String?,
 )
 
 private suspend fun parseTokenIntrospectionResponse(

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClientTest.kt
@@ -1,10 +1,13 @@
 package at.asitplus.wallet.lib.ktor.openid
 
 import at.asitplus.catching
+import at.asitplus.openid.AttestationChallengeResponse
+import at.asitplus.openid.PushedAuthenticationResponseParameters
 import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenIntrospectionRequest
 import at.asitplus.openid.TokenRequestParameters
 import at.asitplus.signum.indispensable.josef.JwsAlgorithm
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.matrix.matrixSuite
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
@@ -20,12 +23,15 @@ import at.asitplus.wallet.lib.ktor.openid.TestUtils.respond
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respondIncludingDpopNonce
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respondOAuth2Error
 import at.asitplus.wallet.lib.oauth2.AttestationBasedClientAuthenticationService
+import at.asitplus.wallet.lib.oauth2.DPoPNonce
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
+import at.asitplus.wallet.lib.oauth2.OAuthClientAttestationChallenge
 import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService
 import at.asitplus.wallet.lib.oauth2.TokenService
 import at.asitplus.wallet.lib.oidvci.BuildClientAttestationJwt
 import at.asitplus.wallet.lib.oidvci.CredentialAuthorizationServiceStrategy
 import at.asitplus.wallet.lib.oidvci.CredentialIssuer
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 import at.asitplus.wallet.lib.oidvci.decodeFromPostBody
 import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
 import io.github.aakira.napier.Napier
@@ -47,6 +53,8 @@ val OAuth2KtorClientTest by matrixSuite {
         val authorizationService: SimpleAuthorizationService,
         val credentialIssuer: CredentialIssuer,
         val client: OAuth2KtorClient,
+        val issuedAttestationChallenges: List<String>,
+        val receivedPopChallenges: List<String?>,
     )
 
     fun setup(
@@ -54,12 +62,16 @@ val OAuth2KtorClientTest by matrixSuite {
         requestObjectSigningAlgorithms: Set<JwsAlgorithm.Signature>?,
         requirePAR: Boolean,
         captureAttestationInput: ((OAuth2KtorClient.LoadInstanceAttestationInput) -> Unit)? = null,
+        serveChallengeEndpoint: Boolean = true,
+        requireChallengeRetry: Boolean = false,
+        provideChallengeOnParSuccess: Boolean = false,
     ): Context {
         val clientAuthKeyMaterial = EphemeralKeyWithoutCert()
         val authorizationEndpointPath = "/authorize"
         val tokenEndpointPath = "/token"
         val introspectionEndpointPath = "/introspect"
         val parEndpointPath = "/par"
+        val challengeEndpointPath = "/challenge"
         val publicContext = "https://issuer.example.com"
         val authorizationService = SimpleAuthorizationService(
             strategy = strategy,
@@ -82,13 +94,55 @@ val OAuth2KtorClientTest by matrixSuite {
             authorizationService = authorizationService,
             credentialSchemes = AttributeIndex.schemeSet,
         )
+        val issuedAttestationChallenges = mutableListOf<String>()
+        val receivedPopChallenges = mutableListOf<String?>()
+        var challengeRetryRequired = requireChallengeRetry
         val mockEngine = MockEngine { request ->
             when {
+                request.url.fullPath.startsWith(challengeEndpointPath) && serveChallengeEndpoint -> {
+                    val response = authorizationService.attestationChallenge().getOrThrow().shouldNotBeNull()
+                    issuedAttestationChallenges += response.attestationChallenge
+                    respond(
+                        joseCompliantSerializer.encodeToString(AttestationChallengeResponse.serializer(), response),
+                        headers = headers {
+                            append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            append(HttpHeaders.CacheControl, "no-store")
+                        },
+                    )
+                }
+
                 request.url.fullPath.startsWith(parEndpointPath) -> {
+                    receivedPopChallenges += request.toRequestInfo().clientAttestationPop?.payload?.challenge
+                    if (challengeRetryRequired) {
+                        challengeRetryRequired = false
+                        val challenge = authorizationService.attestationChallenge().getOrThrow().shouldNotBeNull()
+                            .attestationChallenge
+                            .also { issuedAttestationChallenges += it }
+                        return@MockEngine respondOAuth2Error(OAuth2Exception.UseAttestationChallenge(challenge))
+                    }
                     val requestBody = request.body.toByteArray().decodeToString()
                     val authnRequest: RequestParameters = requestBody.decodeFromPostBody()
                     authorizationService.parWithDpopNonce(authnRequest, request.toRequestInfo()).fold(
-                        onSuccess = { respondIncludingDpopNonce(it) },
+                        onSuccess = {
+                            if (provideChallengeOnParSuccess) {
+                                val challenge = authorizationService.attestationChallenge().getOrThrow().shouldNotBeNull()
+                                    .attestationChallenge
+                                    .also { issuedAttestationChallenges += it }
+                                respond(
+                                    joseCompliantSerializer.encodeToString(
+                                        PushedAuthenticationResponseParameters.serializer(),
+                                        it.response,
+                                    ),
+                                    headers = headers {
+                                        append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                        it.dpopNonce?.let { append(HttpHeaders.DPoPNonce, it) }
+                                        append(HttpHeaders.OAuthClientAttestationChallenge, challenge)
+                                    },
+                                )
+                            } else {
+                                respondIncludingDpopNonce(it)
+                            }
+                        },
                         onFailure = { respondOAuth2Error(it) }
                     )
                 }
@@ -107,6 +161,7 @@ val OAuth2KtorClientTest by matrixSuite {
                 }
 
                 request.url.fullPath.startsWith(tokenEndpointPath) -> {
+                    receivedPopChallenges += request.toRequestInfo().clientAttestationPop?.payload?.challenge
                     val requestBody = request.body.toByteArray().decodeToString()
                     val params: TokenRequestParameters = requestBody.decodeFromPostBody<TokenRequestParameters>()
                     authorizationService.tokenWithDpopNonce(params, request.toRequestInfo()).fold(
@@ -116,6 +171,7 @@ val OAuth2KtorClientTest by matrixSuite {
                 }
 
                 request.url.fullPath.startsWith(introspectionEndpointPath) -> {
+                    receivedPopChallenges += request.toRequestInfo().clientAttestationPop?.payload?.challenge
                     val requestBody = request.body.toByteArray().decodeToString()
                     val params: TokenIntrospectionRequest =
                         requestBody.decodeFromPostBody<TokenIntrospectionRequest>()
@@ -150,7 +206,9 @@ val OAuth2KtorClientTest by matrixSuite {
                 keyMaterial = clientAuthKeyMaterial,
                 oAuth2Client = OAuth2Client(clientId = clientId),
                 randomSource = RandomSource.Default,
-            )
+            ),
+            issuedAttestationChallenges = issuedAttestationChallenges,
+            receivedPopChallenges = receivedPopChallenges,
         )
     }
 
@@ -277,6 +335,93 @@ val OAuth2KtorClientTest by matrixSuite {
                 it.credentialIssuer shouldBe credentialIssuer.metadata.credentialIssuer
                 it.preferredClientStatusPeriod shouldBe credentialIssuer.metadata.preferredClientStatusPeriod
             }
+        }
+    }
+
+    test("fetches advertised attestation challenge for the PAR PoP") {
+        with(setup(strategy, setOf(JwsAlgorithm.Signature.ES256), requirePAR = true)) {
+            client.startAuthorization(
+                oauthMetadata = authorizationService.metadata(),
+                authorizationServer = authorizationService.publicContext,
+                scope = requestedScope,
+            ).getOrThrow()
+
+            receivedPopChallenges.single() shouldBe issuedAttestationChallenges.single()
+        }
+    }
+
+    test("fetches a fresh attestation challenge for every request") {
+        with(setup(strategy, setOf(JwsAlgorithm.Signature.ES256), requirePAR = true)) {
+            val authorization = client.startAuthorization(
+                oauthMetadata = authorizationService.metadata(),
+                authorizationServer = authorizationService.publicContext,
+                scope = requestedScope,
+            ).getOrThrow()
+            val httpClient = HttpClient(mockEngine) { followRedirects = false }
+            val redirect = httpClient.get(authorization.url).headers[HttpHeaders.Location].shouldNotBeNull()
+
+            client.requestTokenWithAuthCode(
+                oauthMetadata = authorizationService.metadata(),
+                url = redirect,
+                authorizationServer = authorizationService.publicContext,
+                state = authorization.state,
+                scope = requestedScope,
+                authorizationDetails = setOf(),
+            ).getOrThrow()
+
+            // A challenge is single-use on the server, so PAR and token must not share one
+            receivedPopChallenges shouldBe issuedAttestationChallenges
+            receivedPopChallenges.distinct() shouldBe receivedPopChallenges
+        }
+    }
+
+    test("retries PAR once with attestation challenge from error response") {
+        with(
+            setup(
+                strategy = strategy,
+                requestObjectSigningAlgorithms = setOf(JwsAlgorithm.Signature.ES256),
+                requirePAR = true,
+                serveChallengeEndpoint = false,
+                requireChallengeRetry = true,
+            )
+        ) {
+            client.startAuthorization(
+                oauthMetadata = authorizationService.metadata(),
+                authorizationServer = authorizationService.publicContext,
+                scope = requestedScope,
+            ).getOrThrow()
+
+            receivedPopChallenges shouldBe listOf(null, issuedAttestationChallenges.single())
+        }
+    }
+
+    test("uses attestation challenge from PAR response for token request") {
+        with(
+            setup(
+                strategy = strategy,
+                requestObjectSigningAlgorithms = setOf(JwsAlgorithm.Signature.ES256),
+                requirePAR = true,
+                provideChallengeOnParSuccess = true,
+            )
+        ) {
+            val authorization = client.startAuthorization(
+                oauthMetadata = authorizationService.metadata(),
+                authorizationServer = authorizationService.publicContext,
+                scope = requestedScope,
+            ).getOrThrow()
+            val httpClient = HttpClient(mockEngine) { followRedirects = false }
+            val redirect = httpClient.get(authorization.url).headers[HttpHeaders.Location].shouldNotBeNull()
+
+            client.requestTokenWithAuthCode(
+                oauthMetadata = authorizationService.metadata(),
+                url = redirect,
+                authorizationServer = authorizationService.publicContext,
+                state = authorization.state,
+                scope = requestedScope,
+                authorizationDetails = setOf(),
+            ).getOrThrow()
+
+            receivedPopChallenges shouldBe issuedAttestationChallenges
         }
     }
 }

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientExternalAuthorizationServerTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientExternalAuthorizationServerTest.kt
@@ -126,6 +126,7 @@ val OpenId4VciClientExternalAuthorizationServerTest by matrixSuite {
         val parEndpointPath = "/par"
         val userInfoEndpointPath = "/userinfo"
         val introspectionEndpointPath = "/introspection"
+        val challengeEndpointPath = "/challenge"
         val issuerPublicContext = "https://issuer.example.com"
         val authServerPublicContext = "https://auth.example.com"
         val tokenService = TokenService.jwt(
@@ -139,6 +140,7 @@ val OpenId4VciClientExternalAuthorizationServerTest by matrixSuite {
             pushedAuthorizationRequestEndpointPath = parEndpointPath,
             userInfoEndpointPath = userInfoEndpointPath,
             introspectionEndpointPath = introspectionEndpointPath,
+            challengeEndpointPath = challengeEndpointPath,
             clientAuthenticationService = AttestationBasedClientAuthenticationService(
                 issuerIdentifier = if (validatePopAudience) authServerPublicContext else null,
             ),
@@ -197,7 +199,6 @@ val OpenId4VciClientExternalAuthorizationServerTest by matrixSuite {
                         onSuccess = { respond(it) },
                         onFailure = { respondOAuth2Error(it) }
                     )
-
                 }
 
                 request.url.toString() == "$authServerPublicContext$introspectionEndpointPath" -> {
@@ -207,11 +208,14 @@ val OpenId4VciClientExternalAuthorizationServerTest by matrixSuite {
                         onSuccess = { respond(it) },
                         onFailure = { respondOAuth2Error(it) }
                     )
-
                 }
 
                 request.url.toString() == "$issuerPublicContext$nonceEndpointPath" -> {
                     respond(credentialIssuer.nonceWithDpopNonce().getOrThrow())
+                }
+
+                request.url.toString() == "$authServerPublicContext$challengeEndpointPath" -> {
+                    respond(externalAuthorizationServer.attestationChallenge().getOrThrow())
                 }
 
                 request.url.toString() == "$issuerPublicContext$credentialEndpointPath" -> {

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientIntegratedDPoPTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientIntegratedDPoPTest.kt
@@ -75,6 +75,7 @@ val OpenId4VciClientIntegratedDPoPTest by matrixSuite {
             val credentialEndpointPath = "/credential"
             val nonceEndpointPath = "/nonce"
             val parEndpointPath = "/par"
+            val challengeEndpointPath = "/challenge"
             val publicContext = "https://issuer.example.com"
             val authorizationService = SimpleAuthorizationService(
                 strategy = CredentialAuthorizationServiceStrategy(credentialSchemes),
@@ -82,6 +83,7 @@ val OpenId4VciClientIntegratedDPoPTest by matrixSuite {
                 authorizationEndpointPath = authorizationEndpointPath,
                 tokenEndpointPath = tokenEndpointPath,
                 pushedAuthorizationRequestEndpointPath = parEndpointPath,
+                challengeEndpointPath = challengeEndpointPath,
                 clientAuthenticationService = AttestationBasedClientAuthenticationService(),
                 tokenService = TokenService.jwt(
                     issueRefreshTokens = true
@@ -103,10 +105,10 @@ val OpenId4VciClientIntegratedDPoPTest by matrixSuite {
             val mockEngine = MockEngine { request ->
                 when {
                     request.url.rawSegments.drop(1) == OpenIdConstants.WellKnownPaths.CredentialIssuer ->
-                        this.respond(credentialIssuer.metadata)
+                        respond(credentialIssuer.metadata)
 
                     request.url.rawSegments.drop(1) == OpenIdConstants.WellKnownPaths.OauthAuthorizationServer ->
-                        this.respond(authorizationService.metadata())
+                        respond(authorizationService.metadata())
 
                     request.url.fullPath.startsWith(parEndpointPath) -> {
                         val requestBody = request.body.toByteArray().decodeToString()
@@ -125,7 +127,7 @@ val OpenId4VciClientIntegratedDPoPTest by matrixSuite {
                             if (requestBody.isEmpty()) queryParameters.decodeFromUrlQuery<RequestParameters>()
                             else requestBody.decodeFromPostBody<RequestParameters>()
                         authorizationService.authorize(authnRequest) { this.catching { TestUtils.dummyUser() } }.fold(
-                            onSuccess = { this.respondRedirect(it.url) },
+                            onSuccess = { respondRedirect(it.url) },
                             onFailure = { fail("$authorizationEndpointPath should not return an error") }
                         )
                     }
@@ -140,7 +142,11 @@ val OpenId4VciClientIntegratedDPoPTest by matrixSuite {
                     }
 
                     request.url.fullPath.startsWith(nonceEndpointPath) -> {
-                        this.respond(credentialIssuer.nonceWithDpopNonce().getOrThrow())
+                        respond(credentialIssuer.nonceWithDpopNonce().getOrThrow())
+                    }
+
+                    request.url.fullPath.startsWith(challengeEndpointPath) -> {
+                        respond(authorizationService.attestationChallenge().getOrThrow())
                     }
 
                     request.url.fullPath.startsWith(credentialEndpointPath) -> {
@@ -156,12 +162,12 @@ val OpenId4VciClientIntegratedDPoPTest by matrixSuite {
                             ),
                             request = request.toRequestInfo(),
                         ).fold(
-                            onSuccess = { this.respond(it) },
+                            onSuccess = { respond(it) },
                             onFailure = { fail("$credentialEndpointPath should not return an error") }
                         )
                     }
 
-                    else -> this.respondError(HttpStatusCode.NotFound)
+                    else -> respondError(HttpStatusCode.NotFound)
                         .also { Napier.w("NOT MATCHED ${request.url.fullPath}") }
                 }
             }

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
@@ -90,6 +90,7 @@ val OpenId4VciClientTest by matrixSuite {
         val credentialEndpointPath = "/credential"
         val nonceEndpointPath = "/nonce"
         val parEndpointPath = "/par"
+        val challengeEndpointPath = "/challenge"
         val publicContext = "https://issuer.example.com"
         val authorizationService = SimpleAuthorizationService(
             strategy = CredentialAuthorizationServiceStrategy(credentialSchemes),
@@ -97,6 +98,7 @@ val OpenId4VciClientTest by matrixSuite {
             authorizationEndpointPath = authorizationEndpointPath,
             tokenEndpointPath = tokenEndpointPath,
             pushedAuthorizationRequestEndpointPath = parEndpointPath,
+            challengeEndpointPath = challengeEndpointPath,
             clientAuthenticationService = AttestationBasedClientAuthenticationService(),
             tokenService = TokenService.jwt(
                 issueRefreshTokens = true
@@ -162,6 +164,10 @@ val OpenId4VciClientTest by matrixSuite {
 
                 request.url.fullPath.startsWith(nonceEndpointPath) -> {
                     respond(credentialIssuer.nonceWithDpopNonce().getOrThrow())
+                }
+
+                request.url.fullPath.startsWith(challengeEndpointPath) -> {
+                    respond(authorizationService.attestationChallenge().getOrThrow())
                 }
 
                 request.url.fullPath.startsWith(credentialEndpointPath) -> {

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientWithEncryptionTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientWithEncryptionTest.kt
@@ -81,6 +81,7 @@ val OpenId4VciClientWithEncryptionTest by matrixSuite {
         val credentialEndpointPath = "/credential"
         val nonceEndpointPath = "/nonce"
         val parEndpointPath = "/par"
+        val challengeEndpointPath = "/challenge"
         val publicContext = "https://issuer.example.com"
         val authorizationService = SimpleAuthorizationService(
             strategy = CredentialAuthorizationServiceStrategy(credentialSchemes),
@@ -88,6 +89,7 @@ val OpenId4VciClientWithEncryptionTest by matrixSuite {
             authorizationEndpointPath = authorizationEndpointPath,
             tokenEndpointPath = tokenEndpointPath,
             pushedAuthorizationRequestEndpointPath = parEndpointPath,
+            challengeEndpointPath = challengeEndpointPath,
             clientAuthenticationService = AttestationBasedClientAuthenticationService(),
             tokenService = TokenService.jwt(
                 issueRefreshTokens = true
@@ -158,13 +160,21 @@ val OpenId4VciClientWithEncryptionTest by matrixSuite {
                     respond(credentialIssuer.nonceWithDpopNonce().getOrThrow())
                 }
 
+                request.url.fullPath.startsWith(challengeEndpointPath) -> {
+                    respond(authorizationService.attestationChallenge().getOrThrow())
+                }
+
                 request.url.fullPath.startsWith(credentialEndpointPath) -> {
                     val requestBody = request.body.toByteArray().decodeToString()
                     val authn = request.headers[HttpHeaders.Authorization].shouldNotBeNull()
                     credentialIssuer.credential(
                         authorizationHeader = authn,
                         params = WalletService.CredentialRequest.parse(requestBody).getOrThrow(),
-                        credentialDataProvider = credentialDataProviderFun(scheme, representation, attributes),
+                        credentialDataProvider = credentialDataProviderFun(
+                            scheme = scheme,
+                            representation = representation,
+                            attributes = attributes
+                        ),
                         request = request.toRequestInfo(),
                     ).fold(
                         onSuccess = { respond(it) },

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/TestUtils.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/TestUtils.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.ktor.openid
 
 import at.asitplus.catching
 import at.asitplus.iso.IssuerSignedItem
+import at.asitplus.openid.AttestationChallengeResponse
 import at.asitplus.openid.IssuerMetadata
 import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.OidcUserInfo
@@ -138,6 +139,13 @@ object TestUtils {
 
     fun MockRequestHandleScope.respond(
         result: PushedAuthenticationResponseParameters
+    ): HttpResponseData = respond(
+        joseCompliantSerializer.encodeToString(result),
+        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+    )
+
+    fun MockRequestHandleScope.respond(
+        result: AttestationChallengeResponse?
     ): HttpResponseData = respond(
         joseCompliantSerializer.encodeToString(result),
         headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/TestUtils.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/TestUtils.kt
@@ -29,6 +29,7 @@ import at.asitplus.wallet.lib.data.SdJwtCredentialScheme
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.RevocationList
 import at.asitplus.wallet.lib.extensions.supportedSdAlgorithms
 import at.asitplus.wallet.lib.oauth2.DPoPNonce
+import at.asitplus.wallet.lib.oauth2.OAuthClientAttestationChallenge
 import at.asitplus.wallet.lib.oauth2.ResponseWithDpopNonce
 import at.asitplus.wallet.lib.oidvci.CredentialDataProviderFun
 import at.asitplus.wallet.lib.oidvci.CredentialIssuer
@@ -57,6 +58,8 @@ object TestUtils {
             append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             (throwable as? OAuth2Exception.UseDpopNonce)?.dpopNonce
                 ?.let { append(HttpHeaders.DPoPNonce, it) }
+            (throwable as? OAuth2Exception.UseAttestationChallenge)?.attestationChallenge
+                ?.let { append(HttpHeaders.OAuthClientAttestationChallenge, it) }
         },
         status = HttpStatusCode.BadRequest
     ).also { Napier.w("Server error: ${throwable.message}", throwable) }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AttestationBasedClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AttestationBasedClientAuthenticationService.kt
@@ -17,7 +17,9 @@ import at.asitplus.wallet.lib.jws.VerifyJwsObjectFun
 import at.asitplus.wallet.lib.jws.VerifyJwsSignatureWithCnf
 import at.asitplus.wallet.lib.jws.VerifyJwsSignatureWithCnfFun
 import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService.Companion.DEFAULT_WALLET_ATTESTATION_ALGORITHMS
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidClient
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception.UseAttestationChallenge
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.jvm.JvmOverloads
 import kotlin.time.Clock
@@ -185,17 +187,17 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
             throw InvalidClient("client attestation PoP expired: ${payload.expiration}")
         }
         if (payload.nonce == null && payload.challenge == null) {
-            throw InvalidClient("client attestation PoP missing challenge/nonce")
+            throw UseAttestationChallenge("client attestation PoP missing challenge/nonce")
         }
         payload.nonce?.let { nonce ->
             if (!nonceService.verifyAndRemoveNonce(nonce)) {
-                throw InvalidClient("client attestation PoP invalid nonce")
+                throw UseAttestationChallenge("client attestation PoP nonce invalid")
             }
         } ?: payload.challenge?.let { challenge ->
             if (!nonceService.verifyAndRemoveNonce(challenge)) {
-                throw InvalidClient("client attestation PoP invalid challenge")
+                throw UseAttestationChallenge("client attestation PoP challenge invalid")
             }
-        } ?: throw InvalidClient("client attestation PoP missing challenge")
+        } ?: throw UseAttestationChallenge("client attestation PoP challenge missing")
         // TODO Verify other fields
         // TODO Validate signature against CNF key
     }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AttestationBasedClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AttestationBasedClientAuthenticationService.kt
@@ -2,15 +2,21 @@ package at.asitplus.wallet.lib.oauth2
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
+import at.asitplus.openid.OAuth2AuthorizationServerMetadata
+import at.asitplus.openid.OpenIdConstants
+import at.asitplus.openid.OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH
 import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.signum.indispensable.josef.JwsAlgorithm
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
+import at.asitplus.wallet.lib.DefaultNonceService
+import at.asitplus.wallet.lib.NonceService
 import at.asitplus.wallet.lib.etsi.Success
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.jws.VerifyJwsObject
 import at.asitplus.wallet.lib.jws.VerifyJwsObjectFun
 import at.asitplus.wallet.lib.jws.VerifyJwsSignatureWithCnf
 import at.asitplus.wallet.lib.jws.VerifyJwsSignatureWithCnfFun
+import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService.Companion.DEFAULT_WALLET_ATTESTATION_ALGORITHMS
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidClient
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.jvm.JvmOverloads
@@ -50,9 +56,24 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
     private val timeLeeway: Duration = 5.minutes,
     /** Identifier of this authorization server, to verify `aud` of incoming PoP JWTs. */
     private val issuerIdentifier: String? = null,
+    /** Used for [OAuth2AuthorizationServerMetadata.clientAttestationSigningAlgValuesSupportedStrings] */
+    private val supportedSigningAlgorithms: Set<JwsAlgorithm.Signature> = DEFAULT_WALLET_ATTESTATION_ALGORITHMS,
+    /** Service used to create challenges for the clients to use in PoP JWT. */
+    private val nonceService: NonceService = DefaultNonceService(),
 ) : ClientAuthenticationService {
+    override val supportedAuthMethods: Set<String>
+        get() = setOf(AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH)
 
-    // TODO Add challenge service here
+    override val supportedPopSigningAlgs: Set<String>
+        get() = supportedSigningAlgorithms.map { it.identifier }.toSet()
+
+    override val supportedSigningAlgs: Set<String>
+        get() = supportedSigningAlgorithms.map { it.identifier }.toSet()
+
+    override val supportedPopMethods: Set<OpenIdConstants.ClientAttestationPopMethod>
+        get() = setOf(OpenIdConstants.ClientAttestationPopMethod.None)
+
+    override suspend fun getAttestationChallenge(): String = nonceService.provideNonce()
 
     /**
      * Authenticates the client as defined from a client attestation JWT.
@@ -97,7 +118,7 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
             throw InvalidClient("client attestation has no x5c")
         }
         if (jws.jwsHeader.algorithm !is JwsAlgorithm.Signature ||
-            jws.jwsHeader.algorithm !in SimpleAuthorizationService.DEFAULT_WALLET_ATTESTATION_ALGORITHMS
+            jws.jwsHeader.algorithm !in supportedSigningAlgorithms
         ) {
             throw InvalidClient("unsupported client attestation alg: ${jws.jwsHeader.algorithm}")
         }
@@ -140,12 +161,12 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
         }
     }
 
-    private fun JwsCompactTyped<JsonWebToken>.validateWalletInstanceAttestationPop(clientId: String?) {
+    private suspend fun JwsCompactTyped<JsonWebToken>.validateWalletInstanceAttestationPop(clientId: String?) {
         if (jws.jwsHeader.type != JwsContentTypeConstants.CLIENT_ATTESTATION_POP_JWT) {
             throw InvalidClient("invalid client attestation PoP typ: ${jws.jwsHeader.type}")
         }
         if (jws.jwsHeader.algorithm !is JwsAlgorithm.Signature ||
-            jws.jwsHeader.algorithm !in SimpleAuthorizationService.DEFAULT_WALLET_ATTESTATION_ALGORITHMS
+            jws.jwsHeader.algorithm !in supportedSigningAlgorithms
         ) {
             throw InvalidClient("unsupported client attestation PoP alg: ${jws.jwsHeader.algorithm}")
         }
@@ -163,8 +184,19 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
         if (payload.expiration == null || payload.expiration!! < (clock.now() - timeLeeway)) {
             throw InvalidClient("client attestation PoP expired: ${payload.expiration}")
         }
+        if (payload.nonce == null && payload.challenge == null) {
+            throw InvalidClient("client attestation PoP missing challenge/nonce")
+        }
+        payload.nonce?.let { nonce ->
+            if (!nonceService.verifyAndRemoveNonce(nonce)) {
+                throw InvalidClient("client attestation PoP invalid nonce")
+            }
+        } ?: payload.challenge?.let { challenge ->
+            if (!nonceService.verifyAndRemoveNonce(challenge)) {
+                throw InvalidClient("client attestation PoP invalid challenge")
+            }
+        } ?: throw InvalidClient("client attestation PoP missing challenge")
         // TODO Verify other fields
-        // TODO Need to verify challenge
         // TODO Validate signature against CNF key
     }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AttestationBasedClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AttestationBasedClientAuthenticationService.kt
@@ -5,6 +5,7 @@ import at.asitplus.catching
 import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH
+import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.signum.indispensable.josef.JwsAlgorithm
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
@@ -20,6 +21,7 @@ import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService.Companion.DEFAUL
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidClient
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.UseAttestationChallenge
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception.UseFreshAttestation
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.jvm.JvmOverloads
 import kotlin.time.Clock
@@ -56,6 +58,8 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
     private val clock: Clock = Clock.System,
     /** Time leeway for verification of WIA and WIA PoP timestamps. */
     private val timeLeeway: Duration = 5.minutes,
+    /** Maximum age of WIA PoP JWTs. */
+    private val maxAgePoP: Duration = 10.minutes,
     /** Identifier of this authorization server, to verify `aud` of incoming PoP JWTs. */
     private val issuerIdentifier: String? = null,
     /** Used for [OAuth2AuthorizationServerMetadata.clientAttestationSigningAlgValuesSupportedStrings] */
@@ -73,14 +77,13 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
         get() = supportedSigningAlgorithms.map { it.identifier }.toSet()
 
     override val supportedPopMethods: Set<OpenIdConstants.ClientAttestationPopMethod>
-        get() = setOf(OpenIdConstants.ClientAttestationPopMethod.None)
+        get() = setOf(OpenIdConstants.ClientAttestationPopMethod.AttestationPopJwt)
 
     override suspend fun getAttestationChallenge(): String = nonceService.provideNonce()
 
     /**
      * Authenticates the client as defined from a client attestation JWT.
      */
-    @Throws(InvalidClient::class, CancellationException::class)
     override suspend fun authenticateClient(
         httpRequest: RequestInfo?,
         clientId: String?,
@@ -102,13 +105,13 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
             throw InvalidClient("client attestation not verified")
         }
 
-        instanceAttestationPopJwt.validateWalletInstanceAttestationPop(instanceAttestation.payload.subject)
         val cnf = instanceAttestation.payload.confirmationClaim
             ?: throw InvalidClient("client attestation has no cnf")
         if (!verifyJwsSignatureWithCnf(instanceAttestationPopJwt.jws, cnf)) {
             throw InvalidClient("client attestation PoP JWT not verified")
         }
 
+        instanceAttestationPopJwt.validateWalletInstanceAttestationPop(instanceAttestation.payload.subject)
         Success
     }
 
@@ -124,9 +127,6 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
         ) {
             throw InvalidClient("unsupported client attestation alg: ${jws.jwsHeader.algorithm}")
         }
-        if (payload.issuer != null) {
-            throw InvalidClient("client attestation must not contain iss")
-        }
         if (payload.subject == null) {
             throw InvalidClient("client attestation has no sub")
         }
@@ -136,13 +136,13 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
         val issuedAt = payload.issuedAt ?: throw InvalidClient("client attestation has no iat")
         val expiration = payload.expiration ?: throw InvalidClient("client attestation has no exp")
         if (issuedAt > (clock.now() + timeLeeway)) {
-            throw InvalidClient("client attestation iat in future: $issuedAt")
+            throw UseFreshAttestation("client attestation iat in future: $issuedAt")
         }
         if (expiration < (clock.now() - timeLeeway)) {
-            throw InvalidClient("client attestation expired: $expiration")
+            throw UseFreshAttestation("client attestation expired: $expiration")
         }
         if (expiration - issuedAt >= 24.hours) {
-            throw InvalidClient("client attestation lifetime must be less than 24 hours")
+            throw UseFreshAttestation("client attestation lifetime must be less than 24 hours")
         }
         if (payload.walletName.isNullOrBlank()) {
             throw InvalidClient("client attestation has no wallet_name")
@@ -157,13 +157,16 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
         if (clientStatus.expiration < (clock.now() - timeLeeway)) {
             throw InvalidClient("client_status expiration in past: ${clientStatus.expiration}")
         }
-        if (payload.confirmationClaim == null) {
-            // TODO Validate this is an asymmetric key
-            throw InvalidClient("client attestation has no cnf")
+        val confirmationKey = payload.confirmationClaim?.jsonWebKey?.toCryptoPublicKey()?.getOrNull()
+            ?: throw InvalidClient("client attestation has no cnf")
+        if (confirmationKey !is CryptoPublicKey.EC && confirmationKey !is CryptoPublicKey.RSA) {
+            throw InvalidClient("client attestation confirmation key is not asymmetric")
         }
     }
 
-    private suspend fun JwsCompactTyped<JsonWebToken>.validateWalletInstanceAttestationPop(clientId: String?) {
+    private suspend fun JwsCompactTyped<JsonWebToken>.validateWalletInstanceAttestationPop(
+        attestationSubject: String?
+    ) {
         if (jws.jwsHeader.type != JwsContentTypeConstants.CLIENT_ATTESTATION_POP_JWT) {
             throw InvalidClient("invalid client attestation PoP typ: ${jws.jwsHeader.type}")
         }
@@ -172,34 +175,41 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
         ) {
             throw InvalidClient("unsupported client attestation PoP alg: ${jws.jwsHeader.algorithm}")
         }
-        if (payload.issuer == null || payload.issuer != clientId) {
-            throw InvalidClient("client attestation PoP iss not equal to client_id")
-        }
         if (issuerIdentifier != null && payload.audience != issuerIdentifier) {
             throw InvalidClient(
                 "client attestation PoP aud '${payload.audience}' does not match issuer '$issuerIdentifier'"
             )
         }
-        if (payload.issuedAt == null || payload.issuedAt!! > (clock.now() + timeLeeway)) {
-            throw InvalidClient("client attestation PoP iat in future: ${payload.issuedAt}")
+        val issuedAt = payload.issuedAt
+            ?: throw InvalidClient("client attestation PoP has no iat")
+        val expiration = payload.expiration // not required!
+        if (issuedAt > (clock.now() + timeLeeway)) {
+            throw InvalidClient("client attestation PoP iat in future: $issuedAt")
         }
-        if (payload.expiration == null || payload.expiration!! < (clock.now() - timeLeeway)) {
-            throw InvalidClient("client attestation PoP expired: ${payload.expiration}")
+        if (issuedAt < (clock.now() - maxAgePoP - timeLeeway)) {
+            throw InvalidClient("client attestation PoP issued too long ago: $issuedAt")
+        }
+        if (expiration != null && expiration < (clock.now() - timeLeeway)) {
+            throw InvalidClient("client attestation PoP expired: $expiration")
+        }
+        if (payload.jwtId == null) {
+            throw InvalidClient("client attestation PoP has no jti")
+        }
+        if (payload.issuer != null && attestationSubject != null && payload.issuer != attestationSubject) {
+            throw InvalidClient("client attestation PoP issuer not equal to attestation subject")
         }
         if (payload.nonce == null && payload.challenge == null) {
-            throw UseAttestationChallenge("client attestation PoP missing challenge/nonce")
+            throw UseAttestationChallenge(nonceService.provideNonce(), "client attestation PoP missing challenge/nonce")
         }
         payload.nonce?.let { nonce ->
             if (!nonceService.verifyAndRemoveNonce(nonce)) {
-                throw UseAttestationChallenge("client attestation PoP nonce invalid")
+                throw UseAttestationChallenge(nonceService.provideNonce(), "client attestation PoP nonce invalid")
             }
         } ?: payload.challenge?.let { challenge ->
             if (!nonceService.verifyAndRemoveNonce(challenge)) {
-                throw UseAttestationChallenge("client attestation PoP challenge invalid")
+                throw UseAttestationChallenge(nonceService.provideNonce(), "client attestation PoP challenge invalid")
             }
-        } ?: throw UseAttestationChallenge("client attestation PoP challenge missing")
-        // TODO Verify other fields
-        // TODO Validate signature against CNF key
+        } ?: throw UseAttestationChallenge(nonceService.provideNonce(), "client attestation PoP challenge missing")
     }
 
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.oauth2
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
+import at.asitplus.openid.OpenIdConstants
 import at.asitplus.wallet.lib.etsi.Success
 
 /**
@@ -9,6 +10,15 @@ import at.asitplus.wallet.lib.etsi.Success
  * see [SimpleAuthorizationService] and subclasses of this interface.
  */
 interface ClientAuthenticationService {
+
+    val supportedAuthMethods: Set<String>?
+    val supportedSigningAlgs: Set<String>?
+    val supportedPopSigningAlgs: Set<String>?
+    val supportedPopMethods: Set<OpenIdConstants.ClientAttestationPopMethod>?
+
+    /** Provide a fresh challenge for attestation PoPs. */
+    suspend fun getAttestationChallenge(): String?
+
     /** Authenticates the client by some data in the request. */
     suspend fun authenticateClient(
         httpRequest: RequestInfo?,
@@ -18,6 +28,17 @@ interface ClientAuthenticationService {
 
 /** Does not verify the client authentication at all */
 object NoopClientAuthenticationService : ClientAuthenticationService {
+    override val supportedAuthMethods: Set<String>?
+        get() = null
+    override val supportedSigningAlgs: Set<String>?
+        get() = null
+    override val supportedPopSigningAlgs: Set<String>?
+        get() = null
+    override val supportedPopMethods: Set<OpenIdConstants.ClientAttestationPopMethod>
+        get() = setOf(OpenIdConstants.ClientAttestationPopMethod.None)
+
+    override suspend fun getAttestationChallenge(): String? = null
+
     override suspend fun authenticateClient(
         httpRequest: RequestInfo?,
         clientId: String?

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/RequestInfo.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/RequestInfo.kt
@@ -70,6 +70,9 @@ val HttpHeaders.OAuthClientAttestation: String
 val HttpHeaders.OAuthClientAttestationPop: String
     get() = "OAuth-Client-Attestation-PoP"
 
+val HttpHeaders.OAuthClientAttestationChallenge: String
+    get() = "OAuth-Client-Attestation-Challenge"
+
 val HttpHeaders.DPoP: String
     get() = "DPoP"
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -114,7 +114,7 @@ class SimpleAuthorizationService @JvmOverloads constructor(
     private val introspectionEndpointPath: String = "/introspect",
     /**
      * Used to build [OAuth2AuthorizationServerMetadata.challengeEndpointUrl], i.e. implementers need to forward requests
-     * to that URI (which starts with [publicContext]) to [challenge].
+     * to that URI (which starts with [publicContext]) to [attestationChallenge].
      */
     private val challengeEndpointPath: String = "/challenge",
     /** Associates issuer_state with credential offers. */
@@ -206,8 +206,10 @@ class SimpleAuthorizationService @JvmOverloads constructor(
      * See
      * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html#name-challenges)
      */
-    suspend fun attestationChallenge() = clientAuthenticationService.getAttestationChallenge()?.let {
-        AttestationChallengeResponse(attestationChallenge = it)
+    suspend fun attestationChallenge(): KmmResult<AttestationChallengeResponse?> = catching {
+        clientAuthenticationService.getAttestationChallenge()?.let {
+            AttestationChallengeResponse(attestationChallenge = it)
+        }
     }
 
     /**
@@ -317,7 +319,7 @@ class SimpleAuthorizationService @JvmOverloads constructor(
         val actualRequest = request.extractPushedRequestParams()
         Napier.i("par called with $actualRequest")
         // TODO bind PAR request state, authorization codes and refresh tokens to the authenticated key
-        clientAuthenticationService.authenticateClient(httpRequest, actualRequest.clientId)
+        clientAuthenticationService.authenticateClient(httpRequest, actualRequest.clientId).getOrThrow()
         // PAR stores the request for later authorization. issuer_state is single-use and must only be consumed
         // when /authorize is executed with the referenced request_uri.
         actualRequest.validate(validateIssuerState = false)
@@ -473,7 +475,7 @@ class SimpleAuthorizationService @JvmOverloads constructor(
         httpRequest: RequestInfo?,
     ): KmmResult<TokenResponseParameters> = catching {
         Napier.i("token called with $request")
-        clientAuthenticationService.authenticateClient(httpRequest, request.clientId)
+        clientAuthenticationService.authenticateClient(httpRequest, request.clientId).getOrThrow()
         if (request.grantType == OpenIdConstants.GRANT_TYPE_TOKEN_EXCHANGE) {
             val userInfoEndpoint = metadata().userInfoEndpoint
                 ?: throw InvalidGrant("token_exchange requires userInfoEndpoint")
@@ -546,8 +548,6 @@ class SimpleAuthorizationService @JvmOverloads constructor(
         val response = token(request, httpRequest).getOrThrow()
         ResponseWithDpopNonce(response, tokenService.dpopNonce())
     }
-
-    // TODO Challenge endpoint for Attestation-Based Client Auth
 
     private fun validateCodeChallenge(code: String, codeVerifier: String?, codeChallenge: String) {
         if (codeVerifier == null) {
@@ -670,7 +670,7 @@ class SimpleAuthorizationService @JvmOverloads constructor(
         httpRequest: RequestInfo?,
     ): KmmResult<TokenIntrospectionResult> = catching {
         // TODO Which client_id to pass?
-        clientAuthenticationService.authenticateClient(httpRequest, null)
+        clientAuthenticationService.authenticateClient(httpRequest, null).getOrThrow()
         val response = catchingUnwrapped {
             tokenService.verification.getTokenInfo(request.token)
         }.fold(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -466,7 +466,7 @@ class SimpleAuthorizationService @JvmOverloads constructor(
      * @param request as sent from the client as `POST`
      * @param httpRequest information about the HTTP request from the client, to validate authentication
      *
-     * @return [KmmResult] may contain a [OAuth2Exception], especially a [UseDpopNonce]
+     * @return [KmmResult] may contain a [OAuth2Exception], especially a [UseDpopNonce] or [UseAttestationChallenge]
      */
     override suspend fun token(
         request: TokenRequestParameters,
@@ -615,7 +615,7 @@ class SimpleAuthorizationService @JvmOverloads constructor(
     /**
      * Returns the user info associated with this access token, when the token in [authorizationHeader] is correct.
      *
-     * @return [KmmResult] may contain a [OAuth2Exception], especially a [UseDpopNonce]
+     * @return [KmmResult] may contain a [OAuth2Exception], especially a [UseDpopNonce] or [UseAttestationChallenge]
      */
     override suspend fun userInfo(
         authorizationHeader: String,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -4,6 +4,7 @@ import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.catchingUnwrapped
 import at.asitplus.iso.sha256
+import at.asitplus.openid.AttestationChallengeResponse
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.AuthenticationResponseParameters
 import at.asitplus.openid.AuthorizationDetails
@@ -16,7 +17,6 @@ import at.asitplus.openid.JarRequestParameters
 import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.openid.OpenIdConstants
-import at.asitplus.openid.OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH
 import at.asitplus.openid.PushedAuthenticationResponseParameters
 import at.asitplus.openid.RequestObjectParameters
 import at.asitplus.openid.RequestParameters
@@ -112,7 +112,11 @@ class SimpleAuthorizationService @JvmOverloads constructor(
      * requests to that URI (which starts with [publicContext]) to [getTokenInfo].
      */
     private val introspectionEndpointPath: String = "/introspect",
-    // TODO Add challenge endpoint path for Attestation-Based Client Auth
+    /**
+     * Used to build [OAuth2AuthorizationServerMetadata.challengeEndpointUrl], i.e. implementers need to forward requests
+     * to that URI (which starts with [publicContext]) to [challenge].
+     */
+    private val challengeEndpointPath: String = "/challenge",
     /** Associates issuer_state with credential offers. */
     private val issuerStateToCredentialOffer: MapStore<String, CredentialOffer> = DefaultMapStore(),
     /** Associates issued codes with the auth request from the client. */
@@ -168,13 +172,14 @@ class SimpleAuthorizationService @JvmOverloads constructor(
             pushedAuthorizationRequestEndpoint = "$publicContext$pushedAuthorizationRequestEndpointPath",
             userInfoEndpoint = "$publicContext$userInfoEndpointPath",
             introspectionEndpoint = "$publicContext$introspectionEndpointPath",
-            introspectionEndpointAuthMethodsSupported = setOf(AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH),
+            challengeEndpoint = clientAuthenticationService.supportedAuthMethods.takeIf { it != null }
+                ?.let { "$publicContext$challengeEndpointPath" },
             requirePushedAuthorizationRequests = requirePushedAuthorizationRequests,
-            tokenEndPointAuthMethodsSupported = setOf(AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH), // per OID4VC HAIP
-            clientAttestationSigningAlgValuesSupportedStrings = supportedSigningAlgorithms
-                .map { it.identifier }.toSet(),
-            clientAttestationPopSigningAlgValuesSupportedStrings = supportedSigningAlgorithms
-                .map { it.identifier }.toSet(),
+            introspectionEndpointAuthMethodsSupported = clientAuthenticationService.supportedAuthMethods,
+            tokenEndPointAuthMethodsSupported = clientAuthenticationService.supportedAuthMethods,
+            clientAttestationSigningAlgValuesSupportedStrings = clientAuthenticationService.supportedSigningAlgs,
+            clientAttestationPopSigningAlgValuesSupportedStrings = clientAuthenticationService.supportedPopSigningAlgs,
+            clientAttestationPopMethodsSupported = clientAuthenticationService.supportedPopMethods,
             dpopSigningAlgValuesSupportedStrings = tokenService.dpopSigningAlgValuesSupportedStrings,
             requestObjectSigningAlgorithmsSupportedStrings = requestObjectSigningAlgorithms
                 ?.map { it.identifier }?.toSet(),
@@ -194,6 +199,16 @@ class SimpleAuthorizationService @JvmOverloads constructor(
      * see [OpenIdConstants.WellKnownPaths.OauthAuthorizationServer].
      */
     override suspend fun metadata(): OAuth2AuthorizationServerMetadata = _metadata
+
+    /**
+     * MUST be delivered with HTTP header `Cache-Control: no-store` (see [io.ktor.http.HttpHeaders.CacheControl]).
+     * Serialize the body as JSON.
+     * See
+     * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html#name-challenges)
+     */
+    suspend fun attestationChallenge() = clientAuthenticationService.getAttestationChallenge()?.let {
+        AttestationChallengeResponse(attestationChallenge = it)
+    }
 
     /**
      * Offer some credential identifiers from [strategy] to clients with auth-code flow.
@@ -301,6 +316,7 @@ class SimpleAuthorizationService @JvmOverloads constructor(
     ) = catching {
         val actualRequest = request.extractPushedRequestParams()
         Napier.i("par called with $actualRequest")
+        // TODO bind PAR request state, authorization codes and refresh tokens to the authenticated key
         clientAuthenticationService.authenticateClient(httpRequest, actualRequest.clientId)
         // PAR stores the request for later authorization. issuer_state is single-use and must only be consumed
         // when /authorize is executed with the referenced request_uri.

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2Exception.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2Exception.kt
@@ -18,6 +18,7 @@ import at.asitplus.openid.OpenIdConstants.Errors.REGISTRATION_VALUE_NOT_SUPPORTE
 import at.asitplus.openid.OpenIdConstants.Errors.UNKNOWN_CREDENTIAL_CONFIGURATION
 import at.asitplus.openid.OpenIdConstants.Errors.UNKNOWN_CREDENTIAL_IDENTIFIER
 import at.asitplus.openid.OpenIdConstants.Errors.USER_CANCELLED
+import at.asitplus.openid.OpenIdConstants.Errors.USE_ATTESTATION_CHALLENGE
 import at.asitplus.openid.OpenIdConstants.Errors.USE_DPOP_NONCE
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import kotlinx.serialization.DeserializationStrategy
@@ -110,6 +111,14 @@ sealed class OAuth2Exception(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
     ) : OAuth2Exception(USE_DPOP_NONCE, description), OAuthAuthorizationError
+
+    @Serializable
+    class UseAttestationChallenge(
+        /** Set this as the value for HTTP header `OAuth-Client-Attestation-Challenge` in the response. */
+        val attestationChallenge: String,
+        @Transient val description: String? = null,
+        @Transient override val cause: Throwable? = null
+    ) : OAuth2Exception(USE_ATTESTATION_CHALLENGE, description), OAuthAuthorizationError
 
     @Serializable
     class InvalidCredentialRequest(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2Exception.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2Exception.kt
@@ -20,6 +20,7 @@ import at.asitplus.openid.OpenIdConstants.Errors.UNKNOWN_CREDENTIAL_IDENTIFIER
 import at.asitplus.openid.OpenIdConstants.Errors.USER_CANCELLED
 import at.asitplus.openid.OpenIdConstants.Errors.USE_ATTESTATION_CHALLENGE
 import at.asitplus.openid.OpenIdConstants.Errors.USE_DPOP_NONCE
+import at.asitplus.openid.OpenIdConstants.Errors.USE_FRESH_ATTESTATION
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.Serializable
@@ -35,7 +36,7 @@ import kotlinx.serialization.json.JsonElement
 sealed class OAuth2Exception(
     val error: String,
     @Transient val errorDescription: String? = null,
-) : Throwable("$error${errorDescription?.let { ": $it" }}") {
+) : Throwable("$error${errorDescription?.let { ": $it" } ?: ""}") {
 
     fun serialize() = joseCompliantSerializer.encodeToString(OAuth2ExceptionSerializer, this)
 
@@ -119,6 +120,12 @@ sealed class OAuth2Exception(
         @Transient val description: String? = null,
         @Transient override val cause: Throwable? = null
     ) : OAuth2Exception(USE_ATTESTATION_CHALLENGE, description), OAuthAuthorizationError
+
+    @Serializable
+    class UseFreshAttestation(
+        @Transient val description: String? = null,
+        @Transient override val cause: Throwable? = null
+    ) : OAuth2Exception(USE_FRESH_ATTESTATION, description)
 
     @Serializable
     class InvalidCredentialRequest(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2SecurityExtensions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2SecurityExtensions.kt
@@ -44,9 +44,7 @@ object BuildDPoPHeader {
             accessTokenHash = accessToken?.encodeToByteArray()?.sha256()?.encodeToString(Base64UrlStrict),
             issuedAt = Clock.System.now().truncateToSeconds(),
             nonce = nonce,
-        ).also {
-            Napier.d("Building DPoP JWT: $it")
-        },
+        ),
         serializer = JsonWebToken.serializer(),
     ).getOrThrow()
 }
@@ -96,9 +94,7 @@ object BuildClientAttestationJwt {
             confirmationClaim = ConfirmationClaim(
                 jsonWebKey = clientKey,
             )
-        ).also {
-            Napier.d("Building client attestation JWT: $it")
-        },
+        ),
         serializer = JsonWebToken.serializer(),
     ).getOrThrow()
 
@@ -116,32 +112,25 @@ object BuildClientAttestationPoPJwt {
      * e.g. as HTTP header `OAuth-Client-Attestation-PoP`, see
      * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html)
      *
-     * @param clientId OAuth 2.0 client ID of the wallet
-     * @param audience The RFC8414 issuer identifier URL of the authorization server MUST be used
+     * @param audience The RFC8414 issuer identifier URL of the authorization server or the resource server MUST be used
      * @param nonce optionally provided from the authorization server
-     * @param lifetime validity period of the assertion (minus the [clockSkew])
      * @param clockSkew duration to subtract from [Clock.System.now] when setting the creation timestamp
      */
     suspend operator fun invoke(
         signJwt: SignJwtFun<JsonWebToken>,
-        clientId: String,
         audience: String,
         nonce: String? = null,
-        lifetime: Duration = 10.minutes,
         clockSkew: Duration = 3.minutes,
         randomSource: RandomSource = RandomSource.Secure
     ): JwsCompactTyped<JsonWebToken> = signJwt(
         type = JwsContentTypeConstants.CLIENT_ATTESTATION_POP_JWT,
-        // TODO Validate fields against latest draft
         payload = JsonWebToken(
-            issuer = clientId,
             audience = audience,
             jwtId = randomSource.nextBytes(12).encodeToString(Base64UrlStrict),
             // Setting both fields here, this changed in draft 10 of OAuth 2.0 Attestation-Based Client Auth
             nonce = nonce,
             challenge = nonce,
             issuedAt = Clock.System.now().truncateToSeconds() - clockSkew.absoluteValue,
-            expiration = Clock.System.now().truncateToSeconds() - clockSkew.absoluteValue + lifetime,
         ).also {
             Napier.d("Building client attestation PoP JWT: $it")
         },

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
@@ -57,29 +57,29 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
             )
 
             val signClientAttestationPop: SignJwtFun<JsonWebToken> = SignJwt(clientKey, JwsHeaderNone())
-            // TODO Need support for nonce/challenge
+            val scope = randomString()
+            val server = SimpleAuthorizationService(
+                publicContext = AUTHORIZATION_SERVER,
+                strategy = DummyAuthorizationServiceStrategy(scope),
+                clientAuthenticationService = AttestationBasedClientAuthenticationService(
+                    issuerIdentifier = AUTHORIZATION_SERVER,
+                    verifyJwsObject = VerifyJwsObjectTrustedCertificate(
+                        trustedIssuers = { setOf(walletProviderCaCert) }
+                    ),
+                )
+            )
             val clientAttestationPop = BuildClientAttestationPoPJwt(
                 signJwt = signClientAttestationPop,
-                clientId = client.clientId,
                 audience = AUTHORIZATION_SERVER,
                 randomSource = RandomSource.Default
             )
 
             object {
-                val scope = randomString()
+                val scope = scope
                 val client = client
-                val walletProviderCa = walletProviderCa
-                val attesterBackend = attesterBackend
-                var server = SimpleAuthorizationService(
-                    publicContext = AUTHORIZATION_SERVER,
-                    strategy = DummyAuthorizationServiceStrategy(scope),
-clientAuthenticationService = AttestationBasedClientAuthenticationService(
-    verifyJwsObject = VerifyJwsObjectTrustedCertificate(
-        trustedIssuers = { setOf(walletProviderCaCert) }
-    ),)
-                )
+                val server = server
                 val clientKey = clientKey
-                var clientAttestation = clientAttestation
+                val clientAttestation = clientAttestation
                 val clientAttestationPop = clientAttestationPop
                 val signClientAttestationPop = signClientAttestationPop
 
@@ -101,22 +101,22 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
                  */
                 suspend fun freshPop() = BuildClientAttestationPoPJwt(
                     signJwt = signClientAttestationPop,
-                    clientId = client.clientId,
                     audience = AUTHORIZATION_SERVER,
+                    nonce = server.attestationChallenge().getOrThrow().shouldNotBeNull().attestationChallenge,
                     randomSource = RandomSource.Default
                 )
 
                 @Suppress("DEPRECATION")
                 suspend fun par(
                     clientAttestation: JwsCompactTyped<JsonWebToken> = this.clientAttestation,
-                    clientAttestationPop: JwsCompactTyped<JsonWebToken> = this.clientAttestationPop,
+                    clientAttestationPop: JwsCompactTyped<JsonWebToken>? = null,
                 ) = server.par(
                     client.createAuthRequestJar(state = uuid4().toString(), scope = scope),
                     RequestInfo(
                         url = "https://example.com/",
                         method = HttpMethod.Post,
                         clientAttestation = clientAttestation,
-                        clientAttestationPop = clientAttestationPop,
+                        clientAttestationPop = clientAttestationPop ?: freshPop(),
                     )
                 ).getOrThrow()
 
@@ -160,6 +160,7 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
                 state = state,
                 scope = it.scope,
             )
+
             @Suppress("DEPRECATION")
             val parResponse = it.server.par(
                 authnRequest,
@@ -167,7 +168,7 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
                     url = "https://example.com/",
                     method = HttpMethod.Post,
                     clientAttestation = it.clientAttestation,
-                    clientAttestationPop = it.clientAttestationPop
+                    clientAttestationPop = it.freshPop()
                 )
             ).getOrThrow()
                 .shouldBeInstanceOf<PushedAuthenticationResponseParameters>()
@@ -194,30 +195,17 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
             it.clientAttestationPop.payload.expiration.shouldBeNull()
         }
 
-        test("client attestation PoP uses challenge instead of nonce") {
-            val challenge = randomString()
+        test("client attestation PoP uses challenge and nonce") {
+            val challenge = it.server.attestationChallenge().getOrThrow().shouldNotBeNull().attestationChallenge
             val pop = BuildClientAttestationPoPJwt(
                 signJwt = it.signClientAttestationPop,
-                clientId = it.client.clientId,
                 audience = "some server",
                 nonce = challenge,
                 randomSource = RandomSource.Default,
             )
 
             pop.payload.challenge shouldBe challenge
-            pop.payload.nonce.shouldBeNull()
-        }
-
-        test("reject client attestation with secret material in cnf jwk") {
-            val clientAttestation = BuildClientAttestationJwt(
-                signJwt = it.attesterBackend,
-                clientId = it.client.clientId,
-                clientKey = it.clientKey.jsonWebKey.copy(k = byteArrayOf(1)),
-            )
-
-            shouldThrow<OAuth2Exception> {
-                it.par(clientAttestation = clientAttestation)
-            }
+            pop.payload.nonce shouldBe challenge
         }
 
         test("reject client attestation without cnf") {
@@ -238,7 +226,7 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
 
         test("accept client attestation PoP with iss and exp, removed in draft 8 and 6 but tolerated") {
             val pop = it.signPop(
-                it.clientAttestationPop.payload.copy(
+                it.freshPop().payload.copy(
                     issuer = it.client.clientId,
                     expiration = Clock.System.now() + 10.minutes,
                 )
@@ -249,7 +237,7 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
 
         test("reject client attestation PoP with iss of another client") {
             val pop = it.signPop(
-                it.clientAttestationPop.payload.copy(issuer = "https://attacker.example")
+                it.freshPop().payload.copy(issuer = "https://attacker.example")
             )
 
             shouldThrow<OAuth2Exception> {
@@ -259,7 +247,7 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
 
         test("reject expired client attestation PoP") {
             val pop = it.signPop(
-                it.clientAttestationPop.payload.copy(expiration = Clock.System.now() - 1.hours)
+                it.freshPop().payload.copy(expiration = Clock.System.now() - 1.hours)
             )
 
             shouldThrow<OAuth2Exception> {
@@ -268,7 +256,7 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
         }
 
         test("reject client attestation PoP without jti") {
-            val pop = it.signPop(it.clientAttestationPop.payload.copy(jwtId = null))
+            val pop = it.signPop(it.freshPop().payload.copy(jwtId = null))
 
             shouldThrow<OAuth2Exception> {
                 it.par(clientAttestationPop = pop)
@@ -277,7 +265,7 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
 
         test("reject client attestation PoP for another audience") {
             val pop = it.signPop(
-                it.clientAttestationPop.payload.copy(audience = "https://attacker.example")
+                it.freshPop().payload.copy(audience = "https://attacker.example")
             )
 
             shouldThrow<OAuth2Exception> {
@@ -286,7 +274,7 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
         }
 
         test("reject client attestation PoP without aud") {
-            val pop = it.signPop(it.clientAttestationPop.payload.copy(audience = null))
+            val pop = it.signPop(it.freshPop().payload.copy(audience = null))
 
             shouldThrow<OAuth2Exception> {
                 it.par(clientAttestationPop = pop)
@@ -295,7 +283,7 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
 
         test("reject stale client attestation PoP") {
             val pop = it.signPop(
-                it.clientAttestationPop.payload.copy(issuedAt = Clock.System.now() - 1.hours)
+                it.freshPop().payload.copy(issuedAt = Clock.System.now() - 1.hours)
             )
 
             shouldThrow<OAuth2Exception> {
@@ -304,7 +292,7 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
         }
 
         test("reject client attestation PoP without iat") {
-            val pop = it.signPop(it.clientAttestationPop.payload.copy(issuedAt = null))
+            val pop = it.signPop(it.freshPop().payload.copy(issuedAt = null))
 
             shouldThrow<OAuth2Exception> {
                 it.par(clientAttestationPop = pop)
@@ -313,14 +301,15 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
 
         test("reject client attestation PoP with unsupported algorithm") {
             shouldThrow<OAuth2Exception> {
-                it.par(clientAttestationPop = it.clientAttestationPop.withHeaderAlg(JwsAlgorithm.Signature.RS256))
+                it.par(clientAttestationPop = it.freshPop().withHeaderAlg(JwsAlgorithm.Signature.RS256))
             }
         }
 
         test("reject client attestation PoP not signed by the cnf key") {
+            val payload = it.freshPop().payload
             val pop = SignJwt<JsonWebToken>(EphemeralKeyWithSelfSignedCert(), JwsHeaderNone())(
                 JwsContentTypeConstants.CLIENT_ATTESTATION_POP_JWT,
-                it.clientAttestationPop.payload,
+                payload,
                 JsonWebToken.serializer(),
             ).getOrThrow()
 
@@ -330,10 +319,11 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
         }
 
         test("reject replayed client attestation PoP") {
-            it.par()
+            val pop = it.freshPop()
+            it.par(clientAttestationPop = pop)
 
             shouldThrow<OAuth2Exception> {
-                it.par()
+                it.par(clientAttestationPop = pop)
             }
         }
 
@@ -344,8 +334,8 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
                 scope = it.scope,
             )
 
-            it.clientAttestation = BuildClientAttestationJwt(
-                SignJwt(it.walletProviderCa.issue(), JwsHeaderCertOrJwk()),
+            val clientAttestation = BuildClientAttestationJwt(
+                SignJwt(EphemeralKeyWithSelfSignedCert(), JwsHeaderCertOrJwk()),
                 clientId = "wrong client id",
                 clientKey = it.clientKey.jsonWebKey
             )
@@ -357,7 +347,7 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
                     RequestInfo(
                         url = "https://example.com/",
                         method = HttpMethod.Post,
-                        clientAttestation = it.clientAttestation,
+                        clientAttestation = clientAttestation,
                         clientAttestationPop = it.clientAttestationPop
                     )
                 ).getOrThrow()
@@ -372,20 +362,20 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
             )
 
             // the attestation is signed by a certificate of it.walletProviderCa, which is not on this trust list
-            it.server = SimpleAuthorizationService(
+            val server = SimpleAuthorizationService(
                 publicContext = AUTHORIZATION_SERVER,
                 strategy = DummyAuthorizationServiceStrategy(it.scope),
-    clientAuthenticationService = AttestationBasedClientAuthenticationService(
+                clientAuthenticationService = AttestationBasedClientAuthenticationService(
 
-        verifyJwsObject = VerifyJwsObjectTrustedCertificate(
-            trustedIssuers = { setOf(TestCertificateAuthority().certificate()) }
-        ),
+                    verifyJwsObject = VerifyJwsObjectTrustedCertificate(
+                        trustedIssuers = { setOf(TestCertificateAuthority().certificate()) }
+                    ),
                 ),
             )
 
             @Suppress("DEPRECATION")
             shouldThrow<OAuth2Exception> {
-                it.server.par(
+                server.par(
                     authnRequest,
                     RequestInfo(
                         url = "https://example.com/",
@@ -404,7 +394,7 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
                 scope = it.scope,
             )
 
-            it.clientAttestation = BuildClientAttestationJwt(
+            val clientAttestation = BuildClientAttestationJwt(
                 SignJwt(EphemeralKeyWithSelfSignedCert(), JwsHeaderCertOrJwk()),
                 clientId = it.client.clientId,
                 clientKey = it.clientKey.jsonWebKey
@@ -417,7 +407,7 @@ clientAuthenticationService = AttestationBasedClientAuthenticationService(
                     RequestInfo(
                         url = "https://example.com/",
                         method = HttpMethod.Post,
-                        clientAttestation = it.clientAttestation,
+                        clientAttestation = clientAttestation,
                         clientAttestationPop = it.clientAttestationPop
                     )
                 ).getOrThrow()


### PR DESCRIPTION
Second stack PR to update our implementation of [OAuth 2.0 Attestation-Based Cliend Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html): Implement new fields, validate them, correctly handle attestation challenges.