### PR TITLE
OAuth: Bind client authentication to internal state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Release 8.0.0 (unreleased):
     - Compare scopes as space-delimited values instead of substrings, when issuing access tokens in `SimpleAuthorizationService` and when authorizing credential requests in `CredentialIssuer`
     - Authorize several credential requests with a single JWT access token
     - Add `TokenService.validateAccessToken()`, which validates the access token and resolves the user info stored at issuance
+    - Bind client authentication to internal state to prevent client mismatches in subsequent requests
 - Deprecations:
     - Remove code deprecated in 7.0.0, e.g. various `Iso180137AnnexC*` and related classes
     - Deprecate all classes used for Presentation Exchange requests and so on, e.g., `CredentialPresentationRequest.PresentationExchangeRequest` or `PresentationExchangeCredentialDisclosure` or `CredentialPresentation.PresentationExchangePresentation`

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AttestationBasedClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AttestationBasedClientAuthenticationService.kt
@@ -11,18 +11,13 @@ import at.asitplus.signum.indispensable.josef.JwsAlgorithm
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.wallet.lib.DefaultNonceService
 import at.asitplus.wallet.lib.NonceService
-import at.asitplus.wallet.lib.etsi.Success
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.jws.VerifyJwsObject
 import at.asitplus.wallet.lib.jws.VerifyJwsObjectFun
 import at.asitplus.wallet.lib.jws.VerifyJwsSignatureWithCnf
 import at.asitplus.wallet.lib.jws.VerifyJwsSignatureWithCnfFun
 import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService.Companion.DEFAULT_WALLET_ATTESTATION_ALGORITHMS
-import at.asitplus.wallet.lib.oidvci.OAuth2Exception
-import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidClient
-import at.asitplus.wallet.lib.oidvci.OAuth2Exception.UseAttestationChallenge
-import at.asitplus.wallet.lib.oidvci.OAuth2Exception.UseFreshAttestation
-import kotlin.coroutines.cancellation.CancellationException
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception.*
 import kotlin.jvm.JvmOverloads
 import kotlin.time.Clock
 import kotlin.time.Duration
@@ -38,8 +33,6 @@ import kotlin.time.Duration.Companion.minutes
  * * [EUDI TS3 Wallet Unit Attestation 1.5.2](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md)
  */
 class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
-    @Deprecated("Always enforces client auth ... if you don't want that, don't use this class")
-    private val enforceClientAuthentication: Boolean = false,
     /**
      * Used to verify client attestation JWTs. Client attestations are required to carry an `x5c`, so pass
      * [at.asitplus.wallet.lib.jws.VerifyJwsObjectTrustedCertificate] with the certificates of the trusted wallet
@@ -49,11 +42,6 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
     private val verifyJwsObject: VerifyJwsObjectFun = VerifyJwsObject(),
     /** Used to verify client attestation JWTs */
     private val verifyJwsSignatureWithCnf: VerifyJwsSignatureWithCnfFun = VerifyJwsSignatureWithCnf(),
-    @Deprecated(
-        "Pass VerifyJwsObjectTrustedCertificate with the trusted wallet provider certificates as " +
-                "verifyJwsObject instead, which evaluates the x5c of the attestation against them."
-    )
-    private val verifyClientAttestationJwt: (suspend (JwsCompactTyped<JsonWebToken>) -> Boolean) = { true },
     /** Clock used to verify WIA and WIA PoP timestamps. */
     private val clock: Clock = Clock.System,
     /** Time leeway for verification of WIA and WIA PoP timestamps. */
@@ -87,7 +75,7 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
     override suspend fun authenticateClient(
         httpRequest: RequestInfo?,
         clientId: String?,
-    ): KmmResult<Success> = catching {
+    ): KmmResult<AuthenticatedClient> = catching {
         val instanceAttestation = httpRequest?.clientAttestation
             ?: throw InvalidClient("client attestation header missing")
 
@@ -100,11 +88,6 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
             throw InvalidClient("client attestation JWT not verified", it)
         }
 
-        @Suppress("DEPRECATION")
-        if (!verifyClientAttestationJwt.invoke(instanceAttestation)) {
-            throw InvalidClient("client attestation not verified")
-        }
-
         val cnf = instanceAttestation.payload.confirmationClaim
             ?: throw InvalidClient("client attestation has no cnf")
         if (!verifyJwsSignatureWithCnf(instanceAttestationPopJwt.jws, cnf)) {
@@ -112,7 +95,12 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
         }
 
         instanceAttestationPopJwt.validateWalletInstanceAttestationPop(instanceAttestation.payload.subject)
-        Success
+        AuthenticatedClient(
+            clientId = instanceAttestation.payload.subject
+                ?: clientId // validation above should have caught that, but the compiler did not
+                ?: throw InvalidClient("No client_id given"),
+            publicKey = cnf.jsonWebKey?.toCryptoPublicKey()?.getOrThrow()
+        )
     }
 
     private fun JwsCompactTyped<JsonWebToken>.validateWalletInstanceAttestation(clientId: String?) {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthRequest.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthRequest.kt
@@ -15,4 +15,8 @@ data class ClientAuthRequest(
     /** Validated [AuthorizationDetails] */
     val authnDetails: Collection<AuthorizationDetails>? = null,
     val codeChallenge: String? = null,
+    /** Client ID to which the auth code was issued */
+    val clientId: String? = null,
+    /** Authenticated with PAR */
+    val authenticatedClient: AuthenticatedClient? = null,
 )

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthRequest.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthRequest.kt
@@ -15,8 +15,6 @@ data class ClientAuthRequest(
     /** Validated [AuthorizationDetails] */
     val authnDetails: Collection<AuthorizationDetails>? = null,
     val codeChallenge: String? = null,
-    /** Client ID to which the auth code was issued */
-    val clientId: String? = null,
-    /** Authenticated with PAR */
-    val authenticatedClient: AuthenticatedClient? = null,
+    /** Client information, which may be authenticated from PAR or self-stated */
+    val clientBinding: ClientBinding? = null,
 )

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
@@ -3,7 +3,9 @@ package at.asitplus.wallet.lib.oauth2
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.openid.OpenIdConstants
-import at.asitplus.wallet.lib.etsi.Success
+import at.asitplus.signum.indispensable.CryptoPublicKey
+import at.asitplus.signum.indispensable.josef.JsonWebKey
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 
 /**
  * Handles authenticating the OAuth 2.0 client for an OAuth 2.0 authorization server,
@@ -23,7 +25,7 @@ interface ClientAuthenticationService {
     suspend fun authenticateClient(
         httpRequest: RequestInfo?,
         clientId: String?,
-    ): KmmResult<Success>
+    ): KmmResult<AuthenticatedClient?>
 }
 
 /** Does not verify the client authentication at all */
@@ -42,7 +44,15 @@ object NoopClientAuthenticationService : ClientAuthenticationService {
     override suspend fun authenticateClient(
         httpRequest: RequestInfo?,
         clientId: String?
-    ): KmmResult<Success> = catching {
-        Success
+    ): KmmResult<AuthenticatedClient?> = catching {
+        null
     }
 }
+
+/** Authenticated OAuth 2.0 client */
+data class AuthenticatedClient(
+    /** `client_id` from the request */
+    val clientId: String,
+    /** The client's public key, if it presented credentials. */
+    val publicKey: CryptoPublicKey?
+)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
@@ -4,8 +4,6 @@ import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.signum.indispensable.CryptoPublicKey
-import at.asitplus.signum.indispensable.josef.JsonWebKey
-import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 
 /**
  * Handles authenticating the OAuth 2.0 client for an OAuth 2.0 authorization server,
@@ -21,11 +19,14 @@ interface ClientAuthenticationService {
     /** Provide a fresh challenge for attestation PoPs. */
     suspend fun getAttestationChallenge(): String?
 
-    /** Authenticates the client by some data in the request. */
+    /**
+     * Authenticates the client by some data in the request.
+     * Return `null` when there is no claimed identity at all.
+     */
     suspend fun authenticateClient(
         httpRequest: RequestInfo?,
         clientId: String?,
-    ): KmmResult<AuthenticatedClient?>
+    ): KmmResult<ClientBinding?>
 }
 
 /** Does not verify the client authentication at all */
@@ -44,15 +45,28 @@ object NoopClientAuthenticationService : ClientAuthenticationService {
     override suspend fun authenticateClient(
         httpRequest: RequestInfo?,
         clientId: String?
-    ): KmmResult<AuthenticatedClient?> = catching {
-        null
+    ): KmmResult<ClientBinding?> = catching {
+        clientId?.let { UnauthenticatedClient(it) }
     }
+}
+
+sealed interface ClientBinding {
+    val clientId: String
 }
 
 /** Authenticated OAuth 2.0 client */
 data class AuthenticatedClient(
     /** `client_id` from the request */
-    val clientId: String,
+    override val clientId: String,
     /** The client's public key, if it presented credentials. */
     val publicKey: CryptoPublicKey?
-)
+) : ClientBinding
+
+/** Self-stated client ID, not verified in any way */
+data class UnauthenticatedClient(
+    override val clientId: String,
+) : ClientBinding
+
+fun ClientBinding.accepts(presented: ClientBinding) =
+    clientId == presented.clientId &&
+            (this is UnauthenticatedClient || this == presented)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -317,15 +317,16 @@ class SimpleAuthorizationService @JvmOverloads constructor(
     ) = catching {
         val actualRequest = request.extractPushedRequestParams()
         Napier.i("par called with $actualRequest")
-        val authenticatedClient = clientAuthenticationService
+        val client = clientAuthenticationService
             .authenticateClient(httpRequest, actualRequest.clientId).getOrThrow()
+            ?: throw InvalidRequest("client could not be authenticated")
         // PAR stores the request for later authorization. issuer_state is single-use and must only be consumed
         // when /authorize is executed with the referenced request_uri.
         actualRequest.validate(validateIssuerState = false)
         val requestUri = "urn:ietf:params:oauth:request_uri:${uuid4()}".also {
             requestUriToPushedAuthorizationRequest.put(
                 it,
-                PushedAuthorizationRequest(actualRequest, authenticatedClient)
+                PushedAuthorizationRequest(actualRequest, client)
             )
         }
         PushedAuthenticationResponseParameters(
@@ -380,15 +381,13 @@ class SimpleAuthorizationService @JvmOverloads constructor(
     internal suspend fun issueCodeForUserInfo(
         userInfo: OidcUserInfoExtended,
         request: AuthenticationRequestParameters,
-        authenticatedClient: AuthenticatedClient?,
+        clientBinding: ClientBinding?,
     ): AuthenticationResponseResult.Redirect {
-        val authorizedClientId = (request.clientId
-            ?: authenticatedClient?.clientId
-            ?: throw InvalidRequest("client_id not set"))
-        authenticatedClient?.let {
-            if (authenticatedClient.clientId != authorizedClientId)
-                throw InvalidRequest("client_id not matching from par: ${request.clientId} vs ${it.clientId}")
-        }
+        // Client authentication in par() already validated its client_id against the authenticated one,
+        // and extractRequestForAuthorize() compares the stored request against the one from /authorize.
+        val boundClient = clientBinding
+            ?: request.clientId?.let(::UnauthenticatedClient)
+            ?: throw InvalidRequest("client_id not set")
         val response = AuthenticationResponseParameters(
             code = codeService.provideCode().also { code ->
                 codeToClientAuthRequest.put(
@@ -399,8 +398,7 @@ class SimpleAuthorizationService @JvmOverloads constructor(
                         scope = request.scope,
                         authnDetails = request.authorizationDetails,
                         codeChallenge = request.codeChallenge,
-                        clientId = authorizedClientId,
-                        authenticatedClient = authenticatedClient,
+                        clientBinding = boundClient,
                     )
                 )
             },
@@ -416,7 +414,7 @@ class SimpleAuthorizationService @JvmOverloads constructor(
 
     internal suspend fun extractRequestForAuthorize(
         input: RequestParameters,
-    ): Pair<AuthenticationRequestParameters, AuthenticatedClient?> = when (input) {
+    ): Pair<AuthenticationRequestParameters, ClientBinding?> = when (input) {
         is AuthenticationRequestParameters -> {
             // can't authenticate client with plain auth request in browser
             input to null
@@ -427,7 +425,7 @@ class SimpleAuthorizationService @JvmOverloads constructor(
                 ?: throw InvalidRequest("request_uri not found: $it")
             if (storedRequest.request.clientId != input.clientId)
                 throw InvalidRequest("client_id not matching from par: ${input.clientId} vs ${storedRequest.request.clientId}")
-            storedRequest.request to storedRequest.client
+            storedRequest.request to storedRequest.clientBinding
         } ?: run {
             val request = requestParser.extractRequest(input, null)?.parameters as? AuthenticationRequestParameters
                 ?: throw InvalidRequest("could not parse request object from request")
@@ -494,10 +492,8 @@ class SimpleAuthorizationService @JvmOverloads constructor(
         httpRequest: RequestInfo?,
     ): KmmResult<TokenResponseParameters> = catching {
         Napier.i("token called with $request")
-        val authenticatedClient = clientAuthenticationService
+        val presentedClient = clientAuthenticationService
             .authenticateClient(httpRequest, request.clientId).getOrThrow()
-        val presentedClientId = authenticatedClient?.clientId
-            ?: request.clientId
             ?: throw InvalidGrant("client_id not set")
 
         if (request.grantType == OpenIdConstants.GRANT_TYPE_TOKEN_EXCHANGE) {
@@ -511,16 +507,11 @@ class SimpleAuthorizationService @JvmOverloads constructor(
         val clientAuthRequest = request.loadClientAuthnRequest(httpRequest, validatedClientKey)
             ?: throw InvalidGrant("could not load user info for $request")
 
-        clientAuthRequest.clientId?.let { expectedClientId ->
-            if (presentedClientId != expectedClientId)
+        clientAuthRequest.clientBinding?.let { expectedClient ->
+            if (!expectedClient.accepts(presentedClient))
                 throw InvalidGrant("code was issued to a different client")
-            if (request.clientId != null && request.clientId != expectedClientId)
+            if (request.clientId != null && request.clientId != expectedClient.clientId)
                 throw InvalidGrant("client_id does not match authorization code")
-        }
-
-        clientAuthRequest.authenticatedClient?.let { previouslyAuthenticatedClient ->
-            if (previouslyAuthenticatedClient != authenticatedClient)
-                throw InvalidGrant("code was issued to a different client instance")
         }
 
         request.code?.let { code ->
@@ -570,11 +561,9 @@ class SimpleAuthorizationService @JvmOverloads constructor(
         token.refreshToken?.let {
             refreshTokenToAuthRequest.put(
                 key = it,
-                value = clientAuthRequest
-                    .copy(
-                        clientId = clientAuthRequest.clientId ?: presentedClientId,
-                        authenticatedClient = clientAuthRequest.authenticatedClient ?: authenticatedClient
-                    )
+                value = clientAuthRequest.copy(
+                    clientBinding = clientAuthRequest.clientBinding ?: presentedClient
+                )
             )
         }
         Napier.i("token returns $token")
@@ -752,5 +741,5 @@ data class ResponseWithDpopNonce<T>(
 
 data class PushedAuthorizationRequest(
     val request: AuthenticationRequestParameters,
-    val client: AuthenticatedClient?
+    val clientBinding: ClientBinding
 )

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -7,7 +7,6 @@ import at.asitplus.iso.sha256
 import at.asitplus.openid.AttestationChallengeResponse
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.AuthenticationResponseParameters
-import at.asitplus.openid.AuthorizationDetails
 import at.asitplus.openid.CredentialOffer
 import at.asitplus.openid.CredentialOfferGrants
 import at.asitplus.openid.CredentialOfferGrantsAuthCode
@@ -124,8 +123,8 @@ class SimpleAuthorizationService @JvmOverloads constructor(
     /** Associates issued refresh tokens with the auth request from the client. *Refresh tokens are usually long-lived!* */
     private val refreshTokenToAuthRequest: MapStore<String, ClientAuthRequest> =
         DefaultMapStore(lifetime = 30.days),
-    /** Associates the issued request_uri to the auth request from the client. */
-    private val requestUriToPushedAuthorizationRequest: MapStore<String, AuthenticationRequestParameters> = DefaultMapStore(),
+    /** Associates the issued `request_uri` sent to the client to the actual request from the client. */
+    private val requestUriToPushedAuthorizationRequest: MapStore<String, PushedAuthorizationRequest> = DefaultMapStore(),
     /** Service to create and validate access tokens. */
     private val tokenService: TokenService = TokenService.bearer(),
     /** Handles client authentication in [par] and [token]. Defaults to [NoopClientAuthenticationService]! */
@@ -318,13 +317,16 @@ class SimpleAuthorizationService @JvmOverloads constructor(
     ) = catching {
         val actualRequest = request.extractPushedRequestParams()
         Napier.i("par called with $actualRequest")
-        // TODO bind PAR request state, authorization codes and refresh tokens to the authenticated key
-        clientAuthenticationService.authenticateClient(httpRequest, actualRequest.clientId).getOrThrow()
+        val authenticatedClient = clientAuthenticationService
+            .authenticateClient(httpRequest, actualRequest.clientId).getOrThrow()
         // PAR stores the request for later authorization. issuer_state is single-use and must only be consumed
         // when /authorize is executed with the referenced request_uri.
         actualRequest.validate(validateIssuerState = false)
         val requestUri = "urn:ietf:params:oauth:request_uri:${uuid4()}".also {
-            requestUriToPushedAuthorizationRequest.put(it, actualRequest)
+            requestUriToPushedAuthorizationRequest.put(
+                it,
+                PushedAuthorizationRequest(actualRequest, authenticatedClient)
+            )
         }
         PushedAuthenticationResponseParameters(
             requestUri = requestUri,
@@ -364,24 +366,29 @@ class SimpleAuthorizationService @JvmOverloads constructor(
         input: RequestParameters,
         loadUserFun: OAuth2LoadUserFun,
     ) = catching {
-        val actualRequest = extractRequestForAuthorize(input).validate()
+        val (actualRequest, authenticatedClient) = extractRequestForAuthorize(input)
+            .let { it.first.validate() to it.second }
         val userInfo = loadUserFun(OAuth2LoadUserFunInput(actualRequest)).getOrElse {
             throw InvalidRequest("Could not load user info for request $input", it)
         }
         with(actualRequest) {
-            issueCodeForUserInfo(userInfo, state, codeChallenge, authorizationDetails, scope, redirectUrl!!)
+            issueCodeForUserInfo(userInfo, actualRequest, authenticatedClient)
                 .also { Napier.i("authorize returns $it") }
         }
     }
 
     internal suspend fun issueCodeForUserInfo(
         userInfo: OidcUserInfoExtended,
-        state: String?,
-        codeChallenge: String?,
-        authorizationDetails: Set<AuthorizationDetails>?,
-        scope: String?,
-        redirectUrl: String,
+        request: AuthenticationRequestParameters,
+        authenticatedClient: AuthenticatedClient?,
     ): AuthenticationResponseResult.Redirect {
+        val authorizedClientId = (request.clientId
+            ?: authenticatedClient?.clientId
+            ?: throw InvalidRequest("client_id not set"))
+        authenticatedClient?.let {
+            if (authenticatedClient.clientId != authorizedClientId)
+                throw InvalidRequest("client_id not matching from par: ${request.clientId} vs ${it.clientId}")
+        }
         val response = AuthenticationResponseParameters(
             code = codeService.provideCode().also { code ->
                 codeToClientAuthRequest.put(
@@ -389,16 +396,18 @@ class SimpleAuthorizationService @JvmOverloads constructor(
                     ClientAuthRequest(
                         issuedCode = code,
                         userInfo = userInfo,
-                        scope = scope,
-                        authnDetails = authorizationDetails,
-                        codeChallenge = codeChallenge
+                        scope = request.scope,
+                        authnDetails = request.authorizationDetails,
+                        codeChallenge = request.codeChallenge,
+                        clientId = authorizedClientId,
+                        authenticatedClient = authenticatedClient,
                     )
                 )
             },
-            state = state,
+            state = request.state,
         )
 
-        val url = URLBuilder(redirectUrl)
+        val url = URLBuilder(request.redirectUrl!!)
             .apply { response.encodeToParameters().forEach { this.parameters.append(it.key, it.value) } }
             .buildString()
 
@@ -407,15 +416,25 @@ class SimpleAuthorizationService @JvmOverloads constructor(
 
     internal suspend fun extractRequestForAuthorize(
         input: RequestParameters,
-    ): AuthenticationRequestParameters = when (input) {
-        is AuthenticationRequestParameters -> input
+    ): Pair<AuthenticationRequestParameters, AuthenticatedClient?> = when (input) {
+        is AuthenticationRequestParameters -> {
+            // can't authenticate client with plain auth request in browser
+            input to null
+        }
+
         is JarRequestParameters -> input.requestUri?.let {
-            requestUriToPushedAuthorizationRequest.remove(it)?.apply {
-                if (clientId != input.clientId)
-                    throw InvalidRequest("client_id not matching from par: ${input.clientId} vs $clientId")
-            }
-        } ?: (requestParser.extractRequest(input, null)?.parameters as? AuthenticationRequestParameters)
-        ?: throw InvalidRequest("could not parse request object from request")
+            val storedRequest = requestUriToPushedAuthorizationRequest.remove(it)
+                ?: throw InvalidRequest("request_uri not found: $it")
+            if (storedRequest.request.clientId != input.clientId)
+                throw InvalidRequest("client_id not matching from par: ${input.clientId} vs ${storedRequest.request.clientId}")
+            storedRequest.request to storedRequest.client
+        } ?: run {
+            val request = requestParser.extractRequest(input, null)?.parameters as? AuthenticationRequestParameters
+                ?: throw InvalidRequest("could not parse request object from request")
+            if (input.clientId != request.clientId)
+                throw InvalidRequest("client_id not matching from par: ${input.clientId} vs ${request.clientId}")
+            request to null
+        }
 
         is RequestObjectParameters -> throw InvalidRequest("could not parse request object from request")
         is SignatureRequestParameters -> throw InvalidRequest("could not parse request object from request")
@@ -475,16 +494,34 @@ class SimpleAuthorizationService @JvmOverloads constructor(
         httpRequest: RequestInfo?,
     ): KmmResult<TokenResponseParameters> = catching {
         Napier.i("token called with $request")
-        clientAuthenticationService.authenticateClient(httpRequest, request.clientId).getOrThrow()
+        val authenticatedClient = clientAuthenticationService
+            .authenticateClient(httpRequest, request.clientId).getOrThrow()
+        val presentedClientId = authenticatedClient?.clientId
+            ?: request.clientId
+            ?: throw InvalidGrant("client_id not set")
+
         if (request.grantType == OpenIdConstants.GRANT_TYPE_TOKEN_EXCHANGE) {
             val userInfoEndpoint = metadata().userInfoEndpoint
                 ?: throw InvalidGrant("token_exchange requires userInfoEndpoint")
             return@catching tokenService.tokenExchange(request, userInfoEndpoint, httpRequest)
         }
+        // TODO For dpop combined mode fold into authenticateClient
         val validatedClientKey = tokenService.verification.extractValidatedClientKey(httpRequest).getOrThrow()
 
         val clientAuthRequest = request.loadClientAuthnRequest(httpRequest, validatedClientKey)
             ?: throw InvalidGrant("could not load user info for $request")
+
+        clientAuthRequest.clientId?.let { expectedClientId ->
+            if (presentedClientId != expectedClientId)
+                throw InvalidGrant("code was issued to a different client")
+            if (request.clientId != null && request.clientId != expectedClientId)
+                throw InvalidGrant("client_id does not match authorization code")
+        }
+
+        clientAuthRequest.authenticatedClient?.let { previouslyAuthenticatedClient ->
+            if (previouslyAuthenticatedClient != authenticatedClient)
+                throw InvalidGrant("code was issued to a different client instance")
+        }
 
         request.code?.let { code ->
             clientAuthRequest.codeChallenge?.let {
@@ -531,7 +568,14 @@ class SimpleAuthorizationService @JvmOverloads constructor(
             throw InvalidRequest("neither authorization details nor scope in request")
         }
         token.refreshToken?.let {
-            refreshTokenToAuthRequest.put(it, clientAuthRequest)
+            refreshTokenToAuthRequest.put(
+                key = it,
+                value = clientAuthRequest
+                    .copy(
+                        clientId = clientAuthRequest.clientId ?: presentedClientId,
+                        authenticatedClient = clientAuthRequest.authenticatedClient ?: authenticatedClient
+                    )
+            )
         }
         Napier.i("token returns $token")
         token
@@ -607,7 +651,7 @@ class SimpleAuthorizationService @JvmOverloads constructor(
                 issuedCode = it,
                 userInfo = userInfo,
                 scope = strategy.validScopes(),
-                authnDetails = strategy.validAuthorizationDetails(publicContext)
+                authnDetails = strategy.validAuthorizationDetails(publicContext),
             )
         )
     }
@@ -664,7 +708,6 @@ class SimpleAuthorizationService @JvmOverloads constructor(
         request: TokenIntrospectionRequest,
         httpRequest: RequestInfo?,
     ): KmmResult<TokenIntrospectionResult> = catching {
-        // TODO Which client_id to pass?
         clientAuthenticationService.authenticateClient(httpRequest, null).getOrThrow()
         val response = catchingUnwrapped {
             tokenService.verification.getTokenInfo(request.token)
@@ -705,4 +748,9 @@ class SimpleAuthorizationService @JvmOverloads constructor(
 data class ResponseWithDpopNonce<T>(
     val response: T,
     val dpopNonce: String?,
+)
+
+data class PushedAuthorizationRequest(
+    val request: AuthenticationRequestParameters,
+    val client: AuthenticatedClient?
 )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAuthenticationTest.kt
@@ -74,6 +74,8 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
                 randomSource = RandomSource.Default
             )
 
+            val otherClientKey = EphemeralKeyWithSelfSignedCert()
+
             object {
                 val scope = scope
                 val client = client
@@ -82,6 +84,8 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
                 val clientAttestation = clientAttestation
                 val clientAttestationPop = clientAttestationPop
                 val signClientAttestationPop = signClientAttestationPop
+                val attesterBackend = attesterBackend
+                val walletProviderCaCert = walletProviderCaCert
 
                 suspend fun signPop(payload: JsonWebToken) = signClientAttestationPop(
                     type = JwsContentTypeConstants.CLIENT_ATTESTATION_POP_JWT,
@@ -105,6 +109,30 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
                     nonce = server.attestationChallenge().getOrThrow().shouldNotBeNull().attestationChallenge,
                     randomSource = RandomSource.Default
                 )
+
+                suspend fun authenticationFor(
+                    client: OAuth2Client,
+                    key: EphemeralKeyWithSelfSignedCert,
+                    authorizationService: SimpleAuthorizationService = server,
+                ) = RequestInfo(
+                    url = "https://example.com/",
+                    method = HttpMethod.Post,
+                    clientAttestation = BuildClientAttestationJwt(
+                        attesterBackend,
+                        clientId = client.clientId,
+                        clientKey = key.jsonWebKey,
+                    ),
+                    clientAttestationPop = BuildClientAttestationPoPJwt(
+                        signJwt = SignJwt(key, JwsHeaderNone()),
+                        audience = AUTHORIZATION_SERVER,
+                        nonce = authorizationService.attestationChallenge().getOrThrow()
+                            .shouldNotBeNull().attestationChallenge,
+                        randomSource = RandomSource.Default,
+                    ),
+                )
+
+                /** A second wallet instance of the same wallet app: same client_id, different instance key. */
+                val otherClientKey = otherClientKey
 
                 @Suppress("DEPRECATION")
                 suspend fun par(
@@ -149,6 +177,59 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
         }
     } - {
 
+        test("reject token request from another wallet instance than the one that pushed the request") {
+            // Both instances use the same client_id, so the client_id cross-check in authorize() passes:
+            // only the key binding established at the PAR endpoint can catch this
+            val state = uuid4().toString()
+            @Suppress("DEPRECATION")
+            val parResponse = it.server.par(
+                it.client.createAuthRequestJar(state = state, scope = it.scope),
+                it.authenticationFor(it.client, it.clientKey)
+            ).getOrThrow().shouldBeInstanceOf<PushedAuthenticationResponseParameters>()
+            val code = it.server
+                .authorize(it.client.createAuthRequestAfterPar(parResponse) as RequestParameters) { catching { user } }
+                .getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+                .params?.code.shouldNotBeNull()
+
+            @Suppress("DEPRECATION")
+            shouldThrow<OAuth2Exception.InvalidGrant> {
+                it.server.token(
+                    request = it.client.createTokenRequestParameters(
+                        state = state,
+                        authorization = OAuth2Client.AuthorizationForToken.Code(code),
+                        scope = it.scope
+                    ),
+                    httpRequest = it.authenticationFor(it.client, it.otherClientKey)
+                ).getOrThrow()
+            }
+        }
+
+        test("accept token request from the second wallet instance when it pushed the request itself") {
+            // Guards against the test above passing merely because the second instance cannot authenticate
+            val state = uuid4().toString()
+            @Suppress("DEPRECATION")
+            val parResponse = it.server.par(
+                it.client.createAuthRequestJar(state = state, scope = it.scope),
+                it.authenticationFor(it.client, it.otherClientKey)
+            ).getOrThrow().shouldBeInstanceOf<PushedAuthenticationResponseParameters>()
+            val code = it.server
+                .authorize(it.client.createAuthRequestAfterPar(parResponse) as RequestParameters) { catching { user } }
+                .getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+                .params?.code.shouldNotBeNull()
+
+            @Suppress("DEPRECATION")
+            it.server.token(
+                request = it.client.createTokenRequestParameters(
+                    state = state,
+                    authorization = OAuth2Client.AuthorizationForToken.Code(code),
+                    scope = it.scope
+                ),
+                httpRequest = it.authenticationFor(it.client, it.otherClientKey)
+            ).getOrThrow().accessToken.shouldNotBeNull()
+        }
+
         test("pushed authorization request") {
             it.clientAttestation.payload.issuer.shouldBeNull()
             it.clientAttestation.payload.walletVersion.shouldNotBeNull()
@@ -185,6 +266,64 @@ val OAuth2ClientAuthenticationTest by matrixSuite {
             it.introspect(token)
                 .shouldBeInstanceOf<TokenIntrospectionResponse>()
                 .apply { active shouldBe true }
+        }
+
+        test("direct authorization code is bound to the client id") {
+            val state = uuid4().toString()
+            val authRequest = it.client.createAuthRequestJar(state = state, scope = it.scope)
+            val code = it.server
+                .authorize(authRequest) { catching { user } }
+                .getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+                .params?.code.shouldNotBeNull()
+            val legitimateRequest = it.client.createTokenRequestParameters(
+                state = state,
+                authorization = OAuth2Client.AuthorizationForToken.Code(code),
+                scope = it.scope,
+            )
+            val attacker = OAuth2Client(clientId = "https://attacker.example/app")
+            val attackerKey = EphemeralKeyWithSelfSignedCert()
+
+            shouldThrow<OAuth2Exception> {
+                it.server.token(
+                    legitimateRequest.copy(clientId = attacker.clientId),
+                    it.authenticationFor(attacker, attackerKey),
+                ).getOrThrow()
+            }
+        }
+
+        test("refresh token is bound when a client first authenticates at the token endpoint") {
+            val server = SimpleAuthorizationService(
+                publicContext = AUTHORIZATION_SERVER,
+                strategy = DummyAuthorizationServiceStrategy(it.scope),
+                tokenService = TokenService.bearer(issueRefreshTokens = true),
+                clientAuthenticationService = AttestationBasedClientAuthenticationService(
+                    issuerIdentifier = AUTHORIZATION_SERVER,
+                    verifyJwsObject = VerifyJwsObjectTrustedCertificate(
+                        trustedIssuers = { setOf(it.walletProviderCaCert) },
+                    ),
+                ),
+            )
+            val preAuthorizedCode = server.providePreAuthorizedCode(user)
+            val refreshToken = server.token(
+                it.client.createTokenRequestParameters(
+                    authorization = OAuth2Client.AuthorizationForToken.PreAuthCode(preAuthorizedCode),
+                    scope = it.scope,
+                ),
+                it.authenticationFor(it.client, it.clientKey, server),
+            ).getOrThrow().refreshToken.shouldNotBeNull()
+            val attacker = OAuth2Client()
+            val attackerKey = EphemeralKeyWithSelfSignedCert()
+
+            shouldThrow<OAuth2Exception> {
+                server.token(
+                    attacker.createTokenRequestParameters(
+                        authorization = OAuth2Client.AuthorizationForToken.RefreshToken(refreshToken),
+                        scope = it.scope,
+                    ),
+                    it.authenticationFor(attacker, attackerKey, server),
+                ).getOrThrow()
+            }
         }
 
         test("client attestation PoP does not contain iss") {


### PR DESCRIPTION
Bind client authentication to the internal state, so that we can't confuse authenticated clients across requests.