### PR TITLE
OAuth: Detangle client authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ Release 8.0.0 (unreleased):
     - Enforce the `pre-registered` client identifier scheme against `RelyingPartyTrust.preRegisteredClients`
     - Requests using a scheme for which no trust material is configured are rejected. `redirect_uri` is not covered; `entity_id` and `did` are handed to `RelyingPartyTrust.custom`, and pass unevaluated when it is null
     - `RequestParser` no longer verifies anything and lost its `requestObjectJwsVerifier` parameter, so parsing a request is purely parsing. Consequently `RequestParametersSigned.verified` is removed, with the `verified` property of `Jws`, `OpenId4VpDcApiSigned` and `OpenId4VpDcApiMultiSigned` and its serialized form. Stored JSON still carrying `"verified"` deserializes fine, as unknown keys are ignored
+- OAuth 2.0:
+    - Update implementation of [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html) to Draft 10 from 2026-07-06
 - Deprecations:
     - Remove code deprecated in 7.0.0, e.g. various `Iso180137AnnexC*` and related classes
     - Deprecate all classes used for Presentation Exchange requests and so on, e.g., `CredentialPresentationRequest.PresentationExchangeRequest` or `PresentationExchangeCredentialDisclosure` or `CredentialPresentation.PresentationExchangePresentation`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Release 8.0.0 (unreleased):
     - Deprecate `TrustStoreLookup`, as trusted certificates are not selected per signed object, replaced by `TrustedCertificates`
     - Deprecate `RequestObjectJwsVerifier` and the `requestObjectJwsVerifier` parameter of `OpenId4VpHolder`, superseded by `RelyingPartyTrust`. **It is no longer invoked**: verifying a request object needs to know where to load the relying party's key from, which depends on the client identifier scheme, so it moved to `AuthorizationRequestValidator`. Supplying one now logs a warning and has no effect, so migrate to `relyingPartyTrust` &mdash; `preRegisteredClients` for the pre-registered case, `custom` for schemes this library does not evaluate natively. To be removed in 9.0.0
     - Deprecate `ClientAuthenticationService.verifyClientAttestationJwt`, which never validated the `x5c` it required; pass `VerifyJwsObjectTrustedCertificate` with the trusted wallet provider certificates as `verifyJwsObject` instead
+    - Deprecate constructor in `RequestInfo` taking single values for some HTTP headers, replace with constructor taking in all HTTP headers
 - Refactorings:
     - In `MdocInputValidator` and `ValidatorMdoc` replace `verifyCoseSignatureWithKey` with a `VerifyCoseSignatureFun<MobileSecurityObject>`, which resolves the issuer key from the COSE headers itself. Consequently `MdocInputValidator.invoke()` and `ValidatorMdoc.verifyIsoCred()` lose their `issuerKey` parameter, `MdocInputValidationSummary.IntegrityValidationSummary.IntegrityValidationResult` loses its `issuerKey` property, and `IntegrityNotValidated` is removed
     - `ValidatorMdoc.verifyDocument()` no longer extracts the issuer certificate itself, but delegates to `MdocInputValidator` like the credential path does
@@ -78,6 +79,7 @@ Release 8.0.0 (unreleased):
     - In `CredentialToBeIssued.Iso` add a property to specify the digest algorithm to be used in the MSO
     - Add method `getCertificateChain` to class `KeyStoreMaterial`
     - In `NonceChallengeVerifier` add `consumeChallenge()`, which consumes the challenge of the request an authentication response refers to and returns a `NonceChallengeVerifier.ChallengeSession` to verify all presentations of that response with, as used by `OpenId4VpVerifier` and `DcApiVerifier`
+    - Add main constructor to `RequestInfo` that takes in all HTTP headers for future extensions to client authentication methods
  - Dependencies:
     - Update to [Signum 3.25.0](https://github.com/a-sit-plus/signum/releases/tag/3.25.0) for HPKE support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Release 8.0.0 (unreleased):
     - Deprecate `RequestObjectJwsVerifier` and the `requestObjectJwsVerifier` parameter of `OpenId4VpHolder`, superseded by `RelyingPartyTrust`. **It is no longer invoked**: verifying a request object needs to know where to load the relying party's key from, which depends on the client identifier scheme, so it moved to `AuthorizationRequestValidator`. Supplying one now logs a warning and has no effect, so migrate to `relyingPartyTrust` &mdash; `preRegisteredClients` for the pre-registered case, `custom` for schemes this library does not evaluate natively. To be removed in 9.0.0
     - Deprecate `ClientAuthenticationService.verifyClientAttestationJwt`, which never validated the `x5c` it required; pass `VerifyJwsObjectTrustedCertificate` with the trusted wallet provider certificates as `verifyJwsObject` instead
     - Deprecate constructor in `RequestInfo` taking single values for some HTTP headers, replace with constructor taking in all HTTP headers
+    - Deprecate constructor parameter `enforceClientAuthentication` in `AttestationBasedClientAuthenticationService` as the new default is `true`. Callers might use a `NoopClientAuthenticationService`
 - Refactorings:
     - In `MdocInputValidator` and `ValidatorMdoc` replace `verifyCoseSignatureWithKey` with a `VerifyCoseSignatureFun<MobileSecurityObject>`, which resolves the issuer key from the COSE headers itself. Consequently `MdocInputValidator.invoke()` and `ValidatorMdoc.verifyIsoCred()` lose their `issuerKey` parameter, `MdocInputValidationSummary.IntegrityValidationSummary.IntegrityValidationResult` loses its `issuerKey` property, and `IntegrityNotValidated` is removed
     - `ValidatorMdoc.verifyDocument()` no longer extracts the issuer certificate itself, but delegates to `MdocInputValidator` like the credential path does
@@ -80,6 +81,7 @@ Release 8.0.0 (unreleased):
     - Add method `getCertificateChain` to class `KeyStoreMaterial`
     - In `NonceChallengeVerifier` add `consumeChallenge()`, which consumes the challenge of the request an authentication response refers to and returns a `NonceChallengeVerifier.ChallengeSession` to verify all presentations of that response with, as used by `OpenId4VpVerifier` and `DcApiVerifier`
     - Add main constructor to `RequestInfo` that takes in all HTTP headers for future extensions to client authentication methods
+    - Rename existing `ClientAuthenticationService` to `AttestationBasedClientAuthenticationService` and extract an interface
  - Dependencies:
     - Update to [Signum 3.25.0](https://github.com/a-sit-plus/signum/releases/tag/3.25.0) for HPKE support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ Release 8.0.0 (unreleased):
     - In `CredentialToBeIssued.Iso` add a property to specify the digest algorithm to be used in the MSO
     - Add method `getCertificateChain` to class `KeyStoreMaterial`
     - In `NonceChallengeVerifier` add `consumeChallenge()`, which consumes the challenge of the request an authentication response refers to and returns a `NonceChallengeVerifier.ChallengeSession` to verify all presentations of that response with, as used by `OpenId4VpVerifier` and `DcApiVerifier`
+ - Dependencies:
+    - Update to [Signum 3.25.0](https://github.com/a-sit-plus/signum/releases/tag/3.25.0) for HPKE support
 
 Release 7.0.0:
 - Credential definitions:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 kotlin = "2.3.0"
 agp = "8.12.3"
 testballoon = "1.0.0-K2.3.0"
-signum = "3.24.0"
+signum = "3.25.0"
 supreme = "0.15.0"
 uuid = "0.8.1"
 jsonpath = "3.0.0"

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/ClientNonceResponse.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/ClientNonceResponse.kt
@@ -3,6 +3,8 @@ package at.asitplus.openid
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+// TODO Copy for Attestation Challenge Response
+
 @Serializable
 data class ClientNonceResponse(
     /**

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OAuth2AuthorizationServerMetadata.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OAuth2AuthorizationServerMetadata.kt
@@ -363,6 +363,8 @@ data class OAuth2AuthorizationServerMetadata(
     @SerialName("code_challenge_methods_supported")
     val codeChallengeMethodsSupported: Set<String>? = null,
 
+    // TODO Support for challenge endpoint and pop methods
+
     /**
      * The Authorization Server SHOULD communicate supported algorithms for client attestations by using
      * [clientAttestationSigningAlgValuesSupportedStrings] and [clientAttestationPopSigningAlgValuesSupportedStrings]
@@ -373,7 +375,7 @@ data class OAuth2AuthorizationServerMetadata(
      * [clientAttestationPopSigningAlgValuesSupportedStrings] in its published metadata if the
      * [tokenEndPointAuthMethodsSupported] includes `attest_jwt_client_auth`.
      * See
-     * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-07.html#name-authorization-server-metada)
+     * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html#name-authorization-server-and-re)
      */
     @SerialName("client_attestation_pop_signing_alg_values_supported")
     val clientAttestationPopSigningAlgValuesSupportedStrings: Set<String>? = null,
@@ -388,7 +390,7 @@ data class OAuth2AuthorizationServerMetadata(
      * [clientAttestationPopSigningAlgValuesSupportedStrings] in its published metadata if the
      * [tokenEndPointAuthMethodsSupported] includes `attest_jwt_client_auth`.
      * See
-     * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-07.html#name-authorization-server-metada)
+     * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html#name-authorization-server-and-re)
      */
     @SerialName("client_attestation_signing_alg_values_supported")
     val clientAttestationSigningAlgValuesSupportedStrings: Set<String>? = null,

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/Extensions.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/Extensions.kt
@@ -2,7 +2,10 @@ package at.asitplus.wallet.lib.ktor.openid
 
 import at.asitplus.catchingUnwrapped
 import at.asitplus.openid.OpenIdConstants.Errors.USE_DPOP_NONCE
+import at.asitplus.wallet.lib.oauth2.DPoPNonce
+import at.asitplus.wallet.lib.oauth2.RequestInfo
 import at.asitplus.wallet.lib.oidvci.OAuth2Error
+import io.ktor.client.request.HttpRequestData
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.coroutines.CoroutineScope
@@ -32,3 +35,9 @@ private fun resourceServerProvidedNonce(response: HttpResponse): String? =
     response.takeIf {
         response.headers.getAll(HttpHeaders.WWWAuthenticate)?.any { it.contains(USE_DPOP_NONCE) } == true
     }?.let { response.headers[HttpHeaders.DPoPNonce] }
+
+fun HttpRequestData.toRequestInfo(): RequestInfo = RequestInfo(
+    url = url.toString(),
+    method = method,
+    headers = headers,
+)

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
@@ -31,8 +31,12 @@ import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
 import at.asitplus.wallet.lib.jws.JwsHeaderNone
 import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.jws.SignJwtFun
+import at.asitplus.wallet.lib.oauth2.DPoP
+import at.asitplus.wallet.lib.oauth2.DPoPNonce
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
 import at.asitplus.wallet.lib.oauth2.OAuth2Client.AuthorizationForToken
+import at.asitplus.wallet.lib.oauth2.OAuthClientAttestation
+import at.asitplus.wallet.lib.oauth2.OAuthClientAttestationPop
 import at.asitplus.wallet.lib.oidvci.BuildClientAttestationPoPJwt
 import at.asitplus.wallet.lib.oidvci.BuildDPoPHeader
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidToken
@@ -577,18 +581,6 @@ class OAuth2KtorClient(
     private fun OAuth2AuthorizationServerMetadata.supportsClientAuth(): Boolean =
         tokenEndPointAuthMethodsSupported?.contains(AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH) == true
 }
-
-val HttpHeaders.OAuthClientAttestation: String
-    get() = "OAuth-Client-Attestation"
-
-val HttpHeaders.OAuthClientAttestationPop: String
-    get() = "OAuth-Client-Attestation-PoP"
-
-val HttpHeaders.DPoP: String
-    get() = "DPoP"
-
-val HttpHeaders.DPoPNonce: String
-    get() = "DPoP-Nonce"
 
 private val HttpResponse.dpopNonce: String?
     get() = headers[HttpHeaders.DPoPNonce]

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
@@ -59,7 +59,7 @@ import kotlin.time.Duration
  * Supported features:
  *  * Token requests and responses
  *  * [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)
- *  * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-04.html)
+ *  * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html)
  *  * [OAuth 2.0 Pushed Authorization Requests](https://datatracker.ietf.org/doc/html/rfc9126)
  *  * [JSON Web Token (JWT) Response for OAuth Token Introspection](https://datatracker.ietf.org/doc/html/rfc9701)
  *  * [EUDI TS3 Wallet Unit Attestation 1.5.2](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md)
@@ -109,6 +109,8 @@ class OAuth2KtorClient(
          * satisfies `client_status.exp - current time >= preferred_client_status_period.` */
         val preferredClientStatusPeriod: Duration?,
     )
+
+    // TODO: Also need to store challenge from Attestation-Based Client Auth
 
     /**
      * Stores the latest DPoP nonce per origin. RFC 9449 requires using only the most recent nonce
@@ -547,7 +549,7 @@ class OAuth2KtorClient(
                     signJwt = SignJwt(keyMaterial, JwsHeaderNone()),
                     clientId = oAuth2Client.clientId,
                     audience = authorizationServer,
-                    nonce = null // TODO: Add nonce after backend implementation is ready
+                    nonce = null // TODO: Read challenge like for DPoP
                 )
             }.getOrThrow()
             wia.jws to pop.jws

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
@@ -14,7 +14,6 @@ import at.asitplus.openid.SupportedCredentialFormatSdJwt
 import at.asitplus.openid.SupportedCredentialFormatW3cVcJsonLd
 import at.asitplus.openid.SupportedCredentialFormatW3cVcJwt
 import at.asitplus.openid.SupportedCredentialFormatW3cVcJwtJsonLd
-import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.wallet.lib.agent.CredentialRenewalInfo
 import at.asitplus.wallet.lib.agent.Holder
 import at.asitplus.wallet.lib.data.AttributeIndex
@@ -46,7 +45,7 @@ import kotlinx.serialization.Serializable
  *  * Pre-authorized grants
  *  * Authentication code flows
  *  * [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)
- *  * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-04.html)
+ *  * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html)
  *  * [OAuth 2.0 Pushed Authorization Requests](https://datatracker.ietf.org/doc/html/rfc9126)
  */
 class OpenId4VciClient(
@@ -503,5 +502,3 @@ data class CredentialIdentifierInfo(
     val supportedCredentialFormat: SupportedCredentialFormat,
 )
 
-private val JsonWebKey.jwkThumbprintPlain: String
-    get() = jwkThumbprint.removePrefix("urn:ietf:params:oauth:jwk-thumbprint:sha256:")

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
@@ -21,6 +21,7 @@ import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MD
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.CredentialScheme
 import at.asitplus.wallet.lib.data.MediaTypes
+import at.asitplus.wallet.lib.oauth2.DPoPNonce
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
 import at.asitplus.wallet.lib.oauth2.OAuth2Utils.insertWellKnownPath
 import at.asitplus.wallet.lib.oidvci.WalletService

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/ExtensionsTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/ExtensionsTest.kt
@@ -3,6 +3,7 @@ package at.asitplus.wallet.lib.ktor.openid
 import at.asitplus.openid.OpenIdConstants.Errors.USE_DPOP_NONCE
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.wallet.lib.oauth2.DPoPNonce
 import at.asitplus.wallet.lib.oidvci.OAuth2Error
 import com.benasher44.uuid.uuid4
 import io.kotest.assertions.throwables.shouldThrow
@@ -11,7 +12,7 @@ import io.ktor.client.*
 import io.ktor.client.engine.mock.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
-import io.ktor.client.statement.bodyAsText
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.buildJsonObject

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClientTest.kt
@@ -19,8 +19,7 @@ import at.asitplus.wallet.lib.ktor.openid.TestUtils.dummyUser
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respond
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respondIncludingDpopNonce
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respondOAuth2Error
-import at.asitplus.wallet.lib.ktor.openid.TestUtils.toRequestInfo
-import at.asitplus.wallet.lib.oauth2.ClientAuthenticationService
+import at.asitplus.wallet.lib.oauth2.AttestationBasedClientAuthenticationService
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
 import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService
 import at.asitplus.wallet.lib.oauth2.TokenService
@@ -68,9 +67,7 @@ val OAuth2KtorClientTest by matrixSuite {
             authorizationEndpointPath = authorizationEndpointPath,
             tokenEndpointPath = tokenEndpointPath,
             pushedAuthorizationRequestEndpointPath = parEndpointPath,
-            clientAuthenticationService = ClientAuthenticationService(
-                enforceClientAuthentication = true,
-            ),
+            clientAuthenticationService = AttestationBasedClientAuthenticationService(),
             tokenService = TokenService.jwt(
                 issueRefreshTokens = true
             ),

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientExternalAuthorizationServerTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientExternalAuthorizationServerTest.kt
@@ -39,10 +39,9 @@ import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.dummyUser
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respond
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respondOAuth2Error
-import at.asitplus.wallet.lib.ktor.openid.TestUtils.toRequestInfo
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.verifyIsoMdocCredential
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.verifySdJwtCredential
-import at.asitplus.wallet.lib.oauth2.ClientAuthenticationService
+import at.asitplus.wallet.lib.oauth2.AttestationBasedClientAuthenticationService
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
 import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService
 import at.asitplus.wallet.lib.oauth2.TokenService
@@ -140,8 +139,7 @@ val OpenId4VciClientExternalAuthorizationServerTest by matrixSuite {
             pushedAuthorizationRequestEndpointPath = parEndpointPath,
             userInfoEndpointPath = userInfoEndpointPath,
             introspectionEndpointPath = introspectionEndpointPath,
-            clientAuthenticationService = ClientAuthenticationService(
-                enforceClientAuthentication = true,
+            clientAuthenticationService = AttestationBasedClientAuthenticationService(
                 issuerIdentifier = if (validatePopAudience) authServerPublicContext else null,
             ),
             tokenService = tokenService,

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientIntegratedDPoPTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientIntegratedDPoPTest.kt
@@ -22,9 +22,8 @@ import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
 import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respond
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respondIncludingDpopNonce
-import at.asitplus.wallet.lib.ktor.openid.TestUtils.toRequestInfo
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.verifySdJwtCredential
-import at.asitplus.wallet.lib.oauth2.ClientAuthenticationService
+import at.asitplus.wallet.lib.oauth2.AttestationBasedClientAuthenticationService
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
 import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService
 import at.asitplus.wallet.lib.oauth2.TokenService
@@ -83,9 +82,7 @@ val OpenId4VciClientIntegratedDPoPTest by matrixSuite {
                 authorizationEndpointPath = authorizationEndpointPath,
                 tokenEndpointPath = tokenEndpointPath,
                 pushedAuthorizationRequestEndpointPath = parEndpointPath,
-                clientAuthenticationService = ClientAuthenticationService(
-                    enforceClientAuthentication = true,
-                ),
+                clientAuthenticationService = AttestationBasedClientAuthenticationService(),
                 tokenService = TokenService.jwt(
                     issueRefreshTokens = true
                 ),

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
@@ -37,10 +37,9 @@ import at.asitplus.wallet.lib.ktor.openid.TestUtils.credentialDataProviderFun
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.dummyUser
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respond
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respondOAuth2Error
-import at.asitplus.wallet.lib.ktor.openid.TestUtils.toRequestInfo
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.verifyIsoMdocCredential
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.verifySdJwtCredential
-import at.asitplus.wallet.lib.oauth2.ClientAuthenticationService
+import at.asitplus.wallet.lib.oauth2.AttestationBasedClientAuthenticationService
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
 import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService
 import at.asitplus.wallet.lib.oauth2.TokenService
@@ -98,9 +97,7 @@ val OpenId4VciClientTest by matrixSuite {
             authorizationEndpointPath = authorizationEndpointPath,
             tokenEndpointPath = tokenEndpointPath,
             pushedAuthorizationRequestEndpointPath = parEndpointPath,
-            clientAuthenticationService = ClientAuthenticationService(
-                enforceClientAuthentication = true,
-            ),
+            clientAuthenticationService = AttestationBasedClientAuthenticationService(),
             tokenService = TokenService.jwt(
                 issueRefreshTokens = true
             ),

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientWithEncryptionTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientWithEncryptionTest.kt
@@ -31,10 +31,9 @@ import at.asitplus.wallet.lib.ktor.openid.TestUtils.credentialDataProviderFun
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.dummyUser
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respond
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respondOAuth2Error
-import at.asitplus.wallet.lib.ktor.openid.TestUtils.toRequestInfo
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.verifyIsoMdocCredential
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.verifySdJwtCredential
-import at.asitplus.wallet.lib.oauth2.ClientAuthenticationService
+import at.asitplus.wallet.lib.oauth2.AttestationBasedClientAuthenticationService
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
 import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService
 import at.asitplus.wallet.lib.oauth2.TokenService
@@ -89,9 +88,7 @@ val OpenId4VciClientWithEncryptionTest by matrixSuite {
             authorizationEndpointPath = authorizationEndpointPath,
             tokenEndpointPath = tokenEndpointPath,
             pushedAuthorizationRequestEndpointPath = parEndpointPath,
-            clientAuthenticationService = ClientAuthenticationService(
-                enforceClientAuthentication = true,
-            ),
+            clientAuthenticationService = AttestationBasedClientAuthenticationService(),
             tokenService = TokenService.jwt(
                 issueRefreshTokens = true
             ),

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/RemoteOAuth2AuthorizationServerAdapterTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/RemoteOAuth2AuthorizationServerAdapterTest.kt
@@ -14,6 +14,7 @@ import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.jws.JwsHeaderNone
 import at.asitplus.wallet.lib.jws.SignJwt
+import at.asitplus.wallet.lib.oauth2.DPoPNonce
 import at.asitplus.wallet.lib.oauth2.RequestInfo
 import at.asitplus.wallet.lib.oauth2.TokenVerificationService
 import at.asitplus.wallet.lib.oidvci.OAuth2Error

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/TestUtils.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/TestUtils.kt
@@ -12,8 +12,6 @@ import at.asitplus.openid.TokenIntrospectionResponse
 import at.asitplus.openid.TokenIntrospectionResult
 import at.asitplus.openid.TokenResponseParameters
 import at.asitplus.signum.indispensable.CryptoPublicKey
-import at.asitplus.signum.indispensable.josef.JsonWebToken
-import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.wallet.eupid.EU_PID_DOCTYPE
 import at.asitplus.wallet.eupidsdjwt.EU_PID_SD_JWT_VCT
@@ -30,7 +28,7 @@ import at.asitplus.wallet.lib.data.MediaTypes
 import at.asitplus.wallet.lib.data.SdJwtCredentialScheme
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.RevocationList
 import at.asitplus.wallet.lib.extensions.supportedSdAlgorithms
-import at.asitplus.wallet.lib.oauth2.RequestInfo
+import at.asitplus.wallet.lib.oauth2.DPoPNonce
 import at.asitplus.wallet.lib.oauth2.ResponseWithDpopNonce
 import at.asitplus.wallet.lib.oidvci.CredentialDataProviderFun
 import at.asitplus.wallet.lib.oidvci.CredentialIssuer
@@ -62,20 +60,6 @@ object TestUtils {
         },
         status = HttpStatusCode.BadRequest
     ).also { Napier.w("Server error: ${throwable.message}", throwable) }
-
-    fun HttpRequestData.toRequestInfo(): RequestInfo = RequestInfo(
-        url = url.toString(),
-        method = method,
-        dpop = headers["DPoP"]
-            ?.takeIf { it.isNotEmpty() }
-            ?.let { JwsCompactTyped<JsonWebToken>(it) },
-        clientAttestation = headers["OAuth-Client-Attestation"]
-            ?.takeIf { it.isNotEmpty() }
-            ?.let { JwsCompactTyped<JsonWebToken>(it) },
-        clientAttestationPop = headers["OAuth-Client-Attestation-PoP"]
-            ?.takeIf { it.isNotEmpty() }
-            ?.let { JwsCompactTyped<JsonWebToken>(it) }
-    )
 
     fun dummyUser(): OidcUserInfoExtended = OidcUserInfoExtended.deserialize("{\"sub\": \"foo\"}").getOrThrow()
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AttestationBasedClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AttestationBasedClientAuthenticationService.kt
@@ -1,0 +1,171 @@
+package at.asitplus.wallet.lib.oauth2
+
+import at.asitplus.KmmResult
+import at.asitplus.catching
+import at.asitplus.signum.indispensable.josef.JsonWebToken
+import at.asitplus.signum.indispensable.josef.JwsAlgorithm
+import at.asitplus.signum.indispensable.josef.JwsCompactTyped
+import at.asitplus.wallet.lib.etsi.Success
+import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
+import at.asitplus.wallet.lib.jws.VerifyJwsObject
+import at.asitplus.wallet.lib.jws.VerifyJwsObjectFun
+import at.asitplus.wallet.lib.jws.VerifyJwsSignatureWithCnf
+import at.asitplus.wallet.lib.jws.VerifyJwsSignatureWithCnfFun
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidClient
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.jvm.JvmOverloads
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+
+/**
+ * Client authentication service for an OAuth2.0 AS, based on Attestation-Based Client Authentication.
+ *
+ * Implemented from:
+ * * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html)
+ * * [EUDI TS3 Wallet Unit Attestation 1.5.2](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md)
+ */
+class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
+    @Deprecated("Always enforces client auth ... if you don't want that, don't use this class")
+    private val enforceClientAuthentication: Boolean = false,
+    /**
+     * Used to verify client attestation JWTs. Client attestations are required to carry an `x5c`, so pass
+     * [at.asitplus.wallet.lib.jws.VerifyJwsObjectTrustedCertificate] with the certificates of the trusted wallet
+     * providers to establish trust in the attestation. The default only verifies the attestation against the
+     * certificate it carries itself, i.e. it makes no trust decision.
+     */
+    private val verifyJwsObject: VerifyJwsObjectFun = VerifyJwsObject(),
+    /** Used to verify client attestation JWTs */
+    private val verifyJwsSignatureWithCnf: VerifyJwsSignatureWithCnfFun = VerifyJwsSignatureWithCnf(),
+    @Deprecated(
+        "Pass VerifyJwsObjectTrustedCertificate with the trusted wallet provider certificates as " +
+                "verifyJwsObject instead, which evaluates the x5c of the attestation against them."
+    )
+    private val verifyClientAttestationJwt: (suspend (JwsCompactTyped<JsonWebToken>) -> Boolean) = { true },
+    /** Clock used to verify WIA and WIA PoP timestamps. */
+    private val clock: Clock = Clock.System,
+    /** Time leeway for verification of WIA and WIA PoP timestamps. */
+    private val timeLeeway: Duration = 5.minutes,
+    /** Identifier of this authorization server, to verify `aud` of incoming PoP JWTs. */
+    private val issuerIdentifier: String? = null,
+) : ClientAuthenticationService {
+
+    // TODO Add challenge service here
+
+    /**
+     * Authenticates the client as defined from a client attestation JWT.
+     */
+    @Throws(InvalidClient::class, CancellationException::class)
+    override suspend fun authenticateClient(
+        httpRequest: RequestInfo?,
+        clientId: String?,
+    ): KmmResult<Success> = catching {
+        val instanceAttestation = httpRequest?.clientAttestation
+            ?: throw InvalidClient("client attestation header missing")
+
+        val instanceAttestationPopJwt = httpRequest.clientAttestationPop
+            ?: throw InvalidClient("client attestation pop header missing")
+
+
+        instanceAttestation.validateWalletInstanceAttestation(clientId)
+        verifyJwsObject(instanceAttestation.jws).getOrElse {
+            throw InvalidClient("client attestation JWT not verified", it)
+        }
+
+        @Suppress("DEPRECATION")
+        if (!verifyClientAttestationJwt.invoke(instanceAttestation)) {
+            throw InvalidClient("client attestation not verified")
+        }
+
+        instanceAttestationPopJwt.validateWalletInstanceAttestationPop(instanceAttestation.payload.subject)
+        val cnf = instanceAttestation.payload.confirmationClaim
+            ?: throw InvalidClient("client attestation has no cnf")
+        if (!verifyJwsSignatureWithCnf(instanceAttestationPopJwt.jws, cnf)) {
+            throw InvalidClient("client attestation PoP JWT not verified")
+        }
+
+        Success
+    }
+
+    private fun JwsCompactTyped<JsonWebToken>.validateWalletInstanceAttestation(clientId: String?) {
+        if (jws.jwsHeader.type != JwsContentTypeConstants.CLIENT_ATTESTATION_JWT) {
+            throw InvalidClient("invalid client attestation typ: ${jws.jwsHeader.type}")
+        }
+        if (jws.jwsHeader.certificateChain.isNullOrEmpty()) {
+            throw InvalidClient("client attestation has no x5c")
+        }
+        if (jws.jwsHeader.algorithm !is JwsAlgorithm.Signature ||
+            jws.jwsHeader.algorithm !in SimpleAuthorizationService.DEFAULT_WALLET_ATTESTATION_ALGORITHMS
+        ) {
+            throw InvalidClient("unsupported client attestation alg: ${jws.jwsHeader.algorithm}")
+        }
+        if (payload.issuer != null) {
+            throw InvalidClient("client attestation must not contain iss")
+        }
+        if (payload.subject == null) {
+            throw InvalidClient("client attestation has no sub")
+        }
+        if (clientId != null && payload.subject != clientId) {
+            throw InvalidClient("subject not equal to client_id")
+        }
+        val issuedAt = payload.issuedAt ?: throw InvalidClient("client attestation has no iat")
+        val expiration = payload.expiration ?: throw InvalidClient("client attestation has no exp")
+        if (issuedAt > (clock.now() + timeLeeway)) {
+            throw InvalidClient("client attestation iat in future: $issuedAt")
+        }
+        if (expiration < (clock.now() - timeLeeway)) {
+            throw InvalidClient("client attestation expired: $expiration")
+        }
+        if (expiration - issuedAt >= 24.hours) {
+            throw InvalidClient("client attestation lifetime must be less than 24 hours")
+        }
+        if (payload.walletName.isNullOrBlank()) {
+            throw InvalidClient("client attestation has no wallet_name")
+        }
+        if (payload.walletVersion.isNullOrBlank()) {
+            throw InvalidClient("client attestation has no wallet_version")
+        }
+        if (payload.walletSolutionCertificationInformation.isNullOrBlank()) {
+            throw InvalidClient("client attestation has no wallet_solution_certification_information")
+        }
+        val clientStatus = payload.clientStatus ?: throw InvalidClient("client attestation has no client_status")
+        if (clientStatus.expiration < (clock.now() - timeLeeway)) {
+            throw InvalidClient("client_status expiration in past: ${clientStatus.expiration}")
+        }
+        if (payload.confirmationClaim == null) {
+            // TODO Validate this is an asymmetric key
+            throw InvalidClient("client attestation has no cnf")
+        }
+    }
+
+    private fun JwsCompactTyped<JsonWebToken>.validateWalletInstanceAttestationPop(clientId: String?) {
+        if (jws.jwsHeader.type != JwsContentTypeConstants.CLIENT_ATTESTATION_POP_JWT) {
+            throw InvalidClient("invalid client attestation PoP typ: ${jws.jwsHeader.type}")
+        }
+        if (jws.jwsHeader.algorithm !is JwsAlgorithm.Signature ||
+            jws.jwsHeader.algorithm !in SimpleAuthorizationService.DEFAULT_WALLET_ATTESTATION_ALGORITHMS
+        ) {
+            throw InvalidClient("unsupported client attestation PoP alg: ${jws.jwsHeader.algorithm}")
+        }
+        if (payload.issuer == null || payload.issuer != clientId) {
+            throw InvalidClient("client attestation PoP iss not equal to client_id")
+        }
+        if (issuerIdentifier != null && payload.audience != issuerIdentifier) {
+            throw InvalidClient(
+                "client attestation PoP aud '${payload.audience}' does not match issuer '$issuerIdentifier'"
+            )
+        }
+        if (payload.issuedAt == null || payload.issuedAt!! > (clock.now() + timeLeeway)) {
+            throw InvalidClient("client attestation PoP iat in future: ${payload.issuedAt}")
+        }
+        if (payload.expiration == null || payload.expiration!! < (clock.now() - timeLeeway)) {
+            throw InvalidClient("client attestation PoP expired: ${payload.expiration}")
+        }
+        // TODO Verify other fields
+        // TODO Need to verify challenge
+        // TODO Validate signature against CNF key
+    }
+
+}

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
@@ -1,175 +1,27 @@
 package at.asitplus.wallet.lib.oauth2
 
-import at.asitplus.signum.indispensable.josef.JsonWebToken
-import at.asitplus.signum.indispensable.josef.JwsAlgorithm
-import at.asitplus.signum.indispensable.josef.JwsCompactTyped
-import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
-import at.asitplus.wallet.lib.jws.VerifyJwsObject
-import at.asitplus.wallet.lib.jws.VerifyJwsObjectFun
-import at.asitplus.wallet.lib.jws.VerifyJwsSignatureWithCnf
-import at.asitplus.wallet.lib.jws.VerifyJwsSignatureWithCnfFun
-import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidClient
-import kotlin.coroutines.cancellation.CancellationException
-import kotlin.jvm.JvmOverloads
-import kotlin.time.Clock
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.minutes
-
+import at.asitplus.KmmResult
+import at.asitplus.catching
+import at.asitplus.wallet.lib.etsi.Success
 
 /**
- * Simple client authentication service for an OAuth2.0 AS.
- *
- * Implemented from:
- * * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html)
- * * [EUDI TS3 Wallet Unit Attestation 1.5.2](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md)
+ * Handles authenticating the OAuth 2.0 client for an OAuth 2.0 authorization server,
+ * see [SimpleAuthorizationService] and subclasses of this interface.
  */
-class ClientAuthenticationService @JvmOverloads constructor(
-    /** Enforce client authentication as defined in OpenID4VC HAIP, i.e. with wallet attestations */
-    private val enforceClientAuthentication: Boolean = false,
-    /**
-     * Used to verify client attestation JWTs. Client attestations are required to carry an `x5c`, so pass
-     * [at.asitplus.wallet.lib.jws.VerifyJwsObjectTrustedCertificate] with the certificates of the trusted wallet
-     * providers to establish trust in the attestation. The default only verifies the attestation against the
-     * certificate it carries itself, i.e. it makes no trust decision.
-     */
-    private val verifyJwsObject: VerifyJwsObjectFun = VerifyJwsObject(),
-    /** Used to verify client attestation JWTs */
-    private val verifyJwsSignatureWithCnf: VerifyJwsSignatureWithCnfFun = VerifyJwsSignatureWithCnf(),
-    @Deprecated(
-        "Pass VerifyJwsObjectTrustedCertificate with the trusted wallet provider certificates as " +
-                "verifyJwsObject instead, which evaluates the x5c of the attestation against them."
-    )
-    /** Callback to verify the client attestation JWT against a set of trusted roots */
-    private val verifyClientAttestationJwt: (suspend (JwsCompactTyped<JsonWebToken>) -> Boolean) = { true },
-    /** Clock used to verify WIA and WIA PoP timestamps. */
-    private val clock: Clock = Clock.System,
-    /** Time leeway for verification of WIA and WIA PoP timestamps. */
-    private val timeLeeway: Duration = 5.minutes,
-    /**
-     * The RFC 8414 issuer identifier of this authorization server.
-     * When set, the `aud` claim of incoming WIA PoP JWTs is validated against this value.
-     */
-    private val issuerIdentifier: String? = null,
-) {
-
-    // TODO Add challenge service here
-
-    /**
-     * Authenticates the client as defined in OpenID4VC HAIP, i.e. with client attestation JWT.
-     * Throws an exception if authentication fails. Honors [enforceClientAuthentication].
-     */
-    @Throws(InvalidClient::class, CancellationException::class)
+interface ClientAuthenticationService {
+    /** Authenticates the client by some data in the request. */
     suspend fun authenticateClient(
         httpRequest: RequestInfo?,
         clientId: String?,
-    ) {
-        // Enforce client authentication once all clients implement it
-        if (enforceClientAuthentication) {
-            if (httpRequest?.clientAttestation == null || httpRequest.clientAttestationPop == null) {
-                throw InvalidClient("client attestation headers missing")
-            }
-        }
+    ): KmmResult<Success>
+}
 
-        if (httpRequest?.clientAttestation != null && httpRequest.clientAttestationPop != null) {
-            val instanceAttestation = httpRequest.clientAttestation
-            instanceAttestation.validateWalletInstanceAttestation(clientId)
-            verifyJwsObject(instanceAttestation.jws).getOrElse {
-                throw InvalidClient("client attestation JWT not verified", it)
-            }
-
-            @Suppress("DEPRECATION")
-            if (!verifyClientAttestationJwt.invoke(instanceAttestation)) {
-                throw InvalidClient("client attestation not verified")
-            }
-
-            val instanceAttestationPopJwt = httpRequest.clientAttestationPop
-            instanceAttestationPopJwt.validateWalletInstanceAttestationPop(instanceAttestation.payload.subject)
-            val cnf = instanceAttestation.payload.confirmationClaim
-                ?: throw InvalidClient("client attestation has no cnf")
-            if (!verifyJwsSignatureWithCnf(instanceAttestationPopJwt.jws, cnf)) {
-                throw InvalidClient("client attestation PoP JWT not verified")
-            }
-        }
+/** Does not verify the client authentication at all */
+object NoopClientAuthenticationService : ClientAuthenticationService {
+    override suspend fun authenticateClient(
+        httpRequest: RequestInfo?,
+        clientId: String?
+    ): KmmResult<Success> = catching {
+        Success
     }
-
-    private fun JwsCompactTyped<JsonWebToken>.validateWalletInstanceAttestation(clientId: String?) {
-        if (jws.jwsHeader.type != JwsContentTypeConstants.CLIENT_ATTESTATION_JWT) {
-            throw InvalidClient("invalid client attestation typ: ${jws.jwsHeader.type}")
-        }
-        if (jws.jwsHeader.certificateChain.isNullOrEmpty()) {
-            throw InvalidClient("client attestation has no x5c")
-        }
-        if (jws.jwsHeader.algorithm !is JwsAlgorithm.Signature ||
-            jws.jwsHeader.algorithm !in SimpleAuthorizationService.DEFAULT_WALLET_ATTESTATION_ALGORITHMS
-        ) {
-            throw InvalidClient("unsupported client attestation alg: ${jws.jwsHeader.algorithm}")
-        }
-        if (payload.issuer != null) {
-            throw InvalidClient("client attestation must not contain iss")
-        }
-        if (payload.subject == null) {
-            throw InvalidClient("client attestation has no sub")
-        }
-        if (clientId != null && payload.subject != clientId) {
-            throw InvalidClient("subject not equal to client_id")
-        }
-        val issuedAt = payload.issuedAt ?: throw InvalidClient("client attestation has no iat")
-        val expiration = payload.expiration ?: throw InvalidClient("client attestation has no exp")
-        if (issuedAt > (clock.now() + timeLeeway)) {
-            throw InvalidClient("client attestation iat in future: $issuedAt")
-        }
-        if (expiration < (clock.now() - timeLeeway)) {
-            throw InvalidClient("client attestation expired: $expiration")
-        }
-        if (expiration - issuedAt >= 24.hours) {
-            throw InvalidClient("client attestation lifetime must be less than 24 hours")
-        }
-        if (payload.walletName.isNullOrBlank()) {
-            throw InvalidClient("client attestation has no wallet_name")
-        }
-        if (payload.walletVersion.isNullOrBlank()) {
-            throw InvalidClient("client attestation has no wallet_version")
-        }
-        if (payload.walletSolutionCertificationInformation.isNullOrBlank()) {
-            throw InvalidClient("client attestation has no wallet_solution_certification_information")
-        }
-        val clientStatus = payload.clientStatus ?: throw InvalidClient("client attestation has no client_status")
-        if (clientStatus.expiration < (clock.now() - timeLeeway)) {
-            throw InvalidClient("client_status expiration in past: ${clientStatus.expiration}")
-        }
-        if (payload.confirmationClaim == null) {
-            // TODO Validate this is an asymmetric key
-            throw InvalidClient("client attestation has no cnf")
-        }
-    }
-
-    private fun JwsCompactTyped<JsonWebToken>.validateWalletInstanceAttestationPop(clientId: String?) {
-        if (jws.jwsHeader.type != JwsContentTypeConstants.CLIENT_ATTESTATION_POP_JWT) {
-            throw InvalidClient("invalid client attestation PoP typ: ${jws.jwsHeader.type}")
-        }
-        if (jws.jwsHeader.algorithm !is JwsAlgorithm.Signature ||
-            jws.jwsHeader.algorithm !in SimpleAuthorizationService.DEFAULT_WALLET_ATTESTATION_ALGORITHMS
-        ) {
-            throw InvalidClient("unsupported client attestation PoP alg: ${jws.jwsHeader.algorithm}")
-        }
-        if (payload.issuer == null || payload.issuer != clientId) {
-            throw InvalidClient("client attestation PoP iss not equal to client_id")
-        }
-        if (issuerIdentifier != null && payload.audience != issuerIdentifier) {
-            throw InvalidClient(
-                "client attestation PoP aud '${payload.audience}' does not match issuer '$issuerIdentifier'"
-            )
-        }
-        if (payload.issuedAt == null || payload.issuedAt!! > (clock.now() + timeLeeway)) {
-            throw InvalidClient("client attestation PoP iat in future: ${payload.issuedAt}")
-        }
-        if (payload.expiration == null || payload.expiration!! < (clock.now() - timeLeeway)) {
-            throw InvalidClient("client attestation PoP expired: ${payload.expiration}")
-        }
-        // TODO Verify other fields
-        // TODO Need to verify challenge
-        // TODO Validate signature against CNF key
-    }
-
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
@@ -21,7 +21,7 @@ import kotlin.time.Duration.Companion.minutes
  * Simple client authentication service for an OAuth2.0 AS.
  *
  * Implemented from:
- * * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-05.html)
+ * * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html)
  * * [EUDI TS3 Wallet Unit Attestation 1.5.2](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md)
  */
 class ClientAuthenticationService @JvmOverloads constructor(
@@ -52,6 +52,8 @@ class ClientAuthenticationService @JvmOverloads constructor(
      */
     private val issuerIdentifier: String? = null,
 ) {
+
+    // TODO Add challenge service here
 
     /**
      * Authenticates the client as defined in OpenID4VC HAIP, i.e. with client attestation JWT.
@@ -137,6 +139,7 @@ class ClientAuthenticationService @JvmOverloads constructor(
             throw InvalidClient("client_status expiration in past: ${clientStatus.expiration}")
         }
         if (payload.confirmationClaim == null) {
+            // TODO Validate this is an asymmetric key
             throw InvalidClient("client attestation has no cnf")
         }
     }
@@ -164,6 +167,9 @@ class ClientAuthenticationService @JvmOverloads constructor(
         if (payload.expiration == null || payload.expiration!! < (clock.now() - timeLeeway)) {
             throw InvalidClient("client attestation PoP expired: ${payload.expiration}")
         }
+        // TODO Verify other fields
+        // TODO Need to verify challenge
+        // TODO Validate signature against CNF key
     }
 
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/RequestInfo.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/RequestInfo.kt
@@ -1,26 +1,77 @@
 package at.asitplus.wallet.lib.oauth2
 
+import at.asitplus.catchingUnwrapped
 import at.asitplus.signum.indispensable.josef.JsonWebToken
+import at.asitplus.signum.indispensable.josef.JwsCompact
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
+import at.asitplus.signum.indispensable.josef.JwsTyped
 import io.ktor.http.*
+import kotlin.jvm.JvmOverloads
 
 /** Holds information about the HTTP request the client has made, to validate client authentication. */
-data class RequestInfo(
+data class RequestInfo @JvmOverloads constructor(
     /** URL that has been used to send this request. */
     val url: String,
     /** HTTP method that the client has used. */
     val method: HttpMethod,
+    /** Headers as received from the client. */
+    val headers: Headers? = null,
+) {
+
+    // To be made internal after 8.0.0
+    @Deprecated("Use main constructor taking in all HTTP headers")
+    constructor(
+        url: String,
+        method: HttpMethod,
+        dpop: JwsCompactTyped<JsonWebToken>? = null,
+        clientAttestation: JwsCompactTyped<JsonWebToken>? = null,
+        clientAttestationPop: JwsCompactTyped<JsonWebToken>? = null,
+    ) : this(
+        url = url,
+        method = method,
+        headers = headers {
+            dpop?.let { set(HttpHeaders.DPoP, dpop.toString()) }
+            clientAttestation?.let { set(HttpHeaders.OAuthClientAttestation, clientAttestation.toString()) }
+            clientAttestationPop?.let { set(HttpHeaders.OAuthClientAttestationPop, clientAttestationPop.toString()) }
+        }
+    )
 
     /** Value of the header `DPoP` (RFC 9449). The value of the header is a JSON Web Token (JWT) */
-    val dpop: JwsCompactTyped<JsonWebToken>? = null,
+    val dpop: JwsCompactTyped<JsonWebToken>?
+        get() = headers.parseJwt(HttpHeaders.DPoP)
+
     /**
      * Value of the header `OAuth-Client-Attestation` (OAuth 2.0 Attestation-Based Client Authentication).
      * A JWT that conforms to the structure and syntax as defined in Section 4.2
      */
-    val clientAttestation: JwsCompactTyped<JsonWebToken>? = null,
+    val clientAttestation: JwsCompactTyped<JsonWebToken>?
+        get() = headers.parseJwt(HttpHeaders.OAuthClientAttestation)
+
     /**
      * Value of the header `OAuth-Client-Attestation-PoP` (OAuth 2.0 Attestation-Based Client Authentication).
      * A JWT that adheres to the structure and syntax as defined in Section 4.3
      */
-    val clientAttestationPop: JwsCompactTyped<JsonWebToken>? = null,
-)
+    val clientAttestationPop: JwsCompactTyped<JsonWebToken>?
+        get() = headers.parseJwt(HttpHeaders.OAuthClientAttestationPop)
+
+    private fun Headers?.parseJwt(headerName: String): JwsTyped<JwsCompact, JsonWebToken>? =
+        catchingUnwrapped {
+            this?.get(headerName)
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { JwsCompactTyped<JsonWebToken>(it) }
+        }.getOrNull()
+
+}
+
+
+val HttpHeaders.OAuthClientAttestation: String
+    get() = "OAuth-Client-Attestation"
+
+val HttpHeaders.OAuthClientAttestationPop: String
+    get() = "OAuth-Client-Attestation-PoP"
+
+val HttpHeaders.DPoP: String
+    get() = "DPoP"
+
+val HttpHeaders.DPoPNonce: String
+    get() = "DPoP-Nonce"

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -124,12 +124,8 @@ class SimpleAuthorizationService @JvmOverloads constructor(
     private val requestUriToPushedAuthorizationRequest: MapStore<String, AuthenticationRequestParameters> = DefaultMapStore(),
     /** Service to create and validate access tokens. */
     private val tokenService: TokenService = TokenService.bearer(),
-    /** Handles client authentication in [par] and [token]. */
-    private val clientAuthenticationService: ClientAuthenticationService = ClientAuthenticationService(
-        enforceClientAuthentication = false,
-        verifyClientAttestationJwt = { true },
-        issuerIdentifier = publicContext
-    ),
+    /** Handles client authentication in [par] and [token]. Defaults to [NoopClientAuthenticationService]! */
+    private val clientAuthenticationService: ClientAuthenticationService = NoopClientAuthenticationService,
     /** Used to parse requests from clients, e.g., when using JWT-Secured Authorization Requests (RFC 9101) */
     private val requestParser: RequestParser = RequestParser(
         /** By default, do not retrieve authn requests referenced by `request_uri`. */

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -75,7 +75,7 @@ import kotlin.time.Duration.Companion.minutes
  * [OAuth 2.0 Pushed Authorization Requests](https://datatracker.ietf.org/doc/html/rfc9126),
  * [Proof Key for Code Exchange by OAuth Public Clients](https://datatracker.ietf.org/doc/html/rfc7636),
  * [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449),
- * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-05.html)
+ * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html)
  * [OAuth 2.0 Token Introspection](https://datatracker.ietf.org/doc/html/rfc7662)
  * [OAuth 2.0 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693)
  */
@@ -112,6 +112,7 @@ class SimpleAuthorizationService @JvmOverloads constructor(
      * requests to that URI (which starts with [publicContext]) to [getTokenInfo].
      */
     private val introspectionEndpointPath: String = "/introspect",
+    // TODO Add challenge endpoint path for Attestation-Based Client Auth
     /** Associates issuer_state with credential offers. */
     private val issuerStateToCredentialOffer: MapStore<String, CredentialOffer> = DefaultMapStore(),
     /** Associates issued codes with the auth request from the client. */
@@ -533,6 +534,8 @@ class SimpleAuthorizationService @JvmOverloads constructor(
         val response = token(request, httpRequest).getOrThrow()
         ResponseWithDpopNonce(response, tokenService.dpopNonce())
     }
+
+    // TODO Challenge endpoint for Attestation-Based Client Auth
 
     private fun validateCodeChallenge(code: String, codeVerifier: String?, codeChallenge: String) {
         if (codeVerifier == null) {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2SecurityExtensions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2SecurityExtensions.kt
@@ -55,7 +55,7 @@ object BuildClientAttestationJwt {
     /**
      * Client attestation JWT, issued by the backend service to a client, which can be sent to an OAuth2 Authorization
      * Server if needed, e.g. as HTTP header `OAuth-Client-Attestation`, see
-     * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-04.html)
+     * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html)
      *
      * @param clientId OAuth 2.0 client ID of the wallet
      * @param clientKey key to be attested, i.e. included in a [ConfirmationClaim]
@@ -114,7 +114,7 @@ object BuildClientAttestationPoPJwt {
     /**
      * Client attestation PoP JWT, issued by the client, which can be sent to an OAuth2 Authorization Server if needed,
      * e.g. as HTTP header `OAuth-Client-Attestation-PoP`, see
-     * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-04.html)
+     * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html)
      *
      * @param clientId OAuth 2.0 client ID of the wallet
      * @param audience The RFC8414 issuer identifier URL of the authorization server MUST be used
@@ -132,11 +132,14 @@ object BuildClientAttestationPoPJwt {
         randomSource: RandomSource = RandomSource.Secure
     ): JwsCompactTyped<JsonWebToken> = signJwt(
         type = JwsContentTypeConstants.CLIENT_ATTESTATION_POP_JWT,
+        // TODO Validate fields against latest draft
         payload = JsonWebToken(
             issuer = clientId,
             audience = audience,
             jwtId = randomSource.nextBytes(12).encodeToString(Base64UrlStrict),
+            // Setting both fields here, this changed in draft 10 of OAuth 2.0 Attestation-Based Client Auth
             nonce = nonce,
+            challenge = nonce,
             issuedAt = Clock.System.now().truncateToSeconds() - clockSkew.absoluteValue,
             expiration = Clock.System.now().truncateToSeconds() - clockSkew.absoluteValue + lifetime,
         ).also {

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
@@ -50,6 +50,7 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
             )
 
             val signClientAttestationPop: SignJwtFun<JsonWebToken> = SignJwt(clientKey, JwsHeaderNone())
+            // TODO Need support for nonce/challenge
             val clientAttestationPop = BuildClientAttestationPoPJwt(
                 signJwt = signClientAttestationPop,
                 clientId = client.clientId,

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
@@ -73,12 +73,10 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
                 var server = SimpleAuthorizationService(
                     publicContext = AUTHORIZATION_SERVER,
                     strategy = DummyAuthorizationServiceStrategy(scope),
-                    clientAuthenticationService = ClientAuthenticationService(
-                        enforceClientAuthentication = true,
-                        verifyJwsObject = VerifyJwsObjectTrustedCertificate(
-                            trustedIssuers = { setOf(walletProviderCaCert) }
-                        ),
-                    )
+clientAuthenticationService = AttestationBasedClientAuthenticationService(
+    verifyJwsObject = VerifyJwsObjectTrustedCertificate(
+        trustedIssuers = { setOf(walletProviderCaCert) }
+    ),)
                 )
                 val clientKey = clientKey
                 var clientAttestation = clientAttestation
@@ -377,14 +375,15 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
             it.server = SimpleAuthorizationService(
                 publicContext = AUTHORIZATION_SERVER,
                 strategy = DummyAuthorizationServiceStrategy(it.scope),
-                clientAuthenticationService = ClientAuthenticationService(
-                    enforceClientAuthentication = true,
-                    verifyJwsObject = VerifyJwsObjectTrustedCertificate(
-                        trustedIssuers = { setOf(TestCertificateAuthority().certificate()) }
-                    ),
+    clientAuthenticationService = AttestationBasedClientAuthenticationService(
+
+        verifyJwsObject = VerifyJwsObjectTrustedCertificate(
+            trustedIssuers = { setOf(TestCertificateAuthority().certificate()) }
+        ),
                 ),
             )
 
+            @Suppress("DEPRECATION")
             shouldThrow<OAuth2Exception> {
                 it.server.par(
                     authnRequest,
@@ -412,6 +411,7 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
             )
 
             shouldThrow<OAuth2Exception> {
+                @Suppress("DEPRECATION")
                 it.server.par(
                     authnRequest,
                     RequestInfo(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
@@ -108,6 +108,7 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
                     randomSource = RandomSource.Default
                 )
 
+                @Suppress("DEPRECATION")
                 suspend fun par(
                     clientAttestation: JwsCompactTyped<JsonWebToken> = this.clientAttestation,
                     clientAttestationPop: JwsCompactTyped<JsonWebToken> = this.clientAttestationPop,
@@ -121,6 +122,7 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
                     )
                 ).getOrThrow()
 
+                @Suppress("DEPRECATION")
                 suspend fun getToken(state: String, code: String): TokenResponseParameters = server.token(
                     request = client.createTokenRequestParameters(
                         state = state,
@@ -130,18 +132,17 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
                     httpRequest = RequestInfo(
                         url = "https://example.com/",
                         method = HttpMethod.Post,
-                        dpop = null,
                         clientAttestation = this.clientAttestation,
                         clientAttestationPop = freshPop()
                     )
                 ).getOrThrow()
 
+                @Suppress("DEPRECATION")
                 suspend fun introspect(token: TokenResponseParameters) = server.tokenIntrospection(
                     TokenIntrospectionRequest(token = token.accessToken),
                     RequestInfo(
                         url = "https://example.com/",
                         method = HttpMethod.Get,
-                        dpop = null,
                         clientAttestation = this.clientAttestation,
                         clientAttestationPop = freshPop()
                     )
@@ -161,6 +162,7 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
                 state = state,
                 scope = it.scope,
             )
+            @Suppress("DEPRECATION")
             val parResponse = it.server.par(
                 authnRequest,
                 RequestInfo(
@@ -350,6 +352,7 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
                 clientKey = it.clientKey.jsonWebKey
             )
 
+            @Suppress("DEPRECATION")
             shouldThrow<OAuth2Exception> {
                 it.server.par(
                     authnRequest,
@@ -428,6 +431,7 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
                 scope = it.scope,
             )
 
+            @Suppress("DEPRECATION")
             shouldThrow<OAuth2Exception> {
                 it.server.par(
                     authnRequest,

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
@@ -14,6 +14,7 @@ import at.asitplus.testballoon.matrix.matrixSuite
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
 import at.asitplus.wallet.lib.agent.RandomSource
 import at.asitplus.wallet.lib.agent.TestCertificateAuthority
+import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
 import at.asitplus.wallet.lib.jws.JwsHeaderNone
 import at.asitplus.wallet.lib.jws.SignJwt
@@ -33,6 +34,12 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+/** RFC 8414 issuer identifier of the AS under test, i.e. the required `aud` of client attestation PoP JWTs. */
+private const val AUTHORIZATION_SERVER = "https://wallet.a-sit.at/authorization-server"
 
 val OAuth2ClientAuthenticationTest by matrixSuite {
 
@@ -54,7 +61,7 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
             val clientAttestationPop = BuildClientAttestationPoPJwt(
                 signJwt = signClientAttestationPop,
                 clientId = client.clientId,
-                audience = "some server",
+                audience = AUTHORIZATION_SERVER,
                 randomSource = RandomSource.Default
             )
 
@@ -62,7 +69,9 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
                 val scope = randomString()
                 val client = client
                 val walletProviderCa = walletProviderCa
+                val attesterBackend = attesterBackend
                 var server = SimpleAuthorizationService(
+                    publicContext = AUTHORIZATION_SERVER,
                     strategy = DummyAuthorizationServiceStrategy(scope),
                     clientAuthenticationService = ClientAuthenticationService(
                         enforceClientAuthentication = true,
@@ -74,6 +83,43 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
                 val clientKey = clientKey
                 var clientAttestation = clientAttestation
                 val clientAttestationPop = clientAttestationPop
+                val signClientAttestationPop = signClientAttestationPop
+
+                suspend fun signPop(payload: JsonWebToken) = signClientAttestationPop(
+                    type = JwsContentTypeConstants.CLIENT_ATTESTATION_POP_JWT,
+                    payload = payload,
+                    serializer = JsonWebToken.serializer(),
+                ).getOrThrow()
+
+                suspend fun signAttestation(payload: JsonWebToken) = attesterBackend(
+                    type = JwsContentTypeConstants.CLIENT_ATTESTATION_JWT,
+                    payload = payload,
+                    serializer = JsonWebToken.serializer(),
+                ).getOrThrow()
+
+                /**
+                 * A conformant client sends a fresh PoP per request (draft-10 5.1: "Clients MUST generate JWTs
+                 * for each target"), so every request in a multi-step flow needs its own `jti`.
+                 */
+                suspend fun freshPop() = BuildClientAttestationPoPJwt(
+                    signJwt = signClientAttestationPop,
+                    clientId = client.clientId,
+                    audience = AUTHORIZATION_SERVER,
+                    randomSource = RandomSource.Default
+                )
+
+                suspend fun par(
+                    clientAttestation: JwsCompactTyped<JsonWebToken> = this.clientAttestation,
+                    clientAttestationPop: JwsCompactTyped<JsonWebToken> = this.clientAttestationPop,
+                ) = server.par(
+                    client.createAuthRequestJar(state = uuid4().toString(), scope = scope),
+                    RequestInfo(
+                        url = "https://example.com/",
+                        method = HttpMethod.Post,
+                        clientAttestation = clientAttestation,
+                        clientAttestationPop = clientAttestationPop,
+                    )
+                ).getOrThrow()
 
                 suspend fun getToken(state: String, code: String): TokenResponseParameters = server.token(
                     request = client.createTokenRequestParameters(
@@ -86,7 +132,18 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
                         method = HttpMethod.Post,
                         dpop = null,
                         clientAttestation = this.clientAttestation,
-                        clientAttestationPop = clientAttestationPop
+                        clientAttestationPop = freshPop()
+                    )
+                ).getOrThrow()
+
+                suspend fun introspect(token: TokenResponseParameters) = server.tokenIntrospection(
+                    TokenIntrospectionRequest(token = token.accessToken),
+                    RequestInfo(
+                        url = "https://example.com/",
+                        method = HttpMethod.Get,
+                        dpop = null,
+                        clientAttestation = this.clientAttestation,
+                        clientAttestationPop = freshPop()
                     )
                 ).getOrThrow()
             }
@@ -124,18 +181,160 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
             val token = it.getToken(state, code).apply {
                 authorizationDetails.shouldBeNull()
             }
-            it.server.tokenIntrospection(
-                TokenIntrospectionRequest(token = token.accessToken),
-                RequestInfo(
-                    url = "https://example.com/",
-                    method = HttpMethod.Get,
-                    dpop = null,
-                    clientAttestation = it.clientAttestation,
-                    clientAttestationPop = it.clientAttestationPop
-                )
-            ).getOrThrow()
+            it.introspect(token)
                 .shouldBeInstanceOf<TokenIntrospectionResponse>()
                 .apply { active shouldBe true }
+        }
+
+        test("client attestation PoP does not contain iss") {
+            it.clientAttestationPop.payload.issuer.shouldBeNull()
+        }
+
+        test("client attestation PoP does not contain exp") {
+            it.clientAttestationPop.payload.expiration.shouldBeNull()
+        }
+
+        test("client attestation PoP uses challenge instead of nonce") {
+            val challenge = randomString()
+            val pop = BuildClientAttestationPoPJwt(
+                signJwt = it.signClientAttestationPop,
+                clientId = it.client.clientId,
+                audience = "some server",
+                nonce = challenge,
+                randomSource = RandomSource.Default,
+            )
+
+            pop.payload.challenge shouldBe challenge
+            pop.payload.nonce.shouldBeNull()
+        }
+
+        test("reject client attestation with secret material in cnf jwk") {
+            val clientAttestation = BuildClientAttestationJwt(
+                signJwt = it.attesterBackend,
+                clientId = it.client.clientId,
+                clientKey = it.clientKey.jsonWebKey.copy(k = byteArrayOf(1)),
+            )
+
+            shouldThrow<OAuth2Exception> {
+                it.par(clientAttestation = clientAttestation)
+            }
+        }
+
+        test("reject client attestation without cnf") {
+            val clientAttestation = it.signAttestation(it.clientAttestation.payload.copy(confirmationClaim = null))
+
+            shouldThrow<OAuth2Exception> {
+                it.par(clientAttestation = clientAttestation)
+            }
+        }
+
+        test("accept client attestation with iss, removed in draft 8 but tolerated") {
+            val clientAttestation = it.signAttestation(
+                it.clientAttestation.payload.copy(issuer = "https://attester.example")
+            )
+
+            it.par(clientAttestation = clientAttestation)
+        }
+
+        test("accept client attestation PoP with iss and exp, removed in draft 8 and 6 but tolerated") {
+            val pop = it.signPop(
+                it.clientAttestationPop.payload.copy(
+                    issuer = it.client.clientId,
+                    expiration = Clock.System.now() + 10.minutes,
+                )
+            )
+
+            it.par(clientAttestationPop = pop)
+        }
+
+        test("reject client attestation PoP with iss of another client") {
+            val pop = it.signPop(
+                it.clientAttestationPop.payload.copy(issuer = "https://attacker.example")
+            )
+
+            shouldThrow<OAuth2Exception> {
+                it.par(clientAttestationPop = pop)
+            }
+        }
+
+        test("reject expired client attestation PoP") {
+            val pop = it.signPop(
+                it.clientAttestationPop.payload.copy(expiration = Clock.System.now() - 1.hours)
+            )
+
+            shouldThrow<OAuth2Exception> {
+                it.par(clientAttestationPop = pop)
+            }
+        }
+
+        test("reject client attestation PoP without jti") {
+            val pop = it.signPop(it.clientAttestationPop.payload.copy(jwtId = null))
+
+            shouldThrow<OAuth2Exception> {
+                it.par(clientAttestationPop = pop)
+            }
+        }
+
+        test("reject client attestation PoP for another audience") {
+            val pop = it.signPop(
+                it.clientAttestationPop.payload.copy(audience = "https://attacker.example")
+            )
+
+            shouldThrow<OAuth2Exception> {
+                it.par(clientAttestationPop = pop)
+            }
+        }
+
+        test("reject client attestation PoP without aud") {
+            val pop = it.signPop(it.clientAttestationPop.payload.copy(audience = null))
+
+            shouldThrow<OAuth2Exception> {
+                it.par(clientAttestationPop = pop)
+            }
+        }
+
+        test("reject stale client attestation PoP") {
+            val pop = it.signPop(
+                it.clientAttestationPop.payload.copy(issuedAt = Clock.System.now() - 1.hours)
+            )
+
+            shouldThrow<OAuth2Exception> {
+                it.par(clientAttestationPop = pop)
+            }
+        }
+
+        test("reject client attestation PoP without iat") {
+            val pop = it.signPop(it.clientAttestationPop.payload.copy(issuedAt = null))
+
+            shouldThrow<OAuth2Exception> {
+                it.par(clientAttestationPop = pop)
+            }
+        }
+
+        test("reject client attestation PoP with unsupported algorithm") {
+            shouldThrow<OAuth2Exception> {
+                it.par(clientAttestationPop = it.clientAttestationPop.withHeaderAlg(JwsAlgorithm.Signature.RS256))
+            }
+        }
+
+        test("reject client attestation PoP not signed by the cnf key") {
+            val pop = SignJwt<JsonWebToken>(EphemeralKeyWithSelfSignedCert(), JwsHeaderNone())(
+                JwsContentTypeConstants.CLIENT_ATTESTATION_POP_JWT,
+                it.clientAttestationPop.payload,
+                JsonWebToken.serializer(),
+            ).getOrThrow()
+
+            shouldThrow<OAuth2Exception> {
+                it.par(clientAttestationPop = pop)
+            }
+        }
+
+        test("reject replayed client attestation PoP") {
+            it.par()
+
+            shouldThrow<OAuth2Exception> {
+                it.par()
+            }
         }
 
         test("pushed authorization request with wrong client attestation JWT") {
@@ -173,6 +372,7 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
 
             // the attestation is signed by a certificate of it.walletProviderCa, which is not on this trust list
             it.server = SimpleAuthorizationService(
+                publicContext = AUTHORIZATION_SERVER,
                 strategy = DummyAuthorizationServiceStrategy(it.scope),
                 clientAuthenticationService = ClientAuthenticationService(
                     enforceClientAuthentication = true,
@@ -270,16 +470,7 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
                 authorizationDetails.shouldBeNull()
             }
 
-            it.server.tokenIntrospection(
-                TokenIntrospectionRequest(token = token.accessToken),
-                RequestInfo(
-                    url = "https://example.com/",
-                    method = HttpMethod.Get,
-                    dpop = null,
-                    clientAttestation = it.clientAttestation,
-                    clientAttestationPop = it.clientAttestationPop
-                )
-            ).getOrThrow()
+            it.introspect(token)
                 .shouldBeInstanceOf<TokenIntrospectionResponse>()
                 .apply { active shouldBe true }
         }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientDPoPTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientDPoPTest.kt
@@ -60,7 +60,7 @@ val OAuth2ClientDPoPTest by matrixSuite {
     } - {
         test("authorization code flow with DPoP") {
             val code = it.getCode(it.state)
-
+            @Suppress("DEPRECATION")
             val token = it.server.token(
                 request = it.client.createTokenRequestParameters(
                     state = it.state,
@@ -97,6 +97,7 @@ val OAuth2ClientDPoPTest by matrixSuite {
             )
 
             // simulate access to protected resource, i.e. verify access token
+            @Suppress("DEPRECATION")
             it.server.userInfo(
                 token.toHttpHeaderValue(),
                 RequestInfo(
@@ -111,6 +112,7 @@ val OAuth2ClientDPoPTest by matrixSuite {
         test("authorization code flow with DPoP and refresh token") {
             val code = it.getCode(it.state)
 
+            @Suppress("DEPRECATION")
             val token = it.server.token(
                 request = it.client.createTokenRequestParameters(
                     state = it.state,
@@ -139,6 +141,7 @@ val OAuth2ClientDPoPTest by matrixSuite {
                 .shouldBeInstanceOf<TokenIntrospectionResponse>()
                 .apply { active shouldBe true }
 
+            @Suppress("DEPRECATION")
             val refreshedAccessToken = it.server.token(
                 request = it.client.createTokenRequestParameters(
                     state = it.state,
@@ -174,6 +177,7 @@ val OAuth2ClientDPoPTest by matrixSuite {
                 randomSource = RandomSource.Default,
             )
 
+            @Suppress("DEPRECATION")
             // simulate access to protected resource, i.e. verify access token
             it.server.userInfo(
                 refreshedAccessToken.toHttpHeaderValue(),
@@ -188,6 +192,7 @@ val OAuth2ClientDPoPTest by matrixSuite {
         test("authorization code flow with DPoP and refresh token, but wrong key in DPoP proof") {
             val code = it.getCode(it.state)
 
+            @Suppress("DEPRECATION")
             val token = it.server.token(
                 request = it.client.createTokenRequestParameters(
                     state = it.state,
@@ -217,6 +222,7 @@ val OAuth2ClientDPoPTest by matrixSuite {
                 .apply { active shouldBe true }
 
             val wrongSignDpop = SignJwt<JsonWebToken>(EphemeralKeyWithoutCert(), JwsHeaderCertOrJwk())
+            @Suppress("DEPRECATION")
             shouldThrow<OAuth2Exception.InvalidDpopProof> {
                 it.server.token(
                     request = it.client.createTokenRequestParameters(
@@ -241,7 +247,7 @@ val OAuth2ClientDPoPTest by matrixSuite {
 
         test("authorization code flow with DPoP and wrong URL") {
             val code = it.getCode(it.state)
-
+            @Suppress("DEPRECATION")
             shouldThrow<OAuth2Exception> {
                 it.server.token(
                     request = it.client.createTokenRequestParameters(
@@ -265,7 +271,7 @@ val OAuth2ClientDPoPTest by matrixSuite {
 
         test("authorization code flow with DPoP and wrong nonce") {
             val code = it.getCode(it.state)
-
+            @Suppress("DEPRECATION")
             shouldThrow<OAuth2Exception> {
                 it.server.token(
                     request = it.client.createTokenRequestParameters(
@@ -304,7 +310,7 @@ val OAuth2ClientDPoPTest by matrixSuite {
 
         test("authorization code flow without DPoP for resource") {
             val code = it.getCode(it.state)
-
+            @Suppress("DEPRECATION")
             val token = it.server.token(
                 request = it.client.createTokenRequestParameters(
                     state = it.state,
@@ -343,7 +349,7 @@ val OAuth2ClientDPoPTest by matrixSuite {
 
         test("authorization code flow with DPoP from other key") {
             val code = it.getCode(it.state)
-
+            @Suppress("DEPRECATION")
             val token = it.server.token(
                 request = it.client.createTokenRequestParameters(
                     state = it.state,
@@ -379,6 +385,7 @@ val OAuth2ClientDPoPTest by matrixSuite {
             )
 
             // simulate access to protected resource, i.e. verify access token
+            @Suppress("DEPRECATION")
             shouldThrow<OAuth2Exception> {
                 it.server.userInfo(
                     token.toHttpHeaderValue(),


### PR DESCRIPTION
First stack PR to update our implementation of [OAuth 2.0 Attestation-Based Cliend Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html): Refactors the base classes, extends the data classes, adds some TODOs (that will be resolved in the upcoming PRs), adds tests for new functionality (fail now, but will be resolved in the upcoming PRs).

Supersedes https://github.com/a-sit-plus/vck/pull/638