### PR TITLE
OAuth: Rework token validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Release 8.0.0 (unreleased):
     - Update implementation of [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html) to Draft 10 from 2026-07-06
     - Add method `attestationChallenge()` to `SimpleAuthorizationService` to deliver challenges for Attestation-Based Client Authentication
     - Support `use_client_attestation` errors and parse challenges from `OAuth-Client-Attestation-Challenge` in `OAuth2KtorClient`
+    - Strengthen validation of DPoP proofs from [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)
 - Deprecations:
     - Remove code deprecated in 7.0.0, e.g. various `Iso180137AnnexC*` and related classes
     - Deprecate all classes used for Presentation Exchange requests and so on, e.g., `CredentialPresentationRequest.PresentationExchangeRequest` or `PresentationExchangeCredentialDisclosure` or `CredentialPresentation.PresentationExchangePresentation`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ Release 8.0.0 (unreleased):
     - Add method `attestationChallenge()` to `SimpleAuthorizationService` to deliver challenges for Attestation-Based Client Authentication
     - Support `use_client_attestation` errors and parse challenges from `OAuth-Client-Attestation-Challenge` in `OAuth2KtorClient`
     - Strengthen validation of DPoP proofs from [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)
+    - Validate the access token in `SimpleAuthorizationService.getUserInfo()` before returning any user info, i.e. it now behaves the same as `userInfo()`. Previously the token was only parsed, so neither its signature, nor its expiration, nor the DPoP proof were verified
+    - Compare scopes as space-delimited values instead of substrings, when issuing access tokens in `SimpleAuthorizationService` and when authorizing credential requests in `CredentialIssuer`
+    - Authorize several credential requests with a single JWT access token
+    - Add `TokenService.validateAccessToken()`, which validates the access token and resolves the user info stored at issuance
 - Deprecations:
     - Remove code deprecated in 7.0.0, e.g. various `Iso180137AnnexC*` and related classes
     - Deprecate all classes used for Presentation Exchange requests and so on, e.g., `CredentialPresentationRequest.PresentationExchangeRequest` or `PresentationExchangeCredentialDisclosure` or `CredentialPresentation.PresentationExchangePresentation`
@@ -74,6 +78,7 @@ Release 8.0.0 (unreleased):
     - Deprecate `ClientAuthenticationService.verifyClientAttestationJwt`, which never validated the `x5c` it required; pass `VerifyJwsObjectTrustedCertificate` with the trusted wallet provider certificates as `verifyJwsObject` instead
     - Deprecate constructor in `RequestInfo` taking single values for some HTTP headers, replace with constructor taking in all HTTP headers
     - Deprecate constructor parameter `enforceClientAuthentication` in `AttestationBasedClientAuthenticationService` as the new default is `true`. Callers might use a `NoopClientAuthenticationService`
+    - Deprecate `TokenService.readUserInfo()`, since it does not prove possession of the key the access token is bound to. Replace with `TokenService.validateAccessToken()`, which validates the access token including the DPoP proof and returns the user info in `ValidatedAccessToken.userInfoExtended`
 - Refactorings:
     - In `MdocInputValidator` and `ValidatorMdoc` replace `verifyCoseSignatureWithKey` with a `VerifyCoseSignatureFun<MobileSecurityObject>`, which resolves the issuer key from the COSE headers itself. Consequently `MdocInputValidator.invoke()` and `ValidatorMdoc.verifyIsoCred()` lose their `issuerKey` parameter, `MdocInputValidationSummary.IntegrityValidationSummary.IntegrityValidationResult` loses its `issuerKey` property, and `IntegrityNotValidated` is removed
     - `ValidatorMdoc.verifyDocument()` no longer extracts the issuer certificate itself, but delegates to `MdocInputValidator` like the credential path does
@@ -85,6 +90,8 @@ Release 8.0.0 (unreleased):
     - In `NonceChallengeVerifier` add `consumeChallenge()`, which consumes the challenge of the request an authentication response refers to and returns a `NonceChallengeVerifier.ChallengeSession` to verify all presentations of that response with, as used by `OpenId4VpVerifier` and `DcApiVerifier`
     - Add main constructor to `RequestInfo` that takes in all HTTP headers for future extensions to client authentication methods
     - Rename existing `ClientAuthenticationService` to `AttestationBasedClientAuthenticationService` and extract an interface
+    - Return the validated token from `validateAccessToken()` in `TokenVerificationService` and `OAuth2AuthorizationServerAdapter` as `ValidatedAccessToken`, and move `validCredentialIdentifiers` from `TokenInfo` to `ValidatedAccessToken`
+    - Authorize credential requests in `CredentialIssuer` from the `ValidatedAccessToken`
  - Dependencies:
     - Update to [Signum 3.25.0](https://github.com/a-sit-plus/signum/releases/tag/3.25.0) for HPKE support
 

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/RemoteOAuth2AuthorizationServerAdapter.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/RemoteOAuth2AuthorizationServerAdapter.kt
@@ -13,6 +13,7 @@ import at.asitplus.wallet.lib.oauth2.OAuth2Client
 import at.asitplus.wallet.lib.oauth2.OAuth2Utils.insertWellKnownPath
 import at.asitplus.wallet.lib.oauth2.RequestInfo
 import at.asitplus.wallet.lib.oauth2.TokenVerificationService
+import at.asitplus.wallet.lib.oauth2.ValidatedAccessToken
 import at.asitplus.wallet.lib.oidvci.OAuth2AuthorizationServerAdapter
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidToken
 import at.asitplus.wallet.lib.oidvci.TokenInfo
@@ -136,12 +137,12 @@ class RemoteOAuth2AuthorizationServerAdapter(
     override suspend fun validateAccessToken(
         authorizationHeader: String,
         httpRequest: RequestInfo?,
-    ): KmmResult<Boolean> = catching {
+    ): KmmResult<ValidatedAccessToken> = catching {
         internalTokenVerificationService.validateAccessToken(
             tokenOrAuthHeader = authorizationHeader,
             httpRequest = httpRequest,
             dpopNonceService = dpopNonceService
-        ).isSuccess
+        ).getOrThrow()
     }
 
     override suspend fun getDpopNonce() = dpopNonceService.provideNonce()

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/RemoteOAuth2AuthorizationServerAdapterTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/RemoteOAuth2AuthorizationServerAdapterTest.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.lib.ktor.openid
 
+import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.OpenIdConstants.Errors.USE_DPOP_NONCE
@@ -17,6 +18,7 @@ import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.oauth2.DPoPNonce
 import at.asitplus.wallet.lib.oauth2.RequestInfo
 import at.asitplus.wallet.lib.oauth2.TokenVerificationService
+import at.asitplus.wallet.lib.oauth2.ValidatedAccessToken
 import at.asitplus.wallet.lib.oidvci.OAuth2Error
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidToken
 import at.asitplus.wallet.lib.oidvci.TokenInfo
@@ -59,7 +61,8 @@ val RemoteOAuth2AuthorizationServerAdapterTest by matrixSuite {
             tokenOrAuthHeader: String,
             httpRequest: RequestInfo?,
             dpopNonceService: NonceService?,
-        ) = catching { }
+        ): KmmResult<ValidatedAccessToken> =
+            catching { ValidatedAccessToken(token = tokenOrAuthHeader) }
 
         override suspend fun extractValidatedClientKey(
             httpRequest: RequestInfo?,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/BearerTokenService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/BearerTokenService.kt
@@ -13,6 +13,7 @@ class BearerTokenService(
     override val supportsRefreshTokens: Boolean,
 ) : TokenService {
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override suspend fun readUserInfo(
         authorizationHeader: String,
         request: RequestInfo?,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/JwtTokenService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/JwtTokenService.kt
@@ -1,7 +1,6 @@
 package at.asitplus.wallet.lib.oauth2
 
 import at.asitplus.catching
-import at.asitplus.openid.OpenIdAuthorizationDetails
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
@@ -31,7 +30,7 @@ class JwtTokenService(
         val jwtId = tokenJwt.payload.jwtId
             ?: throw InvalidToken("access token not valid: $accessToken")
         with(tokenJwt.payload) {
-            toValidatedAccessToken(accessToken, jwtId)
+            toValidatedAccessToken(accessToken, generation.getUserInfoExtended(jwtId))
         }
     } else {
         throw InvalidToken("authorization header not valid: $authorizationHeader")
@@ -50,17 +49,8 @@ class JwtTokenService(
             ?: throw InvalidToken("access token not valid: $subjectToken")
         // can't validate DPoP JWT, as the third party can't forward this
         with(tokenJwt.payload) {
-            toValidatedAccessToken(subjectToken, jwtId)
+            toValidatedAccessToken(subjectToken, generation.getUserInfoExtended(jwtId))
         }
     }
 
-    private suspend fun OpenId4VciAccessToken.toValidatedAccessToken(
-        accessToken: String,
-        jwtId: String,
-    ): ValidatedAccessToken = ValidatedAccessToken(
-        token = accessToken,
-        userInfoExtended = generation.getUserInfoExtended(jwtId),
-        authorizationDetails = authorizationDetails?.filterIsInstance<OpenIdAuthorizationDetails>()?.toSet(),
-        scope = scope
-    )
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/JwtTokenService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/JwtTokenService.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.lib.oauth2
 
+import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
@@ -15,6 +16,21 @@ class JwtTokenService(
     override val dpopSigningAlgValuesSupportedStrings: Set<String>?,
     override val supportsRefreshTokens: Boolean,
 ) : TokenService {
+
+    /**
+     * Validates the access token, and — since [generation] issued it — resolves the user info stored back then,
+     * so callers do not need a second lookup with [readUserInfo].
+     */
+    override suspend fun validateAccessToken(
+        authorizationHeader: String,
+        httpRequest: RequestInfo?,
+    ): KmmResult<ValidatedAccessToken> = catching {
+        val validated = verification.validateAccessToken(authorizationHeader, httpRequest).getOrThrow()
+        validated.jwtId
+            ?.let { generation.getUserInfoExtended(it) }
+            ?.let { validated.copy(userInfoExtended = it) }
+            ?: validated
+    }
 
     /**
      * Provides information about the access token from [authorizationHeader], if it has been issued by [generation].

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/JwtTokenService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/JwtTokenService.kt
@@ -3,7 +3,6 @@ package at.asitplus.wallet.lib.oauth2
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.openid.OpenIdConstants
-import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidToken
 
@@ -36,13 +35,14 @@ class JwtTokenService(
      * Provides information about the access token from [authorizationHeader], if it has been issued by [generation].
      * **Access token needs to be validated before (see [TokenVerificationService.validateAccessToken])**
      */
+    @Suppress("OVERRIDE_DEPRECATION")
     override suspend fun readUserInfo(
         authorizationHeader: String,
         request: RequestInfo?,
     ): ValidatedAccessToken = if (authorizationHeader.startsWith(OpenIdConstants.TOKEN_TYPE_DPOP, ignoreCase = true)) {
         val accessToken = authorizationHeader.removePrefix(OpenIdConstants.TOKEN_PREFIX_DPOP).split(" ").last()
-        val tokenJwt = catching { JwsCompactTyped<OpenId4VciAccessToken>(accessToken) }
-            .getOrElse { throw InvalidToken("could not parse DPoP Token", it) }
+        // Verifies signature, typ, jti, nbf and exp; does not prove possession of the key the token is bound to
+        val tokenJwt = verification.validateToken(accessToken, JwsContentTypeConstants.OID4VCI_AT_JWT)
         val jwtId = tokenJwt.payload.jwtId
             ?: throw InvalidToken("access token not valid: $accessToken")
         with(tokenJwt.payload) {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -562,10 +562,10 @@ class SimpleAuthorizationService @JvmOverloads constructor(
     private fun TokenRequestParameters.validatedScope(clientAuthnRequest: ClientAuthRequest): String? {
         if (clientAuthnRequest.scope == null)
             throw InvalidRequest("Scope not from auth code: ${scope}, for code ${clientAuthnRequest.issuedCode}")
-        scope?.split(" ")?.forEach { singleScope ->
-            if (!clientAuthnRequest.scope.contains(singleScope))
-                throw InvalidRequest("Scope not from auth code: $singleScope")
-        }
+        val requested = scope.orEmpty().split(" ").filter(String::isNotBlank).toSet()
+        val granted = clientAuthnRequest.scope.split(" ").filter(String::isNotBlank).toSet()
+        if (!granted.containsAll(requested))
+            throw InvalidRequest("Not all scopes from auth code: $requested")
         return scope
     }
 
@@ -701,8 +701,8 @@ class SimpleAuthorizationService @JvmOverloads constructor(
     override suspend fun validateAccessToken(
         authorizationHeader: String,
         httpRequest: RequestInfo?,
-    ): KmmResult<Boolean> = catching {
-        tokenService.verification.validateAccessToken(authorizationHeader, httpRequest).isSuccess
+    ): KmmResult<ValidatedAccessToken> = catching {
+        tokenService.verification.validateAccessToken(authorizationHeader, httpRequest).getOrThrow()
     }
 
     override suspend fun getDpopNonce() = tokenService.dpopNonce()

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -621,11 +621,10 @@ class SimpleAuthorizationService @JvmOverloads constructor(
         authorizationHeader: String,
         httpRequest: RequestInfo?,
     ): KmmResult<JsonObject> = catching {
-        tokenService.verification.validateAccessToken(authorizationHeader, httpRequest).getOrThrow()
-        with(tokenService.readUserInfo(authorizationHeader, httpRequest)) {
-            userInfoExtended?.jsonObject
-                ?: throw InvalidGrant("no user info found for $authorizationHeader")
-        }
+        // The user info comes out of the validation itself, so it must not be looked up a second time
+        tokenService.validateAccessToken(authorizationHeader, httpRequest).getOrThrow()
+            .userInfoExtended?.jsonObject
+            ?: throw InvalidGrant("no user info found for $authorizationHeader")
     }
 
     /**
@@ -701,9 +700,8 @@ class SimpleAuthorizationService @JvmOverloads constructor(
     override suspend fun validateAccessToken(
         authorizationHeader: String,
         httpRequest: RequestInfo?,
-    ): KmmResult<ValidatedAccessToken> = catching {
-        tokenService.verification.validateAccessToken(authorizationHeader, httpRequest).getOrThrow()
-    }
+    ): KmmResult<ValidatedAccessToken> =
+        tokenService.validateAccessToken(authorizationHeader, httpRequest)
 
     override suspend fun getDpopNonce() = tokenService.dpopNonce()
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -641,17 +641,13 @@ class SimpleAuthorizationService @JvmOverloads constructor(
 
     /**
      * Obtains a JSON object representing [at.asitplus.openid.OidcUserInfo] from the Authorization Server, and
-     * since we're implementing [OAuth2AuthorizationServerAdapter] here, this is the same as [userInfo].
+     * since we're implementing [OAuth2AuthorizationServerAdapter] here, this is the same as [userInfo],
+     * i.e. the access token is validated before any user info is returned.
      */
     override suspend fun getUserInfo(
         authorizationHeader: String,
         httpRequest: RequestInfo?,
-    ): KmmResult<JsonObject> = catching {
-        with(tokenService.readUserInfo(authorizationHeader, httpRequest)) {
-            userInfoExtended?.jsonObject
-                ?: throw InvalidGrant("no user info found for $authorizationHeader")
-        }
-    }
+    ): KmmResult<JsonObject> = userInfo(authorizationHeader, httpRequest)
 
     /**
      * Obtains information about the token, since we're in-memory here (as an [OAuth2AuthorizationServerAdapter],

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenGenerationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenGenerationService.kt
@@ -129,8 +129,12 @@ class JwtTokenGenerationService @JvmOverloads constructor(
     private val JsonWebKey.jwkThumbprintPlain
         get() = this.jwkThumbprint.removePrefix("urn:ietf:params:oauth:jwk-thumbprint:sha256:")
 
+    /**
+     * Not consuming: one access token may authorize several credential requests, so the entry has to survive
+     * until it expires with the map store (the token's own `exp` bounds it anyway).
+     */
     suspend fun getUserInfoExtended(jwtId: String) =
-        jwtIdToUserInfoExtended.remove(jwtId) ?: refreshTokenJwtIdToUserInfoExtended.remove(jwtId)
+        jwtIdToUserInfoExtended.get(jwtId) ?: refreshTokenJwtIdToUserInfoExtended.get(jwtId)
 
     override suspend fun dpopNonce() = dpopNonceService.provideNonce()
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenService.kt
@@ -37,8 +37,14 @@ interface TokenService {
 
     /**
      * Provides information about the access token from [authorizationHeader], if it has been issued by [generation].
-     * **Access token needs to be validated before (see [TokenVerificationService.validateAccessToken])**
+     *
+     * Does not prove possession of the key the token is bound to, i.e. does not validate the DPoP proof.
      */
+    @Deprecated(
+        "Superseded by validateAccessToken, which validates the token, including the DPoP proof, " +
+                "and returns the user info along with it",
+        ReplaceWith("validateAccessToken(authorizationHeader, request)")
+    )
     suspend fun readUserInfo(
         authorizationHeader: String,
         request: RequestInfo?,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenService.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.lib.oauth2
 
+import at.asitplus.KmmResult
 import at.asitplus.openid.OpenIdConstants.TokenTypes
 import at.asitplus.openid.TokenRequestParameters
 import at.asitplus.openid.TokenResponseParameters
@@ -23,6 +24,16 @@ interface TokenService {
     val verification: TokenVerificationService
     val dpopSigningAlgValuesSupportedStrings: Set<String>?
     val supportsRefreshTokens: Boolean
+
+    /**
+     * Validates the access token from [authorizationHeader] and returns what it authorizes.
+     * Implementations that issued the token themselves also fill [ValidatedAccessToken.userInfoExtended],
+     * so callers do not need a second lookup with [readUserInfo].
+     */
+    suspend fun validateAccessToken(
+        authorizationHeader: String,
+        httpRequest: RequestInfo?,
+    ): KmmResult<ValidatedAccessToken> = verification.validateAccessToken(authorizationHeader, httpRequest)
 
     /**
      * Provides information about the access token from [authorizationHeader], if it has been issued by [generation].

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
@@ -18,6 +18,7 @@ import at.asitplus.wallet.lib.jws.VerifyJwsObject
 import at.asitplus.wallet.lib.jws.VerifyJwsObjectFun
 import at.asitplus.wallet.lib.jws.VerifyJwsSignatureWithKey
 import at.asitplus.wallet.lib.jws.VerifyJwsSignatureWithKeyFun
+import at.asitplus.wallet.lib.oauth2.TokenService.Companion.jwt
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.*
 import at.asitplus.wallet.lib.oidvci.TokenInfo
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
@@ -135,15 +136,8 @@ class JwtTokenVerificationService(
         if (!dpopNonceService.verifyAndRemoveNonce(nonce)) {
             throw UseDpopNonce(dpopNonceService.provideNonce(), "DPoP JWT nonce not valid: $nonce")
         }
-        if (dpopProof.payload.httpTargetUrl != httpRequest.url) {
-            throw InvalidDpopProof("DPoP JWT htu incorrect: ${dpopProof.payload.httpTargetUrl}")
-        }
-        if (dpopProof.payload.httpMethod != httpRequest.method.value.uppercase()) {
-            throw InvalidDpopProof("DPoP JWT htm incorrect: ${dpopProof.payload.httpMethod}")
-        }
         dpopProof.jws.jwsHeader.jsonWebKey
             ?: throw InvalidDpopProof("DPoP JWT contains no public key")
-
     }
 
     private suspend fun verifyDpopProof(
@@ -152,6 +146,23 @@ class JwtTokenVerificationService(
         verifyJwsObject(it.jws).getOrElse { throw InvalidDpopProof("DPoP JWT not verified.", it) }
         if (it.jws.jwsHeader.type != JwsContentTypeConstants.DPOP_JWT) {
             throw InvalidDpopProof("invalid type: ${it.jws.jwsHeader.type}")
+        }
+        if (it.jws.jwsHeader.jsonWebKey == null) {
+            throw InvalidDpopProof("DPoP JWT contains no public key")
+        }
+        if (it.payload.httpTargetUrl != httpRequest.url) {
+            throw InvalidDpopProof("DPoP JWT htu incorrect: ${it.payload.httpTargetUrl}")
+        }
+        if (it.payload.httpMethod != httpRequest.method.value.uppercase()) {
+            throw InvalidDpopProof("DPoP JWT htm incorrect: ${it.payload.httpMethod}")
+        }
+        if (it.payload.jwtId == null) {
+            throw InvalidDpopProof("DPoP JWT contains no jwtId")
+        }
+        if (it.payload.issuedAt == null) {
+            throw InvalidDpopProof("DPoP JWT contains no issuedAt")
+        } else if (it.payload.issuedAt!! > (clock.now() + timeLeeway)) {
+            throw InvalidDpopProof("DPoP JWT issuedAt in future: ${it.payload.issuedAt}")
         }
     } ?: throw InvalidDpopProof("no dpop proof in header")
 
@@ -172,6 +183,7 @@ class JwtTokenVerificationService(
             throw InvalidDpopProof("DPoP JWT JWK not matching cnf.jkt")
         }
         if (validatedClientKey != null) {
+            // DPoP-JWT has already been verified, so we can't check for the nonce twice
             if (jwkThumbprintFromToken != validatedClientKey.jwkThumbprintPlain) {
                 throw InvalidDpopProof(
                     "Key from client ${validatedClientKey.jwkThumbprintPlain}" +
@@ -179,18 +191,11 @@ class JwtTokenVerificationService(
                 )
             }
         } else {
-            // DPoP-JWT has already been verified, so we can't check for the nonce twice
             val nonce = dpopProof.payload.nonce
                 ?: throw UseDpopNonce(dpopNonceService.provideNonce(), "DPoP JWT nonce is null")
             if (!dpopNonceService.verifyAndRemoveNonce(nonce)) {
                 throw UseDpopNonce(dpopNonceService.provideNonce(), "DPoP JWT nonce not valid: $nonce")
             }
-        }
-        if (dpopProof.payload.httpTargetUrl != httpRequest.url) {
-            throw InvalidDpopProof("DPoP JWT htu incorrect: ${dpopProof.payload.httpTargetUrl}")
-        }
-        if (dpopProof.payload.httpMethod != httpRequest.method.value.uppercase()) {
-            throw InvalidDpopProof("DPoP JWT htm incorrect: ${dpopProof.payload.httpMethod}")
         }
         accessToken?.let {
             val ath = accessToken.encodeToByteArray().sha256().encodeToString(Base64UrlStrict)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
@@ -18,7 +18,6 @@ import at.asitplus.wallet.lib.jws.VerifyJwsObject
 import at.asitplus.wallet.lib.jws.VerifyJwsObjectFun
 import at.asitplus.wallet.lib.jws.VerifyJwsSignatureWithKey
 import at.asitplus.wallet.lib.jws.VerifyJwsSignatureWithKeyFun
-import at.asitplus.wallet.lib.oauth2.TokenService.Companion.jwt
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.*
 import at.asitplus.wallet.lib.oidvci.TokenInfo
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
@@ -51,7 +50,7 @@ interface TokenVerificationService {
         tokenOrAuthHeader: String,
         httpRequest: RequestInfo?,
         dpopNonceService: NonceService? = null,
-    ): KmmResult<Unit>
+    ): KmmResult<ValidatedAccessToken>
 
     /** Validate a DPoP proof and extract the client's key if the proof exists at all. */
     suspend fun extractValidatedClientKey(
@@ -118,12 +117,13 @@ class JwtTokenVerificationService(
         tokenOrAuthHeader: String,
         httpRequest: RequestInfo?,
         dpopNonceService: NonceService?,
-    ) = catching {
+    ): KmmResult<ValidatedAccessToken> = catching {
         val accessToken = if (tokenOrAuthHeader.startsWith(TOKEN_TYPE_DPOP, ignoreCase = true))
             tokenOrAuthHeader.removePrefix(TOKEN_PREFIX_DPOP).split(" ").last()
         else tokenOrAuthHeader
         val tokenJwt = validateToken(accessToken, JwsContentTypeConstants.OID4VCI_AT_JWT)
         validateDpopProof(accessToken, tokenJwt, httpRequest, dpopNonceService ?: this.dpopNonceService, null)
+        tokenJwt.payload.toValidatedAccessToken(accessToken, null)
     }
 
     /** Validate a DPoP proof and extract the client's key if the proof exists at all. */
@@ -265,7 +265,13 @@ class BearerTokenVerificationService(
         tokenOrAuthHeader: String,
         httpRequest: RequestInfo?,
         dpopNonceService: NonceService?,
-    ): KmmResult<Unit> = catching { getTokenInfo(tokenOrAuthHeader) }
+    ): KmmResult<ValidatedAccessToken> = catching {
+        val token = if (tokenOrAuthHeader.startsWith(TOKEN_TYPE_BEARER, ignoreCase = true))
+            tokenOrAuthHeader.removePrefix(TOKEN_PREFIX_BEARER).split(" ").last()
+        else tokenOrAuthHeader
+        tokenGenerationService.verifyAccessToken(token)
+            ?: throw InvalidToken("access token not valid: $token")
+    }
 
     override suspend fun getTokenInfo(
         tokenOrAuthHeader: String,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ValidatedAccessToken.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ValidatedAccessToken.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.oauth2
 
 import at.asitplus.openid.AuthorizationDetails
 import at.asitplus.openid.OidcUserInfoExtended
+import at.asitplus.openid.OpenIdAuthorizationDetails
 import at.asitplus.wallet.lib.oidvci.TokenInfo
 import kotlinx.serialization.Serializable
 
@@ -18,5 +19,20 @@ data class ValidatedAccessToken(
         authorizationDetails = authorizationDetails,
         scope = scope,
     )
+
+    val validCredentialIdentifiers: Collection<String>
+        get() = authorizationDetails
+            ?.filterIsInstance<OpenIdAuthorizationDetails>()
+            ?.flatMap { it.credentialIdentifiers ?: setOf() }
+            ?: setOf()
 }
 
+internal fun OpenId4VciAccessToken.toValidatedAccessToken(
+    accessToken: String,
+    userInfo: OidcUserInfoExtended?,
+): ValidatedAccessToken = ValidatedAccessToken(
+    token = accessToken,
+    userInfoExtended = userInfo,
+    authorizationDetails = authorizationDetails?.filterIsInstance<OpenIdAuthorizationDetails>()?.toSet(),
+    scope = scope
+)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ValidatedAccessToken.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ValidatedAccessToken.kt
@@ -13,6 +13,8 @@ data class ValidatedAccessToken(
     val userInfoExtended: OidcUserInfoExtended? = null,
     val authorizationDetails: Set<AuthorizationDetails>? = null,
     val scope: String? = null,
+    /** `jti` of the access token, if it is a JWT, to look up the user info stored when it was issued. */
+    val jwtId: String? = null,
 ) {
     fun toTokenInfo() = TokenInfo(
         token = token,
@@ -34,5 +36,6 @@ internal fun OpenId4VciAccessToken.toValidatedAccessToken(
     token = accessToken,
     userInfoExtended = userInfo,
     authorizationDetails = authorizationDetails?.filterIsInstance<OpenIdAuthorizationDetails>()?.toSet(),
-    scope = scope
+    scope = scope,
+    jwtId = jwtId,
 )

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialIssuer.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialIssuer.kt
@@ -30,6 +30,7 @@ import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.jws.SignJwtFun
 import at.asitplus.wallet.lib.jws.VerifyJwsObject
 import at.asitplus.wallet.lib.oauth2.RequestInfo
+import at.asitplus.wallet.lib.oauth2.ValidatedAccessToken
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.*
 import io.github.aakira.napier.Napier
 import kotlinx.serialization.json.Json
@@ -224,8 +225,10 @@ class CredentialIssuer @JvmOverloads constructor(
         Napier.d("credential called with $authorizationHeader, $request")
         if (!hasBeenEncrypted && encryptionService.requireRequestEncryption)
             throw InvalidEncryptionParameters("Credential request has not been encrypted")
-        authorizationService.validateAccessToken(authorizationHeader, requestInfo).getOrThrow()
-        val userInfo = request.introspectTokenLoadUserInfo(authorizationHeader, requestInfo)
+        val validated = authorizationService.validateAccessToken(authorizationHeader, requestInfo).getOrThrow()
+        request.validateAgainstToken(validated)
+        val userInfo = validated.userInfoExtended
+            ?: loadUserInfo(authorizationHeader, requestInfo)
         val (scheme, representation) = request.extractCredentialRepresentation()
         val responseParameters = proofValidator.validateProofExtractSubjectPublicKeys(request).map { subjectPublicKey ->
             issuer.issueCredential(
@@ -247,42 +250,37 @@ class CredentialIssuer @JvmOverloads constructor(
             .also { Napier.i("credential returns"); Napier.d("credential returns $it") }
     }
 
-    private suspend fun CredentialRequestParameters.introspectTokenLoadUserInfo(
+    private suspend fun loadUserInfo(
         authorizationHeader: String,
         request: RequestInfo?,
-    ): OidcUserInfoExtended = run {
-        validateAgainstToken(authorizationHeader, request)
-        authorizationService.getUserInfo(
-            authorizationHeader = authorizationHeader,
-            httpRequest = request
-        ).getOrThrow().let {
-            OidcUserInfoExtended.fromJsonObject(it).getOrThrow()
-        }
+    ): OidcUserInfoExtended = authorizationService.getUserInfo(
+        authorizationHeader = authorizationHeader,
+        httpRequest = request
+    ).getOrThrow().let {
+        OidcUserInfoExtended.fromJsonObject(it).getOrThrow()
     }
 
-    private suspend fun CredentialRequestParameters.validateAgainstToken(
-        authorizationHeader: String,
-        request: RequestInfo?,
-    ): Unit = authorizationService.getTokenInfo(
-        authorizationHeader = authorizationHeader,
-        httpRequest = request,
-    ).getOrThrow().let {
-        if (it.authorizationDetails != null) {
+    private fun CredentialRequestParameters.validateAgainstToken(
+        token: ValidatedAccessToken,
+    ) {
+        if (token.authorizationDetails != null) {
             if (credentialIdentifier == null)
                 throw InvalidCredentialRequest("credential_identifier expected to be set")
             if (credentialConfigurationId != null)
                 throw InvalidCredentialRequest("credential_configuration_id must not be set when credential_identifier is set")
-            if (!it.validCredentialIdentifiers.contains(credentialIdentifier))
-                throw InvalidToken("credential_identifier $credentialIdentifier expected to be in $it")
-        } else if (it.scope != null) {
+            if (!token.validCredentialIdentifiers.contains(credentialIdentifier))
+                throw InvalidToken("credential_identifier $credentialIdentifier expected to be in $token")
+        } else if (token.scope != null) {
             if (credentialConfigurationId == null)
                 throw InvalidCredentialRequest("credential_configuration_id expected to be set")
             if (credentialIdentifier != null)
                 throw InvalidCredentialRequest("credential_identifier must not be set when credential_configuration_id is set")
             val configurationScope = metadata.supportedCredentialConfigurations?.get(credentialConfigurationId!!)?.scope
                 ?: throw InvalidCredentialRequest("credential_configuration_id $credentialConfigurationId not supported")
-            if (!it.scope.contains(configurationScope))
-                throw InvalidToken("credential_configuration_id $credentialConfigurationId expected to be in $it")
+            val requested = configurationScope.split(" ").filter(String::isNotBlank).toSet()
+            val granted = token.scope.orEmpty().split(" ").filter(String::isNotBlank).toSet()
+            if (!granted.containsAll(requested))
+                throw InvalidToken("credential_configuration_id $credentialConfigurationId not granted by token $token")
         } else {
             throw InvalidToken("Neither scope nor authorization details stored for access token")
         }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2AuthorizationServerAdapter.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2AuthorizationServerAdapter.kt
@@ -5,6 +5,7 @@ import at.asitplus.openid.AuthorizationDetails
 import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.OpenIdAuthorizationDetails
 import at.asitplus.wallet.lib.oauth2.RequestInfo
+import at.asitplus.wallet.lib.oauth2.ValidatedAccessToken
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import kotlinx.serialization.json.JsonObject
@@ -45,7 +46,7 @@ interface OAuth2AuthorizationServerAdapter {
     suspend fun validateAccessToken(
         authorizationHeader: String,
         httpRequest: RequestInfo?,
-    ): KmmResult<Boolean>
+    ): KmmResult<ValidatedAccessToken>
 
     /** If this is an internal AS, provide a fresh DPoP nonce for clients. */
     suspend fun getDpopNonce(): String?
@@ -61,10 +62,4 @@ data class TokenInfo(
     val token: String,
     val authorizationDetails: Set<AuthorizationDetails>? = null,
     val scope: String? = null,
-) {
-    @Transient
-    val validCredentialIdentifiers = authorizationDetails
-        ?.filterIsInstance<OpenIdAuthorizationDetails>()
-        ?.flatMap { it.credentialIdentifiers ?: setOf() }
-        ?: setOf()
-}
+)

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientDPoPTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientDPoPTest.kt
@@ -7,12 +7,15 @@ import at.asitplus.openid.OpenIdConstants.TOKEN_TYPE_DPOP
 import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenIntrospectionRequest
 import at.asitplus.openid.TokenIntrospectionResponse
+import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.RandomSource
+import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
+import at.asitplus.wallet.lib.jws.JwsHeaderNone
 import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.oidvci.BuildDPoPHeader
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
@@ -25,6 +28,8 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.http.*
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
 
 val OAuth2ClientDPoPTest by matrixSuite {
     fixture {
@@ -34,15 +39,38 @@ val OAuth2ClientDPoPTest by matrixSuite {
             val scope = randomString()
             val client = OAuth2Client()
             val user = OidcUserInfoExtended(OidcUserInfo(randomString()))
+            val tokenService = TokenService.jwt(issueRefreshTokens = true)
             val server = SimpleAuthorizationService(
                 strategy = DummyAuthorizationServiceStrategy(scope),
-                tokenService = TokenService.jwt(
-                    issueRefreshTokens = true
-                ),
+                tokenService = tokenService,
             )
             val clientKey = EphemeralKeyWithoutCert()
             val signDpop = SignJwt<JsonWebToken>(clientKey, JwsHeaderCertOrJwk())
             val state = uuid4().toString()
+
+            suspend fun dpopProof(
+                transform: (JsonWebToken) -> JsonWebToken = { it },
+            ) = BuildDPoPHeader(
+                signDpop = signDpop,
+                url = tokenUrl,
+                nonce = server.getDpopNonce(),
+                randomSource = RandomSource.Default,
+            ).let {
+                signDpop(
+                    JwsContentTypeConstants.DPOP_JWT,
+                    transform(it.payload),
+                    JsonWebToken.serializer(),
+                ).getOrThrow()
+            }
+
+            @Suppress("DEPRECATION")
+            suspend fun validateDpop(
+                dpop: JwsCompactTyped<JsonWebToken>,
+                url: String = tokenUrl,
+                method: HttpMethod = HttpMethod.Post,
+            ) = tokenService.verification.extractValidatedClientKey(
+                RequestInfo(url = url, method = method, dpop = dpop)
+            ).getOrThrow()
 
             suspend fun getCode(state: String): String {
                 val authnRequest = client.createAuthRequestJar(
@@ -245,27 +273,63 @@ val OAuth2ClientDPoPTest by matrixSuite {
             }
         }
 
-        test("authorization code flow with DPoP and wrong URL") {
-            val code = it.getCode(it.state)
-            @Suppress("DEPRECATION")
-            shouldThrow<OAuth2Exception> {
-                it.server.token(
-                    request = it.client.createTokenRequestParameters(
-                        state = it.state,
-                        authorization = OAuth2Client.AuthorizationForToken.Code(code),
-                        scope = it.scope
-                    ),
-                    httpRequest = RequestInfo(
-                        url = it.tokenUrl,
-                        method = HttpMethod.Post,
-                        dpop = BuildDPoPHeader(
-                            signDpop = it.signDpop,
-                            url = "https://somethingelse.com/",
-                            nonce = it.server.getDpopNonce(),
-                            randomSource = RandomSource.Default,
-                        )
-                    )
-                ).getOrThrow()
+        test("reject DPoP proof with wrong URL without consuming nonce") {
+            val nonce = it.server.getDpopNonce()
+            val wrongProof = BuildDPoPHeader(
+                signDpop = it.signDpop,
+                url = "https://somethingelse.com/",
+                nonce = nonce,
+                randomSource = RandomSource.Default,
+            )
+
+            shouldThrow<OAuth2Exception.InvalidDpopProof> {
+                it.validateDpop(wrongProof)
+            }
+
+            it.validateDpop(
+                BuildDPoPHeader(
+                    signDpop = it.signDpop,
+                    url = it.tokenUrl,
+                    nonce = nonce,
+                    randomSource = RandomSource.Default,
+                )
+            ).shouldNotBeNull()
+        }
+
+        test("reject DPoP proof with wrong HTTP method") {
+            shouldThrow<OAuth2Exception.InvalidDpopProof> {
+                it.validateDpop(it.dpopProof { proof -> proof.copy(httpMethod = "GET") })
+            }
+        }
+
+        test("reject DPoP proof without jti") {
+            shouldThrow<OAuth2Exception.InvalidDpopProof> {
+                it.validateDpop(it.dpopProof { proof -> proof.copy(jwtId = null) })
+            }
+        }
+
+        test("reject DPoP proof without iat") {
+            shouldThrow<OAuth2Exception.InvalidDpopProof> {
+                it.validateDpop(it.dpopProof { proof -> proof.copy(issuedAt = null) })
+            }
+        }
+
+        test("reject DPoP proof with iat in the future") {
+            shouldThrow<OAuth2Exception.InvalidDpopProof> {
+                it.validateDpop(it.dpopProof { proof -> proof.copy(issuedAt = Clock.System.now() + 1.hours) })
+            }
+        }
+
+        test("reject DPoP proof without public JWK") {
+            val proof = BuildDPoPHeader(
+                signDpop = SignJwt(it.clientKey, JwsHeaderNone()),
+                url = it.tokenUrl,
+                nonce = it.server.getDpopNonce(),
+                randomSource = RandomSource.Default,
+            )
+
+            shouldThrow<OAuth2Exception.InvalidDpopProof> {
+                it.validateDpop(proof)
             }
         }
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientDPoPTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientDPoPTest.kt
@@ -3,15 +3,18 @@ package at.asitplus.wallet.lib.oauth2
 import at.asitplus.catching
 import at.asitplus.openid.OidcUserInfo
 import at.asitplus.openid.OidcUserInfoExtended
+import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.OpenIdConstants.TOKEN_TYPE_DPOP
 import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenIntrospectionRequest
 import at.asitplus.openid.TokenIntrospectionResponse
+import at.asitplus.openid.TokenResponseParameters
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.RandomSource
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
@@ -39,7 +42,8 @@ val OAuth2ClientDPoPTest by matrixSuite {
             val scope = randomString()
             val client = OAuth2Client()
             val user = OidcUserInfoExtended(OidcUserInfo(randomString()))
-            val tokenService = TokenService.jwt(issueRefreshTokens = true)
+            val issuerKey = EphemeralKeyWithoutCert()
+            val tokenService = TokenService.jwt(issueRefreshTokens = true, keyMaterial = issuerKey)
             val server = SimpleAuthorizationService(
                 strategy = DummyAuthorizationServiceStrategy(scope),
                 tokenService = tokenService,
@@ -72,6 +76,14 @@ val OAuth2ClientDPoPTest by matrixSuite {
                 RequestInfo(url = url, method = method, dpop = dpop)
             ).getOrThrow()
 
+            /** Signs an access token as the authorization server itself would, to forge token contents. */
+            suspend fun signAccessToken(payload: OpenId4VciAccessToken, key: KeyMaterial = issuerKey) =
+                SignJwt<OpenId4VciAccessToken>(key, JwsHeaderCertOrJwk())(
+                    JwsContentTypeConstants.OID4VCI_AT_JWT,
+                    payload,
+                    OpenId4VciAccessToken.serializer(),
+                ).getOrThrow()
+
             suspend fun getCode(state: String): String {
                 val authnRequest = client.createAuthRequestJar(
                     state = state,
@@ -84,8 +96,67 @@ val OAuth2ClientDPoPTest by matrixSuite {
                     .shouldNotBeNull()
                 return code
             }
+
+            @Suppress("DEPRECATION")
+            suspend fun getAccessToken(): TokenResponseParameters = server.token(
+                request = client.createTokenRequestParameters(
+                    state = state,
+                    authorization = OAuth2Client.AuthorizationForToken.Code(getCode(state)),
+                    scope = scope
+                ),
+                httpRequest = RequestInfo(
+                    url = tokenUrl,
+                    method = HttpMethod.Post,
+                    dpop = BuildDPoPHeader(
+                        signDpop = signDpop,
+                        url = tokenUrl,
+                        nonce = server.getDpopNonce(),
+                        randomSource = RandomSource.Default,
+                    )
+                )
+            ).getOrThrow()
         }
     } - {
+        test("getUserInfo returns user info for a valid access token") {
+            val token = it.getAccessToken()
+
+            @Suppress("DEPRECATION")
+            it.server.getUserInfo(
+                token.toHttpHeaderValue(),
+                RequestInfo(
+                    url = it.resourceUrl,
+                    method = HttpMethod.Post,
+                    dpop = BuildDPoPHeader(
+                        signDpop = it.signDpop,
+                        url = it.resourceUrl,
+                        accessToken = token.accessToken,
+                        nonce = it.server.getDpopNonce(),
+                        randomSource = RandomSource.Default,
+                    )
+                )
+            ).getOrThrow()
+        }
+
+        test("getUserInfo rejects an access token with an invalid signature") {
+            // The jti is readable from any observed access token, so user info must not be reachable by
+            // replaying it in a token this authorization server did not sign
+            val payload = JwsCompactTyped<OpenId4VciAccessToken>(it.getAccessToken().accessToken).payload
+            val forged = it.signAccessToken(payload, key = EphemeralKeyWithoutCert())
+
+            shouldThrow<OAuth2Exception.InvalidToken> {
+                it.server.getUserInfo("${OpenIdConstants.TOKEN_PREFIX_DPOP}$forged", null).getOrThrow()
+            }
+        }
+
+        test("getUserInfo rejects an expired access token") {
+            val payload = JwsCompactTyped<OpenId4VciAccessToken>(it.getAccessToken().accessToken).payload
+            val expired = it.signAccessToken(payload.copy(expiration = Clock.System.now() - 1.hours))
+
+            shouldThrow<OAuth2Exception.InvalidToken> {
+                it.server.getUserInfo("${OpenIdConstants.TOKEN_PREFIX_DPOP}$expired", null).getOrThrow()
+            }
+        }
+
         test("authorization code flow with DPoP") {
             val code = it.getCode(it.state)
             @Suppress("DEPRECATION")

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientTest.kt
@@ -19,6 +19,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 val OAuth2ClientTest by matrixSuite {
@@ -54,6 +55,22 @@ val OAuth2ClientTest by matrixSuite {
             )
             it.server.token(tokenRequest, null).isSuccess shouldBe true
             it.server.token(tokenRequest, null).isFailure shouldBe true
+        }
+        test("token request with a scope that is only a substring of the granted scope") {
+            val preAuth = it.server.providePreAuthorizedCode(user)
+                .shouldNotBeNull()
+            // Scopes are space-delimited values, so a substring of a granted scope is not itself granted
+            val requestedScope = it.scope.dropLast(1)
+            it.scope shouldContain requestedScope
+            val tokenRequest = it.client.createTokenRequestParameters(
+                state = uuid4().toString(),
+                authorization = OAuth2Client.AuthorizationForToken.PreAuthCode(preAuth),
+                scope = requestedScope
+            )
+
+            shouldThrow<OAuth2Exception> {
+                it.server.token(tokenRequest, null).getOrThrow()
+            }
         }
         test("process with pushed authorization request") {
             val state = uuid4().toString()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciSameScopeTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciSameScopeTest.kt
@@ -12,13 +12,16 @@ package at.asitplus.wallet.lib.oidvci
  * see the "LICENSE" file for more details
  */
 
+import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.catchingUnwrapped
 import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenResponseParameters
+import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.RandomSource
 import at.asitplus.wallet.lib.data.AttributeIndex
@@ -27,8 +30,13 @@ import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
 import at.asitplus.wallet.lib.data.VerifiableCredentialJws
 import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import at.asitplus.wallet.lib.data.rfc3986.toUri
+import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
+import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
+import at.asitplus.wallet.lib.oauth2.RequestInfo
 import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService
+import at.asitplus.wallet.lib.oauth2.TokenService
+import at.asitplus.wallet.lib.oauth2.ValidatedAccessToken
 import at.asitplus.wallet.lib.oidvci.WalletService.RequestOptions
 import at.asitplus.wallet.lib.openid.AuthenticationResponseResult
 import at.asitplus.wallet.lib.openid.DummyOAuth2IssuerCredentialDataProvider
@@ -41,6 +49,7 @@ import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.http.*
 import kotlinx.serialization.json.JsonElement
 
 val OidvciSameScopeTest by matrixSuite {
@@ -155,6 +164,150 @@ val OidvciSameScopeTest by matrixSuite {
                     params = params,
                     credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
                 ).getOrThrow()
+            }
+        }
+
+        test("authorize from validated access token instead of token info") {
+            val fixture = it
+            val requestOptions = RequestOptions(AtomicAttribute2023, PLAIN_JWT)
+            val credentialFormat = fixture.client.selectSupportedCredentialFormat(
+                requestOptions,
+                fixture.issuer.metadata,
+            )
+                .shouldNotBeNull()
+            val requiredScope = credentialFormat.scope.shouldNotBeNull()
+            val token = fixture.getToken(requiredScope)
+            val restrictedScope = requiredScope.dropLast(1)
+
+            val adapter = object : OAuth2AuthorizationServerAdapter by fixture.authorizationService {
+                override suspend fun validateAccessToken(
+                    authorizationHeader: String,
+                    httpRequest: RequestInfo?,
+                ): KmmResult<ValidatedAccessToken> = catching {
+                    fixture.authorizationService.validateAccessToken(authorizationHeader, httpRequest)
+                        .getOrThrow().copy(scope = restrictedScope)
+                }
+
+                override suspend fun getTokenInfo(
+                    authorizationHeader: String,
+                    httpRequest: RequestInfo?,
+                ): KmmResult<TokenInfo> = catching {
+                    TokenInfo(token = token.accessToken, scope = requiredScope)
+                }
+            }
+            val issuer = CredentialIssuer(
+                authorizationService = adapter,
+                issuer = IssuerAgent(
+                    identifier = "https://validated-token.example.com".toUri(),
+                    randomSource = RandomSource.Default,
+                ),
+                credentialSchemes = AttributeIndex.schemeSet,
+                credentialSchemeMapper = fixture.mapper,
+            )
+            val params = fixture.client.createCredential(
+                tokenResponse = token,
+                metadata = issuer.metadata,
+                credentialFormat = credentialFormat,
+                clientNonce = issuer.nonceWithDpopNonce().getOrThrow().response.clientNonce,
+            ).getOrThrow().shouldBeSingleton().first()
+
+            shouldThrow<OAuth2Exception.InvalidToken> {
+                issuer.credential(
+                    authorizationHeader = token.toHttpHeaderValue(),
+                    params = params,
+                    credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
+                ).getOrThrow()
+            }
+        }
+
+        test("request multiple credentials with one JWT access token, using scope") {
+            // Same as the test below, but with sender-constrained JWT access tokens instead of bearer tokens:
+            // one access token must authorize more than one credential request
+            val tokenUrl = "https://jwt-issuer.example.com/token"
+            val tokenService = TokenService.jwt()
+            val authorizationService = SimpleAuthorizationService(
+                strategy = CredentialAuthorizationServiceStrategy(
+                    credentialSchemes = AttributeIndex.schemeSet,
+                    mapper = it.mapper,
+                ),
+                tokenService = tokenService,
+            )
+            val issuer = CredentialIssuer(
+                authorizationService = authorizationService,
+                issuer = IssuerAgent(
+                    identifier = "https://jwt-issuer.example.com".toUri(),
+                    randomSource = RandomSource.Default,
+                ),
+                credentialSchemes = AttributeIndex.schemeSet,
+                credentialSchemeMapper = it.mapper,
+            )
+            val signDpop = SignJwt<JsonWebToken>(EphemeralKeyWithoutCert(), JwsHeaderCertOrJwk())
+
+            val requestOptions = setOf(
+                RequestOptions(AtomicAttribute2023, SD_JWT),
+                RequestOptions(AtomicAttribute2023, ISO_MDOC),
+            ).associateBy { requestOption ->
+                it.client.selectSupportedCredentialFormat(requestOption, issuer.metadata)!!
+            }
+            val scope = requestOptions.keys.joinToString(" ") { it.scope.shouldNotBeNull() }
+
+            val authnRequest = it.oauth2Client.createAuthRequestJar(
+                state = it.state,
+                scope = scope,
+                resource = issuer.metadata.credentialIssuer,
+            )
+            val code = authorizationService
+                .authorize(authnRequest as RequestParameters) { catching { DummyUserProvider.user } }
+                .getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+                .params?.code.shouldNotBeNull()
+            @Suppress("DEPRECATION")
+            val token = authorizationService.token(
+                request = it.oauth2Client.createTokenRequestParameters(
+                    state = it.state,
+                    authorization = OAuth2Client.AuthorizationForToken.Code(code),
+                    scope = scope,
+                    resource = issuer.metadata.credentialIssuer,
+                ),
+                httpRequest = RequestInfo(
+                    url = tokenUrl,
+                    method = HttpMethod.Post,
+                    dpop = BuildDPoPHeader(
+                        signDpop = signDpop,
+                        url = tokenUrl,
+                        nonce = authorizationService.getDpopNonce(),
+                        randomSource = RandomSource.Default,
+                    ),
+                ),
+            ).getOrThrow()
+
+            val credentialUrl = issuer.metadata.credentialEndpointUrl.shouldNotBeNull()
+            requestOptions.keys.forEach { credentialFormat ->
+                @Suppress("DEPRECATION")
+                issuer.credential(
+                    authorizationHeader = token.toHttpHeaderValue(),
+                    params = it.client.createCredential(
+                        tokenResponse = token,
+                        metadata = issuer.metadata,
+                        credentialFormat = credentialFormat,
+                        clientNonce = issuer.nonceWithDpopNonce().getOrThrow().response.clientNonce,
+                    ).getOrThrow().shouldBeSingleton().first(),
+                    credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
+                    request = RequestInfo(
+                        url = credentialUrl,
+                        method = HttpMethod.Post,
+                        dpop = BuildDPoPHeader(
+                            signDpop = signDpop,
+                            url = credentialUrl,
+                            accessToken = token.accessToken,
+                            nonce = authorizationService.getDpopNonce(),
+                            randomSource = RandomSource.Default,
+                        ),
+                    ),
+                ).getOrThrow()
+                    .shouldBeInstanceOf<CredentialIssuer.CredentialResponse.Plain>()
+                    .response
+                    .credentials.shouldNotBeEmpty()
             }
         }
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciSameScopeTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciSameScopeTest.kt
@@ -34,10 +34,12 @@ import at.asitplus.wallet.lib.openid.AuthenticationResponseResult
 import at.asitplus.wallet.lib.openid.DummyOAuth2IssuerCredentialDataProvider
 import at.asitplus.wallet.lib.openid.DummyUserProvider
 import com.benasher44.uuid.uuid4
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.serialization.json.JsonElement
 
@@ -45,7 +47,8 @@ val OidvciSameScopeTest by matrixSuite {
 
     fixture {
         object {
-            val mapper = SameScopeCredentialSchemeMapper()
+            val scope = uuid4().toString()
+            val mapper = SameScopeCredentialSchemeMapper(scope)
             val authorizationService = SimpleAuthorizationService(
                 strategy = CredentialAuthorizationServiceStrategy(
                     credentialSchemes =  AttributeIndex.schemeSet,
@@ -60,6 +63,17 @@ val OidvciSameScopeTest by matrixSuite {
                 ),
                 credentialSchemes =  AttributeIndex.schemeSet,
                 credentialSchemeMapper = mapper,
+            )
+
+            /** Behind the same AS, but all its configurations require a scope that is a substring of [scope]. */
+            val substringScopeIssuer = CredentialIssuer(
+                authorizationService = authorizationService,
+                issuer = IssuerAgent(
+                    identifier = "https://other-issuer.example.com".toUri(),
+                    randomSource = RandomSource.Default
+                ),
+                credentialSchemes = AttributeIndex.schemeSet,
+                credentialSchemeMapper = SameScopeCredentialSchemeMapper(scope.dropLast(1)),
             )
             val client = WalletService()
             val oauth2Client = OAuth2Client()
@@ -112,6 +126,36 @@ val OidvciSameScopeTest by matrixSuite {
             JwsCompactTyped<VerifiableCredentialJws>(
                 serializedCredential
             ).payload.vc.credentialSubject.shouldBeInstanceOf<JsonElement>()
+        }
+
+        test("reject credential whose required scope is only a substring of the granted scope") {
+            val requestOptions = RequestOptions(AtomicAttribute2023, PLAIN_JWT)
+            val grantedFormat = it.client.selectSupportedCredentialFormat(requestOptions, it.issuer.metadata)
+                .shouldNotBeNull()
+            val token = it.getToken(grantedFormat.scope.shouldNotBeNull())
+
+            val requiredFormat = it.client
+                .selectSupportedCredentialFormat(requestOptions, it.substringScopeIssuer.metadata)
+                .shouldNotBeNull()
+            // The granted scope contains the required one as a substring, but does not grant it
+            grantedFormat.scope.shouldNotBeNull() shouldContain requiredFormat.scope.shouldNotBeNull()
+
+            // Both issuers use the same credential identifiers, so the request is built against the issuer
+            // that granted the scope, and then sent to the one that requires the substring scope
+            val params = it.client.createCredential(
+                tokenResponse = token,
+                metadata = it.issuer.metadata,
+                credentialFormat = grantedFormat,
+                clientNonce = it.substringScopeIssuer.nonceWithDpopNonce().getOrThrow().response.clientNonce,
+            ).getOrThrow().shouldBeSingleton().first()
+
+            shouldThrow<OAuth2Exception.InvalidToken> {
+                it.substringScopeIssuer.credential(
+                    authorizationHeader = token.toHttpHeaderValue(),
+                    params = params,
+                    credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
+                ).getOrThrow()
+            }
         }
 
         test("request multiple credentials, using scope") {


### PR DESCRIPTION
Reworks the validation of OAuth tokens, to prepare for DPoP-combined mode https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html#name-dpop-combined-mode