### PR TITLE
OAuth: Implement DPoP combined mode for client authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Release 8.0.0 (unreleased):
     - `RequestParser` no longer verifies anything and lost its `requestObjectJwsVerifier` parameter, so parsing a request is purely parsing. Consequently `RequestParametersSigned.verified` is removed, with the `verified` property of `Jws`, `OpenId4VpDcApiSigned` and `OpenId4VpDcApiMultiSigned` and its serialized form. Stored JSON still carrying `"verified"` deserializes fine, as unknown keys are ignored
 - OAuth 2.0:
     - Update implementation of [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html) to Draft 10 from 2026-07-06
+    - Support DPoP combined mode, advertised with `dpop_combined` to combine client authentication with DPoP proofs from RFC 9449
     - Add method `attestationChallenge()` to `SimpleAuthorizationService` to deliver challenges for Attestation-Based Client Authentication
     - Support `use_client_attestation` errors and parse challenges from `OAuth-Client-Attestation-Challenge` in `OAuth2KtorClient`
     - Strengthen validation of DPoP proofs from [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,8 @@ Release 8.0.0 (unreleased):
     - `RequestParser` no longer verifies anything and lost its `requestObjectJwsVerifier` parameter, so parsing a request is purely parsing. Consequently `RequestParametersSigned.verified` is removed, with the `verified` property of `Jws`, `OpenId4VpDcApiSigned` and `OpenId4VpDcApiMultiSigned` and its serialized form. Stored JSON still carrying `"verified"` deserializes fine, as unknown keys are ignored
 - OAuth 2.0:
     - Update implementation of [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html) to Draft 10 from 2026-07-06
-    - Support DPoP combined mode, advertised with `dpop_combined` to combine client authentication with DPoP proofs from RFC 9449
+    - Support DPoP combined mode, advertised with `dpop_combined` in `client_attestation_pop_methods_supported` to combine client authentication with DPoP proofs from RFC 9449
+    - Support DPoP combined mode on the client side in `OAuth2KtorClient`
     - Add method `attestationChallenge()` to `SimpleAuthorizationService` to deliver challenges for Attestation-Based Client Authentication
     - Support `use_client_attestation` errors and parse challenges from `OAuth-Client-Attestation-Challenge` in `OAuth2KtorClient`
     - Strengthen validation of DPoP proofs from [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
@@ -102,6 +102,9 @@ object OpenIdConstants {
     /** `attest_jwt_client_auth` */
     const val AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH = "attest_jwt_client_auth"
 
+    /** `attest_jwt_client_auth_dpop` */
+    const val AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH_DPOP = "attest_jwt_client_auth_dpop"
+
     /** `prompt` */
     const val PARAMETER_PROMPT = "prompt"
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OpenIdConstants.kt
@@ -407,30 +407,32 @@ object OpenIdConstants {
      */
     @Serializable(with = ClientAttestationPopMethod.Serializer::class)
     sealed class ClientAttestationPopMethod(
-        val stringRepresentation: String
+        val stringRepresentation: String,
+        val clientAuthMethod: String?,
     ) {
         /**
          * The Proof of Possession is a dedicated Client Attestation PoP JWT as defined in
          * Section 5.1 ("normal mode").
          */
-        object AttestationPopJwt : ClientAttestationPopMethod(STRING_ATTESTATION_POP_JWT)
+        object AttestationPopJwt :
+            ClientAttestationPopMethod(STRING_ATTESTATION_POP_JWT, AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH)
 
         /**
          * The Proof of Possession is a DPoP proof serving as the combined Proof of Possession as defined in
          * Section 5.2 ("DPoP combined mode").
          */
-        object DpopCombined : ClientAttestationPopMethod(STRING_DPOP_COMBINED)
+        object DpopCombined : ClientAttestationPopMethod(STRING_DPOP_COMBINED, AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH_DPOP)
 
         /**
          * No Client Attestation is required. A server includes this value to signal that the Client MAY omit the
          * Client Attestation.
          */
-        object None : ClientAttestationPopMethod(STRING_NONE)
+        object None : ClientAttestationPopMethod(STRING_NONE, null)
 
         /**
          * Any not natively supported PoP method, so it can still be parsed
          */
-        class Other(stringRepresentation: String) : ClientAttestationPopMethod(stringRepresentation)
+        class Other(stringRepresentation: String) : ClientAttestationPopMethod(stringRepresentation, null)
 
         companion object {
             private const val STRING_ATTESTATION_POP_JWT = "attestation_pop_jwt"
@@ -444,6 +446,13 @@ object OpenIdConstants {
                     None
                 )
             }
+
+            /**
+             * Matches by client auth method from e.g.
+             * [OAuth2AuthorizationServerMetadata.tokenEndPointAuthMethodsSupported]
+             */
+            fun matchByClientAuthMethod(clientAuthMethod: String) =
+                entries.firstOrNull { it.clientAuthMethod == clientAuthMethod }
         }
 
         object Serializer : KSerializer<ClientAttestationPopMethod> {

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
@@ -12,6 +12,9 @@ import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.OpenIdAuthorizationDetails
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH
+import at.asitplus.openid.OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH_DPOP
+import at.asitplus.openid.OpenIdConstants.ClientAttestationPopMethod.AttestationPopJwt
+import at.asitplus.openid.OpenIdConstants.ClientAttestationPopMethod.DpopCombined
 import at.asitplus.openid.OpenIdConstants.TOKEN_TYPE_DPOP
 import at.asitplus.openid.PushedAuthenticationResponseParameters
 import at.asitplus.openid.RequestParameters
@@ -153,7 +156,6 @@ class OAuth2KtorClient(
      * Stores the latest DPoP nonce per origin. RFC 9449 requires using only the most recent nonce
      * issued by the server that provided it.
      */
-    // TODO Evaluate DPoP combined mode
     private val dpopNonceByOriginRef = AtomicReference(mapOf<String, String>())
 
     private fun String.origin(): String = Url(this).let { parsed ->
@@ -568,7 +570,7 @@ class OAuth2KtorClient(
      * Sets the appropriate headers when accessing a token endpoint (or equivalent, like PAR):
      * - loads client attestation when [loadInstanceAttestation] is set
      * - sends a client attestation PoP for that
-     * - sends a DPoP proof when authorization server advertises support for it
+     * - sends a DPoP proof when the authorization server advertises support for it
      */
     internal suspend fun applyAuthnForToken(
         resourceUrl: String,
@@ -577,50 +579,70 @@ class OAuth2KtorClient(
         oauthMetadata: OAuth2AuthorizationServerMetadata,
         issuerMetadata: IssuerMetadata? = null,
     ): HttpRequestBuilder.() -> Unit {
-        val (clientAttJwt, clientAttPop) = if (loadInstanceAttestation != null && oauthMetadata.supportsClientAuth()) {
-            val wia = loadInstanceAttestation(
+        val supportsClientAuth = oauthMetadata.supportsClientAuth()
+        val clientAuthMethods = oauthMetadata.tokenEndPointAuthMethodsSupported.orEmpty()
+            .mapNotNull { OpenIdConstants.ClientAttestationPopMethod.matchByClientAuthMethod(it) }
+        val normalMode = clientAuthMethods.contains(AttestationPopJwt)
+        val combinedMode = !normalMode && clientAuthMethods.contains(DpopCombined)
+
+        val clientAttJwt = if (loadInstanceAttestation != null && supportsClientAuth) {
+            if (combinedMode) {
+                require(oauthMetadata.supportsDPoP()) {
+                    "Authorization server does not support DPoP, but client attestation PoP is combined"
+                }
+                require(keyMaterial.publicKey == dpopKeyMaterial.publicKey) {
+                    "Key material for DPoP and client attestation PoP are not the same"
+                }
+            }
+            loadInstanceAttestation(
                 LoadInstanceAttestationInput(
                     authorizationServer = authorizationServer,
                     credentialIssuer = issuerMetadata?.credentialIssuer ?: authorizationServer,
                     preferredClientStatusPeriod = issuerMetadata?.preferredClientStatusPeriod,
                 )
-            ).getOrThrow()
-
-            val cnfKey = wia.payload.confirmationClaim?.jsonWebKey
-            require(cnfKey != null) { "Instance attestation has no cnf.jwk — PoP key cannot be verified" }
-            require(cnfKey.jwkThumbprint == keyMaterial.jsonWebKey.jwkThumbprint) {
-                "keyMaterial does not match the cnf key in the instance attestation. " +
-                        "The PoP JWT will not verify on the server. " +
-                        "Expected cnf thumbprint: ${cnfKey.jwkThumbprint}, " +
-                        "got keyMaterial thumbprint: ${keyMaterial.jsonWebKey.jwkThumbprint}"
+            ).getOrThrow().apply {
+                payload.confirmationClaim?.jsonWebKey.let { cnfKey ->
+                    val cryptoPublicKey = cnfKey?.toCryptoPublicKey()?.getOrNull()
+                    require(cryptoPublicKey != null) {
+                        "Instance attestation has no cnf.jwk — PoP key cannot be verified"
+                    }
+                    require(cryptoPublicKey == keyMaterial.publicKey) {
+                        "keyMaterial does not match the cnf key in the instance attestation"
+                    }
+                }
             }
+        } else null
 
-            val pop = catching {
-                BuildClientAttestationPoPJwt(
-                    signJwt = SignJwt(keyMaterial, JwsHeaderNone()),
-                    audience = authorizationServer,
-                    // nonce support must not be implemented by the AS, so we keep it optional
-                    nonce = takeAttestationChallenge(resourceUrl)
-                        ?: fetchAttestationChallenge(oauthMetadata),
-                )
-            }.getOrThrow()
-            wia.jws to pop.jws
-        } else null to null
+        val clientAttPop = if (clientAttJwt != null && normalMode) {
+            BuildClientAttestationPoPJwt(
+                signJwt = SignJwt(keyMaterial, JwsHeaderNone()),
+                audience = authorizationServer,
+                // nonce support must not be implemented by the AS, so we keep it optional
+                nonce = takeAttestationChallenge(resourceUrl)
+                    ?: fetchAttestationChallenge(oauthMetadata),
+            )
+        } else null
 
         val dpopHeader = if (oauthMetadata.supportsDPoP()) {
             BuildDPoPHeader(
                 signDpop = SignJwt(dpopKeyMaterial, JwsHeaderJwk()),
                 url = resourceUrl,
                 httpMethod = httpMethod.value,
-                nonce = currentDpopNonce(resourceUrl),
+                nonce = if (combinedMode) {
+                    takeAttestationChallenge(resourceUrl)
+                        ?: currentDpopNonce(resourceUrl)
+                        ?: fetchAttestationChallenge(oauthMetadata)
+                } else {
+                    currentDpopNonce(resourceUrl)
+                },
                 randomSource = randomSource,
             )
         } else null
 
         return {
             headers {
-                clientAttJwt?.let { append(HttpHeaders.OAuthClientAttestation, it.toString()) }
-                clientAttPop?.let { append(HttpHeaders.OAuthClientAttestationPop, it.toString()) }
+                clientAttJwt?.let { append(HttpHeaders.OAuthClientAttestation, it.jws.toString()) }
+                clientAttPop?.let { append(HttpHeaders.OAuthClientAttestationPop, it.jws.toString()) }
                 dpopHeader?.let { append(HttpHeaders.DPoP, it.toString()) }
             }
         }
@@ -637,9 +659,8 @@ class OAuth2KtorClient(
     }
 
     private fun OAuth2AuthorizationServerMetadata.supportsClientAuth(): Boolean =
-        tokenEndPointAuthMethodsSupported?.contains(
-            AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH
-        ) == true
+        tokenEndPointAuthMethodsSupported.orEmpty()
+            .any { it == AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH || it == AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH_DPOP }
 
     private fun OAuth2AuthorizationServerMetadata.supportsDPoP(): Boolean =
         dpopSigningAlgValuesSupported?.contains(

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClientTest.kt
@@ -2,6 +2,8 @@ package at.asitplus.wallet.lib.ktor.openid
 
 import at.asitplus.catching
 import at.asitplus.openid.AttestationChallengeResponse
+import at.asitplus.openid.OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH
+import at.asitplus.openid.OpenIdConstants.ClientAttestationPopMethod
 import at.asitplus.openid.PushedAuthenticationResponseParameters
 import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenIntrospectionRequest
@@ -9,6 +11,7 @@ import at.asitplus.openid.TokenRequestParameters
 import at.asitplus.signum.indispensable.josef.JwsAlgorithm
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.wallet.lib.DefaultNonceService
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.IssuerAgent
@@ -23,9 +26,14 @@ import at.asitplus.wallet.lib.ktor.openid.TestUtils.respond
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respondIncludingDpopNonce
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respondOAuth2Error
 import at.asitplus.wallet.lib.oauth2.AttestationBasedClientAuthenticationService
+import at.asitplus.wallet.lib.oauth2.DPoP
 import at.asitplus.wallet.lib.oauth2.DPoPNonce
+import at.asitplus.wallet.lib.oauth2.NoopClientAuthenticationService
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
+import at.asitplus.wallet.lib.oauth2.OAuthClientAttestation
 import at.asitplus.wallet.lib.oauth2.OAuthClientAttestationChallenge
+import at.asitplus.wallet.lib.oauth2.OAuthClientAttestationPop
+import at.asitplus.wallet.lib.oauth2.RequestInfo
 import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService
 import at.asitplus.wallet.lib.oauth2.TokenService
 import at.asitplus.wallet.lib.oidvci.BuildClientAttestationJwt
@@ -36,8 +44,11 @@ import at.asitplus.wallet.lib.oidvci.decodeFromPostBody
 import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
 import io.github.aakira.napier.Napier
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.ktor.client.*
 import io.ktor.client.engine.mock.*
@@ -65,6 +76,10 @@ val OAuth2KtorClientTest by matrixSuite {
         serveChallengeEndpoint: Boolean = true,
         requireChallengeRetry: Boolean = false,
         provideChallengeOnParSuccess: Boolean = false,
+        popMethods: Set<ClientAttestationPopMethod>? = setOf(ClientAttestationPopMethod.AttestationPopJwt),
+        dpopAlgorithms: Set<JwsAlgorithm.Signature> = setOf(JwsAlgorithm.Signature.ES256),
+        /** DPoP combined mode has a single key: the attested key is also the DPoP key. */
+        useSingleKey: Boolean = false,
     ): Context {
         val clientAuthKeyMaterial = EphemeralKeyWithoutCert()
         val authorizationEndpointPath = "/authorize"
@@ -73,15 +88,25 @@ val OAuth2KtorClientTest by matrixSuite {
         val parEndpointPath = "/par"
         val challengeEndpointPath = "/challenge"
         val publicContext = "https://issuer.example.com"
+        // In DPoP combined mode the attestation challenge is carried in the DPoP proof's nonce, so both stores
+        // must be the same instance for a challenge to be accepted as a DPoP nonce
+        val proofNonceService = DefaultNonceService()
         val authorizationService = SimpleAuthorizationService(
             strategy = strategy,
             publicContext = publicContext,
             authorizationEndpointPath = authorizationEndpointPath,
             tokenEndpointPath = tokenEndpointPath,
             pushedAuthorizationRequestEndpointPath = parEndpointPath,
-            clientAuthenticationService = AttestationBasedClientAuthenticationService(),
+            clientAuthenticationService = popMethods?.let {
+                AttestationBasedClientAuthenticationService(
+                    acceptedPopMethods = it,
+                    nonceService = proofNonceService,
+                )
+            } ?: NoopClientAuthenticationService,
             tokenService = TokenService.jwt(
-                issueRefreshTokens = true
+                issueRefreshTokens = true,
+                dpopNonceService = proofNonceService,
+                verificationAlgorithms = dpopAlgorithms,
             ),
             requestObjectSigningAlgorithms = requestObjectSigningAlgorithms,
             requirePushedAuthorizationRequests = requirePAR,
@@ -209,6 +234,7 @@ val OAuth2KtorClientTest by matrixSuite {
                     }
                 },
                 keyMaterial = clientAuthKeyMaterial,
+                dpopKeyMaterial = if (useSingleKey) clientAuthKeyMaterial else EphemeralKeyWithoutCert(),
                 oAuth2Client = OAuth2Client(clientId = clientId),
                 randomSource = RandomSource.Default,
             ),
@@ -316,6 +342,60 @@ val OAuth2KtorClientTest by matrixSuite {
         }
     }
 
+    /**
+     * draft-10 8 puts the client authentication method in `token_endpoint_auth_methods_supported`, while
+     * `client_attestation_pop_methods_supported` (7.6) is about presenting an attestation as an *additional*
+     * security signal and MAY be omitted, so the mode must be selected from the former.
+     */
+    test("sends a dedicated PoP when the AS advertises the auth method but no PoP methods") {
+        with(setup(strategy, setOf(JwsAlgorithm.Signature.ES256), requirePAR = false)) {
+            val metadata = authorizationService.metadata().copy(
+                tokenEndPointAuthMethodsSupported = setOf(AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH),
+                clientAttestationPopMethodsSupported = null,
+            )
+
+            val headers = HttpRequestBuilder().apply {
+                client.applyAuthnForToken(
+                    resourceUrl = "https://issuer.example.com/token",
+                    httpMethod = HttpMethod.Post,
+                    authorizationServer = authorizationService.publicContext,
+                    oauthMetadata = metadata,
+                )()
+            }.headers.build()
+
+            headers[HttpHeaders.OAuthClientAttestation].shouldNotBeNull()
+            headers[HttpHeaders.OAuthClientAttestationPop].shouldNotBeNull()
+        }
+    }
+
+    test("combined mode metadata does not break a client that sends no attestation") {
+        with(
+            setup(
+                strategy, setOf(JwsAlgorithm.Signature.ES256), requirePAR = false,
+                popMethods = setOf(ClientAttestationPopMethod.DpopCombined),
+            )
+        ) {
+            // No loadInstanceAttestation, and the two keys are independent because none of them is attested
+            val plainDpopClient = OAuth2KtorClient(
+                engine = mockEngine,
+                oAuth2Client = OAuth2Client(clientId = "https://example.com/rp-no-attestation"),
+                randomSource = RandomSource.Default,
+            )
+
+            val headers = HttpRequestBuilder().apply {
+                plainDpopClient.applyAuthnForToken(
+                    resourceUrl = "https://issuer.example.com/token",
+                    httpMethod = HttpMethod.Post,
+                    authorizationServer = authorizationService.publicContext,
+                    oauthMetadata = authorizationService.metadata(),
+                )()
+            }.headers.build()
+
+            headers[HttpHeaders.OAuthClientAttestation].shouldBeNull()
+            headers[HttpHeaders.DPoP].shouldNotBeNull()
+        }
+    }
+
     test("instance attestation callbacks receive authorization server context") {
         var attestationInput: OAuth2KtorClient.LoadInstanceAttestationInput? = null
 
@@ -417,6 +497,235 @@ val OAuth2KtorClientTest by matrixSuite {
             ).getOrThrow()
 
             receivedPopChallenges shouldBe listOf(null, issuedAttestationChallenges.single())
+        }
+    }
+
+    /**
+     * DPoP combined mode, i.e. one DPoP proof also serving as the Client Attestation PoP, from sections 5.2 and 7.3
+     * of [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html)
+     */
+    val combinedMode = setOf(ClientAttestationPopMethod.DpopCombined)
+
+    test("combined mode sends attestation and DPoP proof, but no dedicated PoP") {
+        with(
+            setup(
+                strategy = strategy,
+                requestObjectSigningAlgorithms = setOf(JwsAlgorithm.Signature.ES256),
+                requirePAR = true,
+                popMethods = combinedMode,
+                useSingleKey = true,
+            )
+        ) {
+            val metadata = authorizationService.metadata()
+            val resourceUrl = metadata.pushedAuthorizationRequestEndpoint.shouldNotBeNull()
+            val builder = HttpRequestBuilder().apply(
+                client.applyAuthnForToken(
+                    resourceUrl = resourceUrl,
+                    httpMethod = HttpMethod.Post,
+                    authorizationServer = authorizationService.publicContext,
+                    oauthMetadata = metadata,
+                )
+            )
+            val request = RequestInfo(resourceUrl, HttpMethod.Post, builder.headers.build())
+
+            request.clientAttestation.shouldNotBeNull()
+            request.dpop.shouldNotBeNull()
+            // 5.2: the DPoP proof replaces the dedicated PoP, it does not accompany it
+            request.clientAttestationPop.shouldBeNull()
+        }
+    }
+
+    test("combined mode signs the DPoP proof with the attested key") {
+        with(
+            setup(
+                strategy = strategy,
+                requestObjectSigningAlgorithms = setOf(JwsAlgorithm.Signature.ES256),
+                requirePAR = true,
+                popMethods = combinedMode,
+                useSingleKey = true,
+            )
+        ) {
+            val metadata = authorizationService.metadata()
+            val resourceUrl = metadata.pushedAuthorizationRequestEndpoint.shouldNotBeNull()
+            val builder = HttpRequestBuilder().apply(
+                client.applyAuthnForToken(
+                    resourceUrl = resourceUrl,
+                    httpMethod = HttpMethod.Post,
+                    authorizationServer = authorizationService.publicContext,
+                    oauthMetadata = metadata,
+                )
+            )
+            val request = RequestInfo(resourceUrl, HttpMethod.Post, builder.headers.build())
+            val attestedKey = request.clientAttestation.shouldNotBeNull()
+                .payload.confirmationClaim.shouldNotBeNull()
+                .jsonWebKey.shouldNotBeNull()
+            val dpopKey = request.dpop.shouldNotBeNull().jws.jwsHeader.jsonWebKey.shouldNotBeNull()
+
+            // Without this the DPoP proof says nothing about possession of the attested key
+            dpopKey.jwkThumbprint shouldBe attestedKey.jwkThumbprint
+        }
+    }
+
+    test("combined mode carries the attestation challenge as the DPoP nonce") {
+        with(
+            setup(
+                strategy = strategy,
+                requestObjectSigningAlgorithms = setOf(JwsAlgorithm.Signature.ES256),
+                requirePAR = true,
+                popMethods = combinedMode,
+                useSingleKey = true,
+            )
+        ) {
+            val metadata = authorizationService.metadata()
+            val resourceUrl = metadata.pushedAuthorizationRequestEndpoint.shouldNotBeNull()
+            val builder = HttpRequestBuilder().apply(
+                client.applyAuthnForToken(
+                    resourceUrl = resourceUrl,
+                    httpMethod = HttpMethod.Post,
+                    authorizationServer = authorizationService.publicContext,
+                    oauthMetadata = metadata,
+                )
+            )
+            val request = RequestInfo(resourceUrl, HttpMethod.Post, builder.headers.build())
+
+            request.dpop.shouldNotBeNull().payload.nonce shouldBe issuedAttestationChallenges.single()
+        }
+    }
+
+    test("combined mode completes the authorization code flow") {
+        with(
+            setup(
+                strategy = strategy,
+                requestObjectSigningAlgorithms = setOf(JwsAlgorithm.Signature.ES256),
+                requirePAR = true,
+                popMethods = combinedMode,
+                useSingleKey = true,
+            )
+        ) {
+            val authorization = client.startAuthorization(
+                oauthMetadata = authorizationService.metadata(),
+                authorizationServer = authorizationService.publicContext,
+                scope = requestedScope,
+            ).getOrThrow()
+            val httpClient = HttpClient(mockEngine) { followRedirects = false }
+            val redirect = httpClient.get(authorization.url).headers[HttpHeaders.Location].shouldNotBeNull()
+
+            client.requestTokenWithAuthCode(
+                oauthMetadata = authorizationService.metadata(),
+                url = redirect,
+                authorizationServer = authorizationService.publicContext,
+                state = authorization.state,
+                scope = requestedScope,
+                authorizationDetails = setOf(),
+            ).getOrThrow().params.accessToken.shouldNotBeNull()
+        }
+    }
+
+    test("combined mode fails before sending when the attested key is not the DPoP key") {
+        with(
+            setup(
+                strategy = strategy,
+                requestObjectSigningAlgorithms = setOf(JwsAlgorithm.Signature.ES256),
+                requirePAR = true,
+                popMethods = combinedMode,
+                useSingleKey = false, // independent DPoP key cannot prove possession of the attested key
+            )
+        ) {
+            shouldThrow<IllegalArgumentException> {
+                client.startAuthorization(
+                    oauthMetadata = authorizationService.metadata(),
+                    authorizationServer = authorizationService.publicContext,
+                    scope = requestedScope,
+                ).getOrThrow()
+            }
+
+            // A request that cannot possibly authenticate must not be sent at all
+            mockEngine.requestHistory.filter { it.url.fullPath.startsWith("/par") }.shouldBeEmpty()
+        }
+    }
+
+    test("combined mode fails before sending when the AS advertises no usable DPoP algorithm") {
+        with(
+            setup(
+                strategy = strategy,
+                requestObjectSigningAlgorithms = setOf(JwsAlgorithm.Signature.ES256),
+                requirePAR = true,
+                popMethods = combinedMode,
+                dpopAlgorithms = setOf(JwsAlgorithm.Signature.ES512), // client keys are ES256
+                useSingleKey = true,
+            )
+        ) {
+            shouldThrow<IllegalArgumentException> {
+                client.startAuthorization(
+                    oauthMetadata = authorizationService.metadata(),
+                    authorizationServer = authorizationService.publicContext,
+                    scope = requestedScope,
+                ).getOrThrow()
+            }
+
+            // Combined mode without a DPoP proof is not a mode, so degrading silently must not happen
+            mockEngine.requestHistory.filter { it.url.fullPath.startsWith("/par") }.shouldBeEmpty()
+        }
+    }
+
+    test("normal mode is preferred when the AS advertises both auth methods") {
+        with(
+            setup(
+                strategy = strategy,
+                requestObjectSigningAlgorithms = setOf(JwsAlgorithm.Signature.ES256),
+                requirePAR = true,
+                popMethods = setOf(
+                    ClientAttestationPopMethod.AttestationPopJwt,
+                    ClientAttestationPopMethod.DpopCombined,
+                ),
+                useSingleKey = false,
+            )
+        ) {
+            val metadata = authorizationService.metadata()
+            val resourceUrl = metadata.pushedAuthorizationRequestEndpoint.shouldNotBeNull()
+            val builder = HttpRequestBuilder().apply(
+                client.applyAuthnForToken(
+                    resourceUrl = resourceUrl,
+                    httpMethod = HttpMethod.Post,
+                    authorizationServer = authorizationService.publicContext,
+                    oauthMetadata = metadata,
+                )
+            )
+            val request = RequestInfo(resourceUrl, HttpMethod.Post, builder.headers.build())
+            val attestedKey = request.clientAttestation.shouldNotBeNull()
+                .payload.confirmationClaim.shouldNotBeNull()
+                .jsonWebKey.shouldNotBeNull()
+            val dpop = request.dpop.shouldNotBeNull()
+
+            request.clientAttestationPop.shouldNotBeNull()
+            dpop.payload.nonce.shouldBeNull()
+            dpop.jws.jwsHeader.jsonWebKey.shouldNotBeNull().jwkThumbprint shouldNotBe attestedKey.jwkThumbprint
+        }
+    }
+
+    test("no attestation headers when the AS advertises no attestation auth method") {
+        with(
+            setup(
+                strategy = strategy,
+                requestObjectSigningAlgorithms = setOf(JwsAlgorithm.Signature.ES256),
+                requirePAR = false,
+                popMethods = null,
+            )
+        ) {
+            val metadata = authorizationService.metadata()
+            val resourceUrl = metadata.tokenEndpoint.shouldNotBeNull()
+            val builder = HttpRequestBuilder().apply(
+                client.applyAuthnForToken(
+                    resourceUrl = resourceUrl,
+                    httpMethod = HttpMethod.Post,
+                    authorizationServer = authorizationService.publicContext,
+                    oauthMetadata = metadata,
+                )
+            )
+            val request = RequestInfo(resourceUrl, HttpMethod.Post, builder.headers.build())
+
+            request.clientAttestation.shouldBeNull()
+            request.clientAttestationPop.shouldBeNull()
         }
     }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AttestationBasedClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AttestationBasedClientAuthenticationService.kt
@@ -74,13 +74,7 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
     }
 
     override val supportedAuthMethods: Set<String>
-        get() = acceptedPopMethods.mapNotNull {
-            when (it) {
-                AttestationPopJwt -> OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH
-                DpopCombined -> OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH_DPOP
-                else -> null
-            }
-        }.toSet()
+        get() = acceptedPopMethods.mapNotNull { it.clientAuthMethod }.toSet()
 
     override val supportedPopSigningAlgs: Set<String>
         get() = supportedSigningAlgorithms.map { it.identifier }.toSet()

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AttestationBasedClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AttestationBasedClientAuthenticationService.kt
@@ -4,7 +4,9 @@ import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.OpenIdConstants
-import at.asitplus.openid.OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH
+import at.asitplus.openid.OpenIdConstants.ClientAttestationPopMethod
+import at.asitplus.openid.OpenIdConstants.ClientAttestationPopMethod.AttestationPopJwt
+import at.asitplus.openid.OpenIdConstants.ClientAttestationPopMethod.DpopCombined
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JsonWebToken
@@ -34,6 +36,8 @@ import kotlin.time.Duration.Companion.minutes
  * * [EUDI TS3 Wallet Unit Attestation 1.5.2](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md)
  */
 class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
+    private val acceptedPopMethods: Set<ClientAttestationPopMethod> =
+        setOf(AttestationPopJwt),
     /**
      * Used to verify client attestation JWTs. Client attestations are required to carry an `x5c`, so pass
      * [at.asitplus.wallet.lib.jws.VerifyJwsObjectTrustedCertificate] with the certificates of the trusted wallet
@@ -53,11 +57,30 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
     private val issuerIdentifier: String? = null,
     /** Used for [OAuth2AuthorizationServerMetadata.clientAttestationSigningAlgValuesSupportedStrings] */
     private val supportedSigningAlgorithms: Set<JwsAlgorithm.Signature> = DEFAULT_WALLET_ATTESTATION_ALGORITHMS,
-    /** Service used to create challenges for the clients to use in PoP JWT. */
+    /**
+     * Service used to create challenges for the clients to use in PoP JWT.
+     *
+     * For [OpenIdConstants.ClientAttestationPopMethod.DpopCombined] the challenge is carried in the DPoP proof's
+     * `nonce`, so pass the same instance as `dpopNonceService` of [TokenService.jwt].
+     */
     private val nonceService: NonceService = DefaultNonceService(),
 ) : ClientAuthenticationService {
+
+    init {
+        require(acceptedPopMethods.all { it == DpopCombined || it == AttestationPopJwt }
+                && acceptedPopMethods.isNotEmpty()) {
+            "acceptedPopMethods must contain only $DpopCombined or $AttestationPopJwt"
+        }
+    }
+
     override val supportedAuthMethods: Set<String>
-        get() = setOf(AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH)
+        get() = acceptedPopMethods.mapNotNull {
+            when (it) {
+                AttestationPopJwt -> OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH
+                DpopCombined -> OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH_DPOP
+                else -> null
+            }
+        }.toSet()
 
     override val supportedPopSigningAlgs: Set<String>
         get() = supportedSigningAlgorithms.map { it.identifier }.toSet()
@@ -65,8 +88,8 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
     override val supportedSigningAlgs: Set<String>
         get() = supportedSigningAlgorithms.map { it.identifier }.toSet()
 
-    override val supportedPopMethods: Set<OpenIdConstants.ClientAttestationPopMethod>
-        get() = setOf(OpenIdConstants.ClientAttestationPopMethod.AttestationPopJwt)
+    override val supportedPopMethods: Set<ClientAttestationPopMethod>
+        get() = acceptedPopMethods
 
     override suspend fun getAttestationChallenge(): String = nonceService.provideNonce()
 
@@ -81,10 +104,6 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
         val instanceAttestation = httpRequest?.clientAttestation
             ?: throw InvalidClient("client attestation header missing")
 
-        val instanceAttestationPopJwt = httpRequest.clientAttestationPop
-            ?: throw InvalidClient("client attestation pop header missing")
-
-
         instanceAttestation.validateWalletInstanceAttestation(clientId)
         verifyJwsObject(instanceAttestation.jws).getOrElse {
             throw InvalidClient("client attestation JWT not verified", it)
@@ -92,17 +111,31 @@ class AttestationBasedClientAuthenticationService @JvmOverloads constructor(
 
         val cnf = instanceAttestation.payload.confirmationClaim
             ?: throw InvalidClient("client attestation has no cnf")
-        if (!verifyJwsSignatureWithCnf(instanceAttestationPopJwt.jws, cnf)) {
-            throw InvalidClient("client attestation PoP JWT not verified")
+        val cnfPublicKey = cnf.jsonWebKey?.toCryptoPublicKey()?.getOrThrow()
+        val validatedClientId = (instanceAttestation.payload.subject
+            ?: clientId // validation above should have caught that, but the compiler did not
+            ?: throw InvalidClient("No client_id given"))
+
+        val acceptsCombined = acceptedPopMethods.contains(DpopCombined)
+        val instanceAttestationPopJwt = httpRequest.clientAttestationPop
+        if (instanceAttestationPopJwt != null) {
+            if (acceptedPopMethods.singleOrNull() == DpopCombined)
+                throw InvalidClient("client attestation PoP header not allowed in combined-only mode")
+            if (!verifyJwsSignatureWithCnf(instanceAttestationPopJwt.jws, cnf))
+                throw InvalidClient("client attestation PoP JWT not verified")
+            instanceAttestationPopJwt.validateWalletInstanceAttestationPop(instanceAttestation.payload.subject)
+        } else if (acceptsCombined) {
+            val dpopPublicKey = validatedClientKey?.toCryptoPublicKey()?.getOrNull()
+                ?: throw InvalidClient("DPoP header missing")
+            if (dpopPublicKey != cnfPublicKey)
+                throw InvalidClient("DPoP key does not match client attestation key")
+        } else {
+            throw InvalidClient("client attestation pop header missing")
         }
 
-        // TODO use validatedClientKey
-        instanceAttestationPopJwt.validateWalletInstanceAttestationPop(instanceAttestation.payload.subject)
         AuthenticatedClient(
-            clientId = instanceAttestation.payload.subject
-                ?: clientId // validation above should have caught that, but the compiler did not
-                ?: throw InvalidClient("No client_id given"),
-            publicKey = cnf.jsonWebKey?.toCryptoPublicKey()?.getOrThrow()
+            clientId = validatedClientId,
+            publicKey = cnfPublicKey
         )
     }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
@@ -22,6 +22,7 @@ interface ClientAuthenticationService {
 
     /**
      * Authenticates the client by some data in the request.
+     * @param validatedClientKey the client's public key, extracted from a DPoP proof.
      * Return `null` when there is no claimed identity at all.
      */
     suspend fun authenticateClient(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/RequestInfo.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/RequestInfo.kt
@@ -38,28 +38,29 @@ data class RequestInfo @JvmOverloads constructor(
 
     /** Value of the header `DPoP` (RFC 9449). The value of the header is a JSON Web Token (JWT) */
     val dpop: JwsCompactTyped<JsonWebToken>?
-        get() = headers.parseJwt(HttpHeaders.DPoP)
+        get() = headers.parseSingletonJwt(HttpHeaders.DPoP)
 
     /**
      * Value of the header `OAuth-Client-Attestation` (OAuth 2.0 Attestation-Based Client Authentication).
      * A JWT that conforms to the structure and syntax as defined in Section 4.2
      */
     val clientAttestation: JwsCompactTyped<JsonWebToken>?
-        get() = headers.parseJwt(HttpHeaders.OAuthClientAttestation)
+        get() = headers.parseSingletonJwt(HttpHeaders.OAuthClientAttestation)
 
     /**
      * Value of the header `OAuth-Client-Attestation-PoP` (OAuth 2.0 Attestation-Based Client Authentication).
      * A JWT that adheres to the structure and syntax as defined in Section 4.3
      */
     val clientAttestationPop: JwsCompactTyped<JsonWebToken>?
-        get() = headers.parseJwt(HttpHeaders.OAuthClientAttestationPop)
+        get() = headers.parseSingletonJwt(HttpHeaders.OAuthClientAttestationPop)
 
-    private fun Headers?.parseJwt(headerName: String): JwsTyped<JwsCompact, JsonWebToken>? =
-        catchingUnwrapped {
-            this?.get(headerName)
-                ?.takeIf { it.isNotEmpty() }
-                ?.let { JwsCompactTyped<JsonWebToken>(it) }
-        }.getOrNull()
+    /** Reads and parses the value of `headerName`, and also checks that there is exactly one such header. */
+    private fun Headers?.parseSingletonJwt(headerName: String): JwsTyped<JwsCompact, JsonWebToken>? =
+        this?.contains(headerName)?.takeIf { it }?.let {
+            catchingUnwrapped {
+                getAll(headerName).orEmpty().single().let { JwsCompactTyped<JsonWebToken>(it) }
+            }.getOrNull()
+        }
 
 }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -155,6 +155,15 @@ class SimpleAuthorizationService @JvmOverloads constructor(
         SignJwt(EphemeralKeyWithoutCert(), JwsHeaderCertOrJwk()),
 ) : OAuth2AuthorizationServerAdapter, AuthorizationService {
 
+    init {
+        if (clientAuthenticationService.supportedAuthMethods.orEmpty()
+                .contains(OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH_DPOP)
+            && tokenService.dpopSigningAlgValuesSupportedStrings.orEmpty().isEmpty()
+        ) {
+            throw IllegalArgumentException("Client authn DPoP combined mode requires Token Service with DPoP support")
+        }
+    }
+
     companion object {
         val DEFAULT_WALLET_ATTESTATION_ALGORITHMS: Set<JwsAlgorithm.Signature> = setOf(
             JwsAlgorithm.Signature.ES256,
@@ -756,6 +765,7 @@ class SimpleAuthorizationService @JvmOverloads constructor(
 
     override suspend fun getDpopNonce() = tokenService.dpopNonce()
 
+    /** Extracts and validated the DPoP proof, if there is any */
     private suspend fun RequestInfo?.validatedClientKey(): JsonWebKey? =
         this?.dpop?.let { tokenService.verification.extractValidatedClientKey(this).getOrThrow() }
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenService.kt
@@ -135,6 +135,7 @@ interface TokenService {
                 refreshTokenNonceService = refreshTokenNonceService,
                 dpopNonceService = dpopNonceService,
                 issuerKey = keyMaterial.jsonWebKey,
+                supportedSignatureAlgorithms = verificationAlgorithms,
             ),
             dpopSigningAlgValuesSupportedStrings = verificationAlgorithms.map { it.identifier }.toSet(),
             supportsRefreshTokens = true,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
@@ -11,6 +11,7 @@ import at.asitplus.openid.OpenIdConstants.TOKEN_TYPE_DPOP
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JsonWebToken
+import at.asitplus.signum.indispensable.josef.JwsAlgorithm
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.wallet.lib.NonceService
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
@@ -82,6 +83,10 @@ class JwtTokenVerificationService(
     private val clock: Clock = System,
     /** Time leeway for verification of timestamps in access tokens and refresh tokens. */
     private val timeLeeway: Duration = 5.minutes,
+    /** Maximum age of DPoP proofs. */
+    private val maxAgePoP: Duration = 10.minutes,
+    /** Supported verification algorithms */
+    private val supportedSignatureAlgorithms: Collection<JwsAlgorithm.Signature> = setOf(JwsAlgorithm.Signature.ES256),
 ) : TokenVerificationService {
 
     override suspend fun validateRefreshToken(
@@ -91,7 +96,13 @@ class JwtTokenVerificationService(
     ): String {
         val tokenJwt = validateToken(refreshToken, JwsContentTypeConstants.RT_JWT, refreshTokenNonceService)
         // ath is not required on /token endpoints
-        validateDpopProof(null, tokenJwt, httpRequest, dpopNonceService, validatedClientKey)
+        validateDpopProof(
+            accessToken = null,
+            tokenJwt = tokenJwt,
+            httpRequest = httpRequest,
+            dpopNonceService = dpopNonceService,
+            validatedClientKey = validatedClientKey
+        )
         return refreshToken
     }
 
@@ -153,10 +164,15 @@ class JwtTokenVerificationService(
     ): JwsCompactTyped<JsonWebToken> = httpRequest.dpop?.also {
         verifyJwsObject(it.jws).getOrElse { throw InvalidDpopProof("DPoP JWT not verified.", it) }
         if (it.jws.jwsHeader.type != JwsContentTypeConstants.DPOP_JWT) {
-            throw InvalidDpopProof("invalid type: ${it.jws.jwsHeader.type}")
+            throw InvalidDpopProof("DPoP JWT invalid type: ${it.jws.jwsHeader.type}")
         }
         if (it.jws.jwsHeader.jsonWebKey == null) {
             throw InvalidDpopProof("DPoP JWT contains no public key")
+        }
+        if (it.jws.jwsHeader.algorithm !is JwsAlgorithm.Signature ||
+            it.jws.jwsHeader.algorithm !in supportedSignatureAlgorithms
+        ) {
+            throw InvalidDpopProof("DPoP JWT unsupported alg: ${it.jws.jwsHeader.algorithm}")
         }
         if (it.payload.httpTargetUrl != httpRequest.url) {
             throw InvalidDpopProof("DPoP JWT htu incorrect: ${it.payload.httpTargetUrl}")
@@ -167,10 +183,13 @@ class JwtTokenVerificationService(
         if (it.payload.jwtId == null) {
             throw InvalidDpopProof("DPoP JWT contains no jwtId")
         }
-        if (it.payload.issuedAt == null) {
-            throw InvalidDpopProof("DPoP JWT contains no issuedAt")
-        } else if (it.payload.issuedAt!! > (clock.now() + timeLeeway)) {
-            throw InvalidDpopProof("DPoP JWT issuedAt in future: ${it.payload.issuedAt}")
+        val issuedAt = it.payload.issuedAt
+            ?: throw InvalidDpopProof("DPoP JWT contains no issuedAt")
+        if (issuedAt > (clock.now() + timeLeeway)) {
+            throw InvalidDpopProof("DPoP JWT issuedAt in future: $issuedAt")
+        }
+        if (issuedAt < (clock.now() - maxAgePoP - timeLeeway)) {
+            throw InvalidDpopProof("DPoP JWT issued too long ago: $issuedAt")
         }
     } ?: throw InvalidDpopProof("no dpop proof in header")
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAttestationDpopCombinedTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientAttestationDpopCombinedTest.kt
@@ -1,0 +1,321 @@
+package at.asitplus.wallet.lib.oauth2
+
+import at.asitplus.catching
+import at.asitplus.openid.OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH
+import at.asitplus.openid.OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH_DPOP
+import at.asitplus.openid.OpenIdConstants.ClientAttestationPopMethod
+import at.asitplus.openid.PushedAuthenticationResponseParameters
+import at.asitplus.openid.RequestParameters
+import at.asitplus.signum.indispensable.josef.JsonWebToken
+import at.asitplus.signum.indispensable.josef.JwsCompactTyped
+import at.asitplus.testballoon.matrix.fixture
+import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.wallet.lib.DefaultNonceService
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.agent.KeyMaterial
+import at.asitplus.wallet.lib.agent.RandomSource
+import at.asitplus.wallet.lib.agent.TestCertificateAuthority
+import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
+import at.asitplus.wallet.lib.jws.JwsHeaderJwk
+import at.asitplus.wallet.lib.jws.JwsHeaderNone
+import at.asitplus.wallet.lib.jws.SignJwt
+import at.asitplus.wallet.lib.jws.SignJwtFun
+import at.asitplus.wallet.lib.jws.VerifyJwsObjectTrustedCertificate
+import at.asitplus.wallet.lib.oidvci.BuildClientAttestationJwt
+import at.asitplus.wallet.lib.oidvci.BuildClientAttestationPoPJwt
+import at.asitplus.wallet.lib.oidvci.BuildDPoPHeader
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception
+import at.asitplus.wallet.lib.oidvci.randomString
+import at.asitplus.wallet.lib.openid.AuthenticationResponseResult
+import at.asitplus.wallet.lib.openid.DummyUserProvider.user
+import com.benasher44.uuid.uuid4
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+
+/** RFC 8414 issuer identifier of the AS under test. */
+private const val AUTHORIZATION_SERVER = "https://wallet.a-sit.at/authorization-server"
+
+/**
+ * DPoP combined mode, i.e. one DPoP proof serving as the Client Attestation PoP, from sections 5.2 and 7.3 of
+ * [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html).
+ */
+val OAuth2ClientAttestationDpopCombinedTest by matrixSuite {
+
+    fixture {
+        runBlocking {
+            val walletProviderCa = TestCertificateAuthority()
+            val walletProviderCaCert = walletProviderCa.certificate()
+            val attesterBackend = SignJwt<JsonWebToken>(walletProviderCa.issue(), JwsHeaderCertOrJwk())
+            val client = OAuth2Client()
+            val scope = randomString()
+
+            /** The attested key is also the DPoP key: combined mode has only one key. */
+            val clientKey: KeyMaterial = EphemeralKeyWithoutCert()
+            val clientAttestation = BuildClientAttestationJwt(
+                attesterBackend,
+                clientId = client.clientId,
+                clientKey = clientKey.jsonWebKey,
+            )
+
+            /**
+             * The attestation challenge is carried in the DPoP proof's `nonce`, so the challenge store and the
+             * DPoP nonce store must be the same instance.
+             */
+            fun serverWith(vararg popMethods: ClientAttestationPopMethod): SimpleAuthorizationService {
+                val proofNonceService = DefaultNonceService()
+                return SimpleAuthorizationService(
+                    publicContext = AUTHORIZATION_SERVER,
+                    strategy = DummyAuthorizationServiceStrategy(scope),
+                    tokenService = TokenService.jwt(dpopNonceService = proofNonceService),
+                    clientAuthenticationService = AttestationBasedClientAuthenticationService(
+                        issuerIdentifier = AUTHORIZATION_SERVER,
+                        verifyJwsObject = VerifyJwsObjectTrustedCertificate(
+                            trustedIssuers = { setOf(walletProviderCaCert) }
+                        ),
+                        nonceService = proofNonceService,
+                        acceptedPopMethods = popMethods.toSet(),
+                    ),
+                )
+            }
+
+            object {
+                val scope = scope
+                val client = client
+                val clientKey = clientKey
+                val clientAttestation = clientAttestation
+                val attesterBackend = attesterBackend
+                val combinedOnly = serverWith(ClientAttestationPopMethod.DpopCombined)
+                val normalOnly = serverWith(ClientAttestationPopMethod.AttestationPopJwt)
+                val bothModes = serverWith(
+                    ClientAttestationPopMethod.AttestationPopJwt,
+                    ClientAttestationPopMethod.DpopCombined,
+                )
+
+                /**
+                 * A request carrying both proofs, which no conformant client sends: draft-10 7 has the AS advertise
+                 * the method it accepts, so the client picks one.
+                 */
+                suspend fun bothProofsRequest(
+                    server: SimpleAuthorizationService,
+                    url: String = "https://example.com/",
+                ): RequestInfo {
+                    val pop = BuildClientAttestationPoPJwt(
+                        signJwt = SignJwt(clientKey, JwsHeaderNone()),
+                        audience = AUTHORIZATION_SERVER,
+                        nonce = server.attestationChallenge().getOrThrow().shouldNotBeNull().attestationChallenge,
+                        randomSource = RandomSource.Default,
+                    )
+                    val dpop = BuildDPoPHeader(
+                        signDpop = SignJwt(clientKey, JwsHeaderJwk()),
+                        url = url,
+                        nonce = server.attestationChallenge().getOrThrow().shouldNotBeNull().attestationChallenge,
+                        randomSource = RandomSource.Default,
+                    )
+                    return RequestInfo(
+                        url = url,
+                        method = HttpMethod.Post,
+                        headers = headers {
+                            append(HttpHeaders.OAuthClientAttestation, clientAttestation.toString())
+                            append(HttpHeaders.OAuthClientAttestationPop, pop.toString())
+                            append(HttpHeaders.DPoP, dpop.toString())
+                        },
+                    )
+                }
+
+                /** A request in DPoP combined mode: attestation plus one DPoP proof, and no dedicated PoP. */
+                suspend fun combinedRequest(
+                    server: SimpleAuthorizationService = combinedOnly,
+                    url: String = "https://example.com/",
+                    method: HttpMethod = HttpMethod.Post,
+                    attestation: JwsCompactTyped<JsonWebToken> = clientAttestation,
+                    dpopSigner: SignJwtFun<JsonWebToken> = SignJwt(clientKey, JwsHeaderJwk()),
+                ): RequestInfo {
+                    val dpop = BuildDPoPHeader(
+                        signDpop = dpopSigner,
+                        url = url,
+                        httpMethod = method.value,
+                        nonce = server.attestationChallenge().getOrThrow().shouldNotBeNull().attestationChallenge,
+                        randomSource = RandomSource.Default,
+                    )
+                    return RequestInfo(
+                        url = url,
+                        method = method,
+                        headers = headers {
+                            append(HttpHeaders.OAuthClientAttestation, attestation.toString())
+                            append(HttpHeaders.DPoP, dpop.toString())
+                        },
+                    )
+                }
+
+                /** A request in normal mode: attestation plus a dedicated PoP JWT, and no DPoP proof. */
+                suspend fun normalModeRequest(
+                    server: SimpleAuthorizationService,
+                    url: String = "https://example.com/",
+                ): RequestInfo {
+                    val pop = BuildClientAttestationPoPJwt(
+                        signJwt = SignJwt(clientKey, JwsHeaderNone()),
+                        audience = AUTHORIZATION_SERVER,
+                        nonce = server.attestationChallenge().getOrThrow().shouldNotBeNull().attestationChallenge,
+                        randomSource = RandomSource.Default,
+                    )
+                    return RequestInfo(
+                        url = url,
+                        method = HttpMethod.Post,
+                        headers = headers {
+                            append(HttpHeaders.OAuthClientAttestation, clientAttestation.toString())
+                            append(HttpHeaders.OAuthClientAttestationPop, pop.toString())
+                        },
+                    )
+                }
+
+                suspend fun par(server: SimpleAuthorizationService, httpRequest: RequestInfo) = server.par(
+                    client.createAuthRequestJar(state = uuid4().toString(), scope = scope),
+                    httpRequest,
+                ).getOrThrow()
+            }
+        }
+    } - {
+
+        test("combined mode accepts attestation with a DPoP proof for the attested key at PAR") {
+            it.par(it.combinedOnly, it.combinedRequest())
+                .shouldBeInstanceOf<PushedAuthenticationResponseParameters>()
+                .requestUri.shouldNotBeNull()
+        }
+
+        test("combined mode accepts the same client at the token endpoint") {
+            val state = uuid4().toString()
+            val parResponse = it.combinedOnly.par(
+                it.client.createAuthRequestJar(state = state, scope = it.scope),
+                it.combinedRequest(),
+            ).getOrThrow().shouldBeInstanceOf<PushedAuthenticationResponseParameters>()
+            val code = it.combinedOnly
+                .authorize(it.client.createAuthRequestAfterPar(parResponse) as RequestParameters) { catching { user } }
+                .getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+                .params?.code.shouldNotBeNull()
+
+            it.combinedOnly.token(
+                request = it.client.createTokenRequestParameters(
+                    state = state,
+                    authorization = OAuth2Client.AuthorizationForToken.Code(code),
+                    scope = it.scope,
+                ),
+                httpRequest = it.combinedRequest(),
+            ).getOrThrow().accessToken.shouldNotBeNull()
+        }
+
+        test("combined mode rejects a DPoP proof from a key the attestation does not confirm") {
+            // The whole point of 5.2: the DPoP key must be the key in cnf.jwk, otherwise the proof says nothing
+            // about possession of the attested key
+            shouldThrow<OAuth2Exception> {
+                it.par(
+                    it.combinedOnly,
+                    it.combinedRequest(dpopSigner = SignJwt(EphemeralKeyWithoutCert(), JwsHeaderJwk())),
+                )
+            }
+        }
+
+        test("combined mode rejects a request without any proof of possession") {
+            val attestationOnly = RequestInfo(
+                url = "https://example.com/",
+                method = HttpMethod.Post,
+                headers = headers {
+                    append(HttpHeaders.OAuthClientAttestation, it.clientAttestation.toString())
+                },
+            )
+
+            shouldThrow<OAuth2Exception> {
+                it.par(it.combinedOnly, attestationOnly)
+            }
+        }
+
+        test("combined mode rejects a dedicated attestation PoP JWT") {
+            // draft-10 7: the accepted PoP method is configuration, not the client's choice
+            shouldThrow<OAuth2Exception> {
+                it.par(it.combinedOnly, it.normalModeRequest(it.combinedOnly))
+            }
+        }
+
+        test("accepting both methods accepts a normal mode request") {
+            // An AS advertising both methods lets the client pick, so a dedicated PoP without any DPoP proof must
+            // still authenticate: requiring both proofs at once is neither mode
+            it.par(it.bothModes, it.normalModeRequest(it.bothModes))
+                .shouldBeInstanceOf<PushedAuthenticationResponseParameters>()
+        }
+
+        test("accepting both methods accepts a combined mode request") {
+            it.par(it.bothModes, it.combinedRequest(server = it.bothModes))
+                .shouldBeInstanceOf<PushedAuthenticationResponseParameters>()
+        }
+
+        test("combined mode rejects a dedicated PoP even alongside a valid DPoP proof") {
+            // draft-10 7: the configured method is not negotiable, so normal mode must not be reachable on an AS
+            // that only advertises attest_jwt_client_auth_dpop
+            shouldThrow<OAuth2Exception> {
+                it.par(it.combinedOnly, it.bothProofsRequest(it.combinedOnly))
+            }
+        }
+
+        test("normal mode rejects a combined mode request") {
+            shouldThrow<OAuth2Exception> {
+                it.par(it.normalOnly, it.combinedRequest(server = it.normalOnly))
+            }
+        }
+
+        test("reject duplicate client attestation headers") {
+            // draft-10 7: exactly one attestation, so a second header cannot be smuggled past the parsed
+            // single-value accessor
+            val second = BuildClientAttestationJwt(
+                it.attesterBackend,
+                clientId = it.client.clientId,
+                clientKey = EphemeralKeyWithoutCert().jsonWebKey,
+            )
+            val dpop = BuildDPoPHeader(
+                signDpop = SignJwt(it.clientKey, JwsHeaderJwk()),
+                url = "https://example.com/",
+                nonce = it.combinedOnly.attestationChallenge().getOrThrow()
+                    .shouldNotBeNull().attestationChallenge,
+                randomSource = RandomSource.Default,
+            )
+            val duplicated = RequestInfo(
+                url = "https://example.com/",
+                method = HttpMethod.Post,
+                headers = headers {
+                    append(HttpHeaders.OAuthClientAttestation, it.clientAttestation.toString())
+                    append(HttpHeaders.OAuthClientAttestation, second.toString())
+                    append(HttpHeaders.DPoP, dpop.toString())
+                },
+            )
+
+            shouldThrow<OAuth2Exception> {
+                it.par(it.combinedOnly, duplicated)
+            }
+        }
+
+        test("metadata advertises only the configured PoP method") {
+            it.combinedOnly.metadata().apply {
+                tokenEndPointAuthMethodsSupported.shouldNotBeNull()
+                    .shouldContain(AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH_DPOP)
+                tokenEndPointAuthMethodsSupported.shouldNotBeNull()
+                    .shouldNotContain(AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH)
+                clientAttestationPopMethodsSupported shouldBe setOf(ClientAttestationPopMethod.DpopCombined)
+                // combined mode is unusable without DPoP, so the AS must publish its DPoP algorithms
+                dpopSigningAlgValuesSupportedStrings.shouldNotBeNull().isNotEmpty() shouldBe true
+            }
+
+            it.normalOnly.metadata().apply {
+                tokenEndPointAuthMethodsSupported.shouldNotBeNull()
+                    .shouldContain(AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH)
+                tokenEndPointAuthMethodsSupported.shouldNotBeNull()
+                    .shouldNotContain(AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH_DPOP)
+                clientAttestationPopMethodsSupported shouldBe setOf(ClientAttestationPopMethod.AttestationPopJwt)
+            }
+        }
+    }
+}

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientDPoPTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2ClientDPoPTest.kt
@@ -9,6 +9,7 @@ import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenIntrospectionRequest
 import at.asitplus.openid.TokenIntrospectionResponse
 import at.asitplus.openid.TokenResponseParameters
+import at.asitplus.signum.indispensable.josef.JwsAlgorithm
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.testballoon.matrix.fixture
@@ -388,6 +389,114 @@ val OAuth2ClientDPoPTest by matrixSuite {
         test("reject DPoP proof with iat in the future") {
             shouldThrow<OAuth2Exception.InvalidDpopProof> {
                 it.validateDpop(it.dpopProof { proof -> proof.copy(issuedAt = Clock.System.now() + 1.hours) })
+            }
+        }
+
+        test("reject DPoP proof issued too long ago") {
+            // RFC 9449 4.3: the creation time must be within an acceptable window, so a proof stays replayable
+            // for as long as its nonce lives without a lower bound on iat
+            shouldThrow<OAuth2Exception.InvalidDpopProof> {
+                it.validateDpop(it.dpopProof { proof -> proof.copy(issuedAt = Clock.System.now() - 24.hours) })
+            }
+        }
+
+        test("reject DPoP proof with an algorithm the AS does not advertise") {
+            // RFC 9449 4.3: alg must be an asymmetric algorithm the server supports, i.e. one of the algorithms
+            // published as dpop_signing_alg_values_supported
+            val es384Only = TokenService.jwt(
+                keyMaterial = it.issuerKey,
+                verificationAlgorithms = setOf(JwsAlgorithm.Signature.ES384),
+            )
+            es384Only.dpopSigningAlgValuesSupportedStrings shouldBe setOf(JwsAlgorithm.Signature.ES384.identifier)
+
+            val es256Proof = BuildDPoPHeader(
+                signDpop = it.signDpop,
+                url = it.tokenUrl,
+                nonce = es384Only.dpopNonce(),
+                randomSource = RandomSource.Default,
+            )
+            es256Proof.jws.jwsHeader.algorithm shouldBe JwsAlgorithm.Signature.ES256
+
+            @Suppress("DEPRECATION")
+            shouldThrow<OAuth2Exception.InvalidDpopProof> {
+                es384Only.verification.extractValidatedClientKey(
+                    RequestInfo(url = it.tokenUrl, method = HttpMethod.Post, dpop = es256Proof)
+                ).getOrThrow()
+            }
+        }
+
+        test("reject duplicate DPoP headers") {
+            // draft-10 7.3 and RFC 9449 4.2: exactly one proof, so a second header cannot be smuggled past the
+            // parsed single-value accessor
+            val proof = it.dpopProof()
+            val duplicated = RequestInfo(
+                url = it.tokenUrl,
+                method = HttpMethod.Post,
+                headers = headers {
+                    append(HttpHeaders.DPoP, proof.toString())
+                    append(HttpHeaders.DPoP, proof.toString())
+                },
+            )
+
+            shouldThrow<OAuth2Exception.InvalidDpopProof> {
+                it.tokenService.verification.extractValidatedClientKey(duplicated).getOrThrow()
+            }
+        }
+
+        test("token exchange consumes the DPoP nonce only once") {
+            val token = it.getAccessToken()
+            val resource = it.server.metadata().userInfoEndpoint.shouldNotBeNull()
+
+            @Suppress("DEPRECATION")
+            val exchanged = it.server.token(
+                request = it.client.createTokenRequestParameters(
+                    state = it.state,
+                    authorization = OAuth2Client.AuthorizationForToken.TokenExchange(token.accessToken),
+                    resource = resource,
+                ),
+                httpRequest = RequestInfo(
+                    url = it.tokenUrl,
+                    method = HttpMethod.Post,
+                    dpop = BuildDPoPHeader(
+                        signDpop = it.signDpop,
+                        url = it.tokenUrl,
+                        accessToken = token.accessToken,
+                        nonce = it.server.getDpopNonce(),
+                        randomSource = RandomSource.Default,
+                    ),
+                ),
+            ).getOrThrow()
+
+            exchanged.accessToken shouldNotBe token.accessToken
+        }
+
+        test("token exchange rejects a subject token bound to another key") {
+            val token = it.getAccessToken()
+            val resource = it.server.metadata().userInfoEndpoint.shouldNotBeNull()
+            val otherKey = SignJwt<JsonWebToken>(EphemeralKeyWithoutCert(), JwsHeaderCertOrJwk())
+
+            // Guards the test above against passing because the ath and cnf.jkt checks were dropped along with
+            // the second nonce check
+            @Suppress("DEPRECATION")
+            shouldThrow<OAuth2Exception> {
+                it.server.token(
+                    request = it.client.createTokenRequestParameters(
+                        state = it.state,
+                        authorization = OAuth2Client.AuthorizationForToken.TokenExchange(token.accessToken),
+                        resource = resource,
+                    ),
+                    httpRequest = RequestInfo(
+                        url = it.tokenUrl,
+                        method = HttpMethod.Post,
+                        dpop = BuildDPoPHeader(
+                            signDpop = otherKey,
+                            url = it.tokenUrl,
+                            accessToken = token.accessToken,
+                            nonce = it.server.getDpopNonce(),
+                            randomSource = RandomSource.Default,
+                        ),
+                    ),
+                ).getOrThrow()
             }
         }
 


### PR DESCRIPTION
Final PR in the large stack: Actually implement DPoP combined mode defined in [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-10.html#name-dpop-combined-mode) referencing [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)