### PR TITLE
OpenID4VP: Correctly use ephemeral encryption keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Release 8.0.0 (unreleased):
     - Derive SD-JWT Digital Credentials API identifiers from the JWT ID or serialized credential instead of the subject
 - Verifiable Presentations:
     - Compute ISO mDoc `DeviceAuthentication` signatures automatically using the `calcIsoSessionTranscript` callback instead of requiring `calcIsoDeviceSignaturePlain` 
-    - Replace `PresentationRequestParameters.calcIsoDeviceSignaturePlain` with the PresentationRequestParameters.calcIsoSessionTranscript` callback to return a nullable `SessionTranscript?`. DeviceSignature and DeviceAuth is now calculated based on the Transcript.
+    - Replace `PresentationRequestParameters.calcIsoDeviceSignaturePlain` with the `PresentationRequestParameters.calcIsoSessionTranscript` callback to return a nullable `SessionTranscript`. DeviceSignature and DeviceAuth is now calculated based on the Transcript.
     - Add optional `signDeviceAuthDetached` parameter to `HolderAgent` and `VerifiablePresentationFactory` to centralize ISO mDoc device authentication within the holder
 - OpenID for Verifiable Presentations:
     - Remove support for Presentation Exchange, since OpenID4VP 1.0 only supports DCQL
@@ -27,6 +27,11 @@ Release 8.0.0 (unreleased):
     - Add `VerifierInfo` to `OpenId4VpRequestOptions`
     - Do not accept responses for the same `state` twice for OpenID4VP flows
     - Do not accept responses for the same `externalId` twice for DCAPI flows
+    - Supply an ephemeral response encryption key specific to each authentication request in its client metadata, as required by OpenID4VP 1.0, Section 8.3, and OpenID4VC HAIP. Keys are identified by the `kid` of the JWE, and also used as the HPKE recipient key for ISO/IEC 18013-7 Annex C requests, where they are identified by the request's `state`
+    - Add `EphemeralEncryptionKeyService` holding these keys in a `MapStore<String, String>`, PKCS#8 PEM encoded, so that applications running several instances can synchronize them, along with the parameter `ephemeralEncryptionKeyService` on `OpenId4VpVerifier` and `DcApiVerifier`. Every key decrypts at most one response
+    - Add `DecryptJweWithEphemeralKey`, resolving the decryption key from the `kid` header of the JWE
+    - In `OpenId4VpVerifier` and `DcApiVerifier` the `decryptionKeyMaterial` is now nullable and defaults to `null`: it is only advertised in `metadata` resp. `metadataWithEncryption`, i.e. for client identifier schemes that distribute it out-of-band, which is not conformant to HAIP
+    - In `OpenId4VpVerifier` and `DcApiVerifier` remove the `decryptJwe` function from the list of constructor arguments
     - Consume the request's nonce when validating an authentication response, regardless of the validation result, i.e. authentication responses are not retryable
 - OpenID for Verifiable Credential Issuance:
     - Rework validation of key attestation statements

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OAuth2AuthorizationServerMetadata.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OAuth2AuthorizationServerMetadata.kt
@@ -203,13 +203,6 @@ data class OAuth2AuthorizationServerMetadata(
     val idTokenTypesSupported: Set<IdTokenType>? = null,
 
     /**
-     * OID4VP: OPTIONAL. Boolean value specifying whether the Wallet supports the transfer of `presentation_definition`
-     * by reference, with true indicating support. If omitted, the default value is true.
-     */
-    @SerialName("presentation_definition_uri_supported")
-    val presentationDefinitionUriSupported: Boolean = true,
-
-    /**
      * OID4VP: REQUIRED. An object containing a list of key value pairs, where the key is a string identifying a
      * Credential format supported by the Wallet. Valid Credential format identifier values are defined in Annex E
      * of OpenID.VCI. Other values may be used when defined in the profiles of this specification.

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
@@ -37,6 +37,7 @@ import at.asitplus.signum.supreme.sign.Signer
 import at.asitplus.wallet.lib.DefaultNonceService
 import at.asitplus.wallet.lib.MdocDeviceSignatureVerifier
 import at.asitplus.wallet.lib.NonceService
+import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.NonceChallengeVerifier
@@ -47,8 +48,8 @@ import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKey
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKeyFun
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.IsoDeviceRetrieval
-import at.asitplus.wallet.lib.jws.DecryptJwe
 import at.asitplus.wallet.lib.jws.DecryptJweFun
+import at.asitplus.wallet.lib.jws.DecryptJweWithEphemeralKey
 import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.jws.SignJwtFun
 import at.asitplus.wallet.lib.jws.VerifyJwsObject
@@ -79,10 +80,18 @@ class DcApiVerifier @JvmOverloads constructor(
     private val keyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
     /** Verifies the holder's response against our identifier from [clientIdScheme]. */
     val verifier: Verifier = VerifierAgent(identifier = clientIdScheme.clientId),
-    /** Advertised in [metadata] so that holders can encrypt responses. */
-    private val decryptionKeyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
-    /** Decrypts encrypted responses from holders. */
-    private val decryptJwe: DecryptJweFun = DecryptJwe(decryptionKeyMaterial),
+    /**
+     * Long-lived key advertised in [metadata] so that holders can encrypt responses, but **only** for client
+     * identifier schemes that do not convey client metadata in the request, i.e. where this key is distributed
+     * out-of-band. This is not conformant to OpenID4VC HAIP, so leave it `null` to have every request carry its own
+     * ephemeral encryption key, see [ephemeralEncryptionKeyService].
+     */
+    private val decryptionKeyMaterial: KeyMaterial? = null,
+    /** Creates one ephemeral encryption key per authentication request (Annex C and OpenID4VP) */
+    private val ephemeralEncryptionKeyService: EphemeralEncryptionKeyService = EphemeralEncryptionKeyService(),
+    @Deprecated("Will be derived from [ephemeralEncryptionKeyService] and [decryptionKeyMaterial]")
+    private val decryptJwe: DecryptJweFun =
+        DecryptJweWithEphemeralKey(ephemeralEncryptionKeyService, decryptionKeyMaterial),
     /** Signs authentication requests for signed DC API requests. */
     private val signAuthnRequest: SignJwtFun<AuthenticationRequestParameters> =
         SignJwt(keyMaterial, JwsHeaderClientIdScheme(clientIdScheme)),
@@ -101,7 +110,6 @@ class DcApiVerifier @JvmOverloads constructor(
     /** Algorithms supported to decrypt responses from wallets, for [metadataWithEncryption]. */
     private val supportedJweEncryptionAlgorithms: Set<JweEncryption> = JweEncryption.entries.toSet(),
 ) {
-
     private val mdocDeviceSignatureVerifier = MdocDeviceSignatureVerifier(verifyCoseSignature = verifyCoseSignature)
 
     /** Cipher suite to decrypt responses acc. to ISO/IEC 18013-7 Annex C */
@@ -114,6 +122,7 @@ class DcApiVerifier @JvmOverloads constructor(
     )
     private val requestFactory = OpenId4VpRequestFactory(
         clientIdScheme = clientIdScheme,
+        ephemeralEncryptionKeyService = ephemeralEncryptionKeyService,
         decryptionKeyMaterial = decryptionKeyMaterial,
         signAuthnRequest = signAuthnRequest,
         nonceService = nonceService,
@@ -126,7 +135,10 @@ class DcApiVerifier @JvmOverloads constructor(
         createSessionTranscript = DcApiSessionTranscriptCalculator(),
         decryptionKeyMaterial = decryptionKeyMaterial,
     )
-    private val responseParser = ResponseParser(decryptJwe, verifyJwsObject)
+    private val responseParser = ResponseParser(
+        decryptJwe = DecryptJweWithEphemeralKey(ephemeralEncryptionKeyService, decryptionKeyMaterial),
+        verifyJwsObject = verifyJwsObject
+    )
 
     /**
      * Creates the [at.asitplus.openid.RelyingPartyMetadata], without encryption (see [metadataWithEncryption])
@@ -170,48 +182,39 @@ class DcApiVerifier @JvmOverloads constructor(
     ): DigitalCredentialGetRequest = when (this) {
         is DcApiCreationOptions.OpenId4VpUnsigned -> OpenId4VpUnsigned(
             // client_id MUST be omitted in unsigned requests, per OpenID4VP 1.0 Appendix A.3.1
-            requestFactory.createPlainAuthnRequest(
-                requestFactory.requireEncryptionKeyConveyed(requestOptions).copy(populateClientId = false)
-            )
+            requestFactory.createPlainAuthnRequest(requestOptions.copy(populateClientId = false))
         )
 
         is DcApiCreationOptions.OpenId4VpSigned -> OpenId4VpSigned(
             SignedDataElement(
                 requestFactory.createSignedRequestObject(
-                    requestFactory.requireEncryptionKeyConveyed(requestOptions),
+                    requestOptions,
                     RequestObjectSigning.DcApi,
                 ).getOrThrow().jws
             )
         )
 
-        DcApiCreationOptions.Iso180137AnnexC -> when (requestOptions.presentationRequest) {
-            is DCQLRequest -> IsoMdoc(
-                IsoMdocRequest(
-                    deviceRequest = requestOptions.presentationRequest.dcqlQuery.toIso180137AnnexCDeviceRequest(),
-                    encryptionInfo = EncryptionInfo(
-                        type = TYPE_DCAPI,
-                        encryptionParameters = EncryptionParameters(
-                            nonceService.provideNonce().toByteArray(),
-                            decryptionKeyMaterial.publicKey.toCoseKey().getOrThrow()
-                        )
-                    )
-                ).also { stateToIsoMdocRequestStore.put(requestOptions.state, it) }
+        DcApiCreationOptions.Iso180137AnnexC -> {
+            // the recipient key is ephemeral for this request, and recovered in [validateIsoResponse]
+            val encryptionInfo = EncryptionInfo(
+                type = TYPE_DCAPI,
+                encryptionParameters = EncryptionParameters(
+                    nonceService.provideNonce().toByteArray(),
+                    ephemeralEncryptionKeyService.createKey(requestOptions.state)
+                        .publicKey.toCoseKey().getOrThrow()
+                )
             )
-
-            is IsoDeviceRetrieval -> IsoMdoc(
-                IsoMdocRequest(
-                    deviceRequest = requestOptions.presentationRequest.deviceRequest,
-                    encryptionInfo = EncryptionInfo(
-                        type = TYPE_DCAPI,
-                        encryptionParameters = EncryptionParameters(
-                            nonceService.provideNonce().toByteArray(),
-                            decryptionKeyMaterial.publicKey.toCoseKey().getOrThrow()
-                        )
-                    )
-                ).also { stateToIsoMdocRequestStore.put(requestOptions.state, it) }
+            val deviceRequest = when (requestOptions.presentationRequest) {
+                is DCQLRequest -> requestOptions.presentationRequest.dcqlQuery.toIso180137AnnexCDeviceRequest()
+                is IsoDeviceRetrieval -> requestOptions.presentationRequest.deviceRequest
+                else -> throw IllegalArgumentException(
+                    "ISO 18013-7 Annex C requires a Device Request or DCQL presentation"
+                )
+            }
+            IsoMdoc(
+                IsoMdocRequest(deviceRequest = deviceRequest, encryptionInfo = encryptionInfo)
+                    .also { stateToIsoMdocRequestStore.put(requestOptions.state, it) }
             )
-
-            else -> throw IllegalArgumentException("ISO 18013-7 Annex C requires a Device Request or DCQL presentation")
         }
     }
 
@@ -304,8 +307,8 @@ class DcApiVerifier @JvmOverloads constructor(
     ): KmmResult<Iso180137AnnexCWrapper> = catching {
         val isoMdocRequest = stateToIsoMdocRequestStore.remove(externalId)
             ?: throw IllegalStateException("Can't load request for response to $externalId")
-        val decryptionKey = decryptionKeyMaterial.getUnderLyingSigner() as? Signer.ECDSA
-            ?: throw IllegalStateException("Expected ECDSA decryption key material")
+        val decryptionKey = ephemeralEncryptionKeyService.consumeKey(externalId)?.getUnderLyingSigner() as? Signer.ECDSA
+            ?: throw IllegalStateException("Can't load ephemeral decryption key for response to $externalId")
         val serializedOrigin = expectedOrigin.serializeOrigin()
             ?: throw IllegalStateException("Expected origin invalid")
         val encryptedResponseData = receivedData.response.encryptedResponseData

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -80,9 +80,11 @@ class OpenId4VpHolder @JvmOverloads constructor(
     /** Advertised in [metadata] and compared against holder's requirements. */
     private val supportedAlgorithms: Set<SignatureAlgorithm> = setOf(SignatureAlgorithm.ECDSAwithSHA256),
     /** Signs the session transcript for mDoc responses. */
-    @Deprecated("signDeviceAuthDetached no longer has any effect because ISO Device signature" +
-            "creation has been moved into Holder's credential presentation. " +
-            "Signing function can be overridden in HolderAgent instead.")
+    @Deprecated(
+        "signDeviceAuthDetached no longer has any effect because ISO Device signature" +
+                "creation has been moved into Holder's credential presentation. " +
+                "Signing function can be overridden in HolderAgent instead."
+    )
     private val signDeviceAuthDetached: SignCoseDetachedFun<ByteArray> =
         SignCoseDetached(keyMaterial, CoseHeaderNone(), CoseHeaderNone()),
     @Deprecated("Support for SIOPv2 has been removed")
@@ -150,10 +152,7 @@ class OpenId4VpHolder @JvmOverloads constructor(
             issuer = clientId,
             authorizationEndpoint = authorizationEndpoint,
             responseTypesSupported = setOf(VP_TOKEN),
-            scopesSupported = setOf(OpenIdConstants.SCOPE_OPENID),
-            idTokenSigningAlgorithmsSupportedStrings = supportedJwsAlgorithms.toSet(),
             requestObjectSigningAlgorithmsSupportedStrings = supportedJwsAlgorithms.toSet(),
-            presentationDefinitionUriSupported = false,
             clientIdPrefixesSupported = listOf(
                 ClientIdScheme.PreRegistered,
                 ClientIdScheme.RedirectUri,
@@ -204,7 +203,7 @@ class OpenId4VpHolder @JvmOverloads constructor(
     ) = requestParser.parseRequestParameters(input)
         .getOrThrow() as RequestParametersFrom<AuthenticationRequestParameters>
 
-    @Deprecated("Use createAuthnErrorResponse with AuthorizationResponsePreparationState parameter",)
+    @Deprecated("Use createAuthnErrorResponse with AuthorizationResponsePreparationState parameter")
     suspend fun createAuthnErrorResponse(
         error: Throwable,
         request: RequestParametersFrom<AuthenticationRequestParameters>,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpRequestFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpRequestFactory.kt
@@ -20,6 +20,7 @@ import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
 import at.asitplus.wallet.lib.NonceService
+import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
 import at.asitplus.wallet.lib.data.toBase64UrlJsonString
@@ -48,8 +49,10 @@ internal sealed interface RequestObjectSigning {
 internal class OpenId4VpRequestFactory(
     /** Scheme to use for our client identifier. */
     private val clientIdScheme: ClientIdScheme,
-    /** Advertised in [metadata] so that holders can encrypt responses. */
-    private val decryptionKeyMaterial: KeyMaterial,
+    /** Creates one ephemeral encryption key per authentication request, see OpenID4VP 1.0, Section 8.3. */
+    private val ephemeralEncryptionKeyService: EphemeralEncryptionKeyService,
+    /** Advertised in [metadata] so that holders can encrypt responses, for out-of-band metadata only. */
+    private val decryptionKeyMaterial: KeyMaterial?,
     /** Signs authentication requests in [createSignedRequestObject]. */
     private val signAuthnRequest: SignJwtFun<AuthenticationRequestParameters>,
     /** Creates OpenID4VP request nonces. */
@@ -68,16 +71,15 @@ internal class OpenId4VpRequestFactory(
         .mapNotNull { it.toCoseAlgorithm().getOrNull()?.coseValue }
 
     /**
-     * Creates the [at.asitplus.openid.RelyingPartyMetadata], without encryption (see [metadataWithEncryption])
+     * Creates the [at.asitplus.openid.RelyingPartyMetadata], without encryption (see [metadataWithEncryption]).
+     * Carries a JSON Web Key Set only if a long-lived [decryptionKeyMaterial] has been configured to be distributed
+     * out-of-band, requests built here embed a key specific to that request instead, see
+     * [metadataWithEphemeralEncryptionKey].
      */
     val metadata by lazy {
         RelyingPartyMetadata(
             redirectUris = listOfNotNull((clientIdScheme as? ClientIdScheme.RedirectUri)?.redirectUri),
-            jsonWebKeySet = JsonWebKeySet(
-                listOf(
-                    decryptionKeyMaterial.publicKey.toJsonWebKey(decryptionKeyMaterial.identifier).withAlgorithm()
-                )
-            ),
+            jsonWebKeySet = decryptionKeyMaterial?.let { JsonWebKeySet(listOf(it.toEncryptionJsonWebKey())) },
             vpFormatsSupported = VpFormatsSupported(
                 vcJwt = SupportedAlgorithmsContainerJwt(
                     algorithmStrings = supportedJwsAlgorithms.toSet()
@@ -97,15 +99,28 @@ internal class OpenId4VpRequestFactory(
     /**
      * Creates the [RelyingPartyMetadata], but with parameters set to request encryption of pushed authentication
      * responses, see [RelyingPartyMetadata.encryptedResponseEncValues].
+     *
+     * Carries the long-lived [decryptionKeyMaterial], so this is only useful to publish out-of-band, for client
+     * identifier schemes that do not convey client metadata in the request itself. Requests built here embed a key
+     * specific to that request instead, see [metadataWithEphemeralEncryptionKey].
      */
-    val metadataWithEncryption by lazy {
-        metadata.copy(
-            encryptedResponseEncValuesSupportedString = supportedJweEncryptionAlgorithms.map { it.identifier }.toSet(),
-            jsonWebKeySet = metadata.jsonWebKeySet?.let {
-                JsonWebKeySet(it.keys.map { it.copy(publicKeyUse = "enc") })
-            }
-        )
-    }
+    val metadataWithEncryption by lazy { metadata.requestingEncryptedResponses() }
+
+    /**
+     * Creates the [RelyingPartyMetadata] with an encryption key valid for exactly one authentication request, as
+     * required by
+     * [OpenID4VP 1.0, 8.3](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-encrypted-responses)
+     * and
+     * [OpenID4VC HAIP 1.0](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0-final.html),
+     */
+    private suspend fun metadataWithEphemeralEncryptionKey(): RelyingPartyMetadata = metadata.copy(
+        jsonWebKeySet = JsonWebKeySet(listOf(ephemeralEncryptionKeyService.createKey().toEncryptionJsonWebKey()))
+    ).requestingEncryptedResponses()
+
+    private fun RelyingPartyMetadata.requestingEncryptedResponses(): RelyingPartyMetadata = copy(
+        encryptedResponseEncValuesSupportedString = supportedJweEncryptionAlgorithms.map { it.identifier }.toSet(),
+        jsonWebKeySet = jsonWebKeySet?.let { JsonWebKeySet(it.keys.map { key -> key.copy(publicKeyUse = "enc") }) }
+    )
 
     suspend fun createPlainAuthnRequest(
         requestOptions: OpenId4VpRequestOptions,
@@ -167,56 +182,55 @@ internal class OpenId4VpRequestFactory(
         return authnRequest
     }
 
-    /**
-     * The DC API has no other channel to convey the verifier's encryption key: wallets can only encrypt responses
-     * with a key from [at.asitplus.openid.AuthenticationRequestParameters.clientMetadata] in the request itself.
-     */
-    fun requireEncryptionKeyConveyed(requestOptions: OpenId4VpRequestOptions): OpenId4VpRequestOptions =
-        requestOptions.also {
-            if (it.responseMode.requiresEncryption) {
-                requireNotNull(it.clientMetadata()?.jsonWebKeySet) {
-                    "Encrypted responses require client metadata with a JSON Web Key Set in the request, " +
-                            "which is not populated for this client identifier scheme"
-                }
-            }
-        }
-
     private suspend fun OpenId4VpRequestOptions.toAuthnRequest(
         requestObjectParameters: RequestObjectParameters?,
-    ): AuthenticationRequestParameters = AuthenticationRequestParameters(
-        responseType = responseType,
-        clientId = if (populateClientId) clientIdScheme.clientId else null,
-        redirectUrl = if (!isAnyDirectPost) clientIdScheme.redirectUri else null,
-        responseUrl = responseUrl,
-        // Using scope as an alias for a well-defined DCQL Query is not supported
-        scope = null,
-        nonce = nonceService.provideNonce(),
-        walletNonce = requestObjectParameters?.walletNonce,
-        clientMetadata = clientMetadata(),
-        responseMode = responseMode,
-        // the DC API binds request and response through the browser, not through a `state`
-        state = if (isAnyDcApi) null else state,
-        dcqlQuery = (presentationRequest as? DCQLRequest)?.dcqlQuery,
-        transactionData = transactionData?.map { it.toBase64UrlJsonString() },
-        expectedOrigins = expectedOrigins,
-        verifierInfo = verifierInfo,
-    )
+    ): AuthenticationRequestParameters {
+        // one ephemeral encryption key per request, so this must be evaluated exactly once
+        val clientMetadata = clientMetadata()
+        if (isAnyDcApi && responseMode.requiresEncryption) {
+            // The DC API has no other channel to convey the verifier's encryption key: wallets can only encrypt
+            // responses with a key from the client metadata in the request itself.
+            requireNotNull(clientMetadata?.jsonWebKeySet) {
+                "Encrypted responses require client metadata with a JSON Web Key Set in the request, " +
+                        "which is not populated for this client identifier scheme"
+            }
+        }
+        return AuthenticationRequestParameters(
+            responseType = responseType,
+            clientId = if (populateClientId) clientIdScheme.clientId else null,
+            redirectUrl = if (!isAnyDirectPost) clientIdScheme.redirectUri else null,
+            responseUrl = responseUrl,
+            // Using scope as an alias for a well-defined DCQL Query is not supported
+            scope = null,
+            nonce = nonceService.provideNonce(),
+            walletNonce = requestObjectParameters?.walletNonce,
+            clientMetadata = clientMetadata,
+            responseMode = responseMode,
+            // the DC API binds request and response through the browser, not through a `state`
+            state = if (isAnyDcApi) null else state,
+            dcqlQuery = (presentationRequest as? DCQLRequest)?.dcqlQuery,
+            transactionData = transactionData?.map { it.toBase64UrlJsonString() },
+            expectedOrigins = expectedOrigins,
+            verifierInfo = verifierInfo,
+        )
+    }
 
-    private fun OpenId4VpRequestOptions.clientMetadata(): RelyingPartyMetadata? = when (verifierMetadataMode) {
+    private suspend fun OpenId4VpRequestOptions.clientMetadata(): RelyingPartyMetadata? = when (verifierMetadataMode) {
         VerifierMetadataMode.OMIT_IF_OUT_OF_BAND -> null
         VerifierMetadataMode.AUTO -> when (clientIdScheme) {
             is ClientIdScheme.RedirectUri,
             is ClientIdScheme.VerifierAttestation,
             is ClientIdScheme.CertificateSanDns,
             is ClientIdScheme.CertificateHash,
-                -> if (responseMode.requiresEncryption) metadataWithEncryption else metadata
+                -> if (responseMode.requiresEncryption) metadataWithEphemeralEncryptionKey() else metadata
 
             else -> null
         }
     }
 
     // should always be ecdh-es for encryption
-    private fun JsonWebKey.withAlgorithm(): JsonWebKey = this.copy(algorithm = JweAlgorithm.ECDH_ES)
+    private fun KeyMaterial.toEncryptionJsonWebKey(): JsonWebKey =
+        publicKey.toJsonWebKey(identifier).copy(algorithm = JweAlgorithm.ECDH_ES)
 
     companion object {
         /**

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpRequestFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpRequestFactory.kt
@@ -24,6 +24,7 @@ import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
 import at.asitplus.wallet.lib.data.toBase64UrlJsonString
+import at.asitplus.wallet.lib.extensions.getEncryptionTargetKey
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.jws.SignJwtFun
 import at.asitplus.wallet.lib.utils.MapStore
@@ -175,10 +176,25 @@ internal class OpenId4VpRequestFactory(
             ?: throw IllegalArgumentException("Neither externalId nor state given")
         val authnRequest = stateToAuthnRequestStore.remove(storedId)
             ?: throw IllegalArgumentException("No authn request found for $storedId")
-        if (authnRequest.responseMode?.requiresEncryption == true)
-            require(input.hasBeenEncrypted) {
+        val ephemeralKey = authnRequest.clientMetadata?.jsonWebKeySet?.keys?.getEncryptionTargetKey()
+        val ephemeralKeyId = ephemeralKey?.keyId
+        if (authnRequest.responseMode?.requiresEncryption == true) {
+            require(input is ResponseParametersFrom.JweDecrypted) {
                 "response_mode requires encryption, but no encrypted response was given"
             }
+            val responseKeyId = input.jweDecrypted.header.keyId
+            if (ephemeralKey != null) {
+                requireNotNull(ephemeralKeyId) { "Authentication request encryption key has no kid" }
+                require(responseKeyId == ephemeralKeyId) {
+                    "Encrypted response key does not match the authentication request"
+                }
+            } else {
+                requireNotNull(decryptionKeyMaterial) { "No decryption key configured" }
+                require(responseKeyId == null || responseKeyId == decryptionKeyMaterial.identifier) {
+                    "Encrypted response key does not match the configured decryption key"
+                }
+            }
+        }
         return authnRequest
     }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -16,6 +16,7 @@ import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.wallet.lib.DefaultNonceService
 import at.asitplus.wallet.lib.MdocDeviceSignatureVerifier
 import at.asitplus.wallet.lib.NonceService
+import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.NonceChallengeVerifier
@@ -26,6 +27,7 @@ import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKey
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKeyFun
 import at.asitplus.wallet.lib.jws.DecryptJwe
 import at.asitplus.wallet.lib.jws.DecryptJweFun
+import at.asitplus.wallet.lib.jws.DecryptJweWithEphemeralKey
 import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.jws.SignJwtFun
 import at.asitplus.wallet.lib.jws.VerifyJwsObject
@@ -54,10 +56,17 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     private val keyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
     /** Verifies the holder's response against our identifier from [clientIdScheme]. */
     val verifier: Verifier = VerifierAgent(identifier = clientIdScheme.clientId),
-    /** Advertised in [metadata] so that holders can encrypt responses. */
-    private val decryptionKeyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
-    /** Decrypts encrypted responses from holders. */
-    private val decryptJwe: DecryptJweFun = DecryptJwe(decryptionKeyMaterial),
+    /**
+     * Long-lived key advertised in [metadata] so that holders can encrypt responses, but **only** for client
+     * identifier schemes that do not convey client metadata in the request, i.e. where this key is distributed
+     * out-of-band. This is not conformant to OpenID4VC HAIP, so leave it `null` to have every request carry its own
+     * ephemeral encryption key, see [ephemeralEncryptionKeyService].
+     */
+    private val decryptionKeyMaterial: KeyMaterial? = null,
+    /** Creates one ephemeral encryption key per authentication request, see OpenID4VP 1.0, Section 8.3. */
+    private val ephemeralEncryptionKeyService: EphemeralEncryptionKeyService = EphemeralEncryptionKeyService(),
+    @Deprecated("Will be derived from [ephemeralEncryptionKeyService] and [decryptionKeyMaterial]")
+    private val decryptJwe: DecryptJweFun = DecryptJweWithEphemeralKey(ephemeralEncryptionKeyService, decryptionKeyMaterial),
     /** Signs authentication requests in [createSignedRequestObject]. */
     private val signAuthnRequest: SignJwtFun<AuthenticationRequestParameters> =
         SignJwt(keyMaterial, JwsHeaderClientIdScheme(clientIdScheme)),
@@ -78,7 +87,6 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     /** Algorithms supported to decrypt responses from wallets, for [metadataWithEncryption]. */
     private val supportedJweEncryptionAlgorithms: Set<JweEncryption> = JweEncryption.entries.toSet(),
 ) {
-
     private val nonceAwareVerifier = NonceChallengeVerifier(
         verifierId = clientIdScheme.clientId,
         verifier = verifier,
@@ -86,6 +94,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     )
     private val requestFactory = OpenId4VpRequestFactory(
         clientIdScheme = clientIdScheme,
+        ephemeralEncryptionKeyService = ephemeralEncryptionKeyService,
         decryptionKeyMaterial = decryptionKeyMaterial,
         signAuthnRequest = signAuthnRequest,
         nonceService = nonceService,
@@ -98,7 +107,10 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         createSessionTranscript = UrlSessionTranscriptCalculator(),
         decryptionKeyMaterial = decryptionKeyMaterial
     )
-    private val responseParser = ResponseParser(decryptJwe, verifyJwsObject)
+    private val responseParser = ResponseParser(
+        decryptJwe = DecryptJweWithEphemeralKey(ephemeralEncryptionKeyService, decryptionKeyMaterial),
+        verifyJwsObject = verifyJwsObject
+    )
 
     /**
      * Creates the [at.asitplus.openid.RelyingPartyMetadata], without encryption (see [metadataWithEncryption])

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -38,8 +38,6 @@ import io.ktor.http.*
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.jvm.JvmOverloads
 import kotlin.time.Clock
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 
 /**
  * Combines Verifiable Presentations with OAuth 2.0.
@@ -69,8 +67,8 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     private val supportedAlgorithms: Set<SignatureAlgorithm> = setOf(SignatureAlgorithm.ECDSAwithSHA256),
     /** Used to verify session transcripts from mDoc responses. */
     private val verifyCoseSignature: VerifyCoseSignatureWithKeyFun<ByteArray> = VerifyCoseSignatureWithKey(),
-    /** Leeway for time validity checks. */
-    timeLeewaySeconds: Long = 300L,
+    @Deprecated("Support for SIOPv2 has been removed")
+    private val timeLeewaySeconds: Long = 300L,
     @Deprecated("Support for SIOPv2 has been removed")
     private val clock: Clock = Clock.System,
     /** Creates and validates OpenID4VP request nonces. */
@@ -101,7 +99,6 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         decryptionKeyMaterial = decryptionKeyMaterial
     )
     private val responseParser = ResponseParser(decryptJwe, verifyJwsObject)
-    private val timeLeeway = timeLeewaySeconds.toDuration(DurationUnit.SECONDS)
 
     /**
      * Creates the [at.asitplus.openid.RelyingPartyMetadata], without encryption (see [metadataWithEncryption])

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -25,7 +25,6 @@ import at.asitplus.wallet.lib.agent.Verifier
 import at.asitplus.wallet.lib.agent.VerifierAgent
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKey
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKeyFun
-import at.asitplus.wallet.lib.jws.DecryptJwe
 import at.asitplus.wallet.lib.jws.DecryptJweFun
 import at.asitplus.wallet.lib.jws.DecryptJweWithEphemeralKey
 import at.asitplus.wallet.lib.jws.SignJwt
@@ -66,7 +65,8 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     /** Creates one ephemeral encryption key per authentication request, see OpenID4VP 1.0, Section 8.3. */
     private val ephemeralEncryptionKeyService: EphemeralEncryptionKeyService = EphemeralEncryptionKeyService(),
     @Deprecated("Will be derived from [ephemeralEncryptionKeyService] and [decryptionKeyMaterial]")
-    private val decryptJwe: DecryptJweFun = DecryptJweWithEphemeralKey(ephemeralEncryptionKeyService, decryptionKeyMaterial),
+    private val decryptJwe: DecryptJweFun =
+        DecryptJweWithEphemeralKey(ephemeralEncryptionKeyService, decryptionKeyMaterial),
     /** Signs authentication requests in [createSignedRequestObject]. */
     private val signAuthnRequest: SignJwtFun<AuthenticationRequestParameters> =
         SignJwt(keyMaterial, JwsHeaderClientIdScheme(clientIdScheme)),
@@ -107,6 +107,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         createSessionTranscript = UrlSessionTranscriptCalculator(),
         decryptionKeyMaterial = decryptionKeyMaterial
     )
+
     private val responseParser = ResponseParser(
         decryptJwe = DecryptJweWithEphemeralKey(ephemeralEncryptionKeyService, decryptionKeyMaterial),
         verifyJwsObject = verifyJwsObject

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/VpTokenValidator.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/VpTokenValidator.kt
@@ -13,12 +13,14 @@ import at.asitplus.openid.dcql.DCQLQuery
 import at.asitplus.openid.dcql.DCQLQueryResponse
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.wallet.lib.MdocDeviceSignatureVerifier
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.NonceChallengeVerifier.ChallengeSession
 import at.asitplus.wallet.lib.agent.Verifier.VerifyPresentationResult
 import at.asitplus.wallet.lib.data.VerifiablePresentationJws
+import at.asitplus.wallet.lib.extensions.getEncryptionTargetKey
 import at.asitplus.wallet.lib.jws.SdJwtSigned
 import at.asitplus.wallet.lib.procedures.dcql.DCQLQueryAdapter
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
@@ -44,8 +46,8 @@ internal class VpTokenValidator(
     private val mdocDeviceSignatureVerifier: MdocDeviceSignatureVerifier,
     /** Calculates the ISO session transcript for the transport the response was received over. */
     private val createSessionTranscript: SessionTranscriptCalculator,
-    /** To be used for ISO session transcript calculation when the response has been encrypted. */
-    private val decryptionKeyMaterial: KeyMaterial,
+    /** Long-lived decryption key, when the request did not convey the key itself (it was distributed out-of-band). */
+    private val decryptionKeyMaterial: KeyMaterial?,
 ) {
 
     /**
@@ -70,6 +72,10 @@ internal class VpTokenValidator(
         val query = authnRequest.dcqlQuery
             ?: throw IllegalArgumentException("DCQL Query not present in $authnRequest")
         val clientIdRequired = responseParameters.clientIdRequired
+        val recipientKey = if (responseParameters.hasBeenEncrypted) {
+            authnRequest.clientMetadata?.jsonWebKeySet?.keys?.getEncryptionTargetKey()
+                ?: decryptionKeyMaterial?.jsonWebKey
+        } else null
 
         val presentation = vpToken.jsonObject.mapKeys {
             DCQLCredentialQueryIdentifier(it.key)
@@ -82,13 +88,13 @@ internal class VpTokenValidator(
                     claimFormat = credentialQuery.format.toClaimFormat(),
                     relatedPresentation = it.jsonPrimitive,
                     session = session,
-                    input = responseParameters,
                     clientId = authnRequest.clientId,
                     responseUrl = authnRequest.responseUrl ?: authnRequest.redirectUrlExtracted,
                     transactionData = authnRequest.transactionData,
                     clientIdRequired = clientIdRequired,
                     origin = origin,
                     requireCryptographicHolderBinding = query.credentialQuery(credentialQueryId)?.requireCryptographicHolderBinding,
+                    recipientKey = recipientKey,
                 )
             }
         }
@@ -116,6 +122,7 @@ internal class VpTokenValidator(
         CredentialFormatEnum.DC_SD_JWT -> ClaimFormat.SD_JWT
         CredentialFormatEnum.MSO_MDOC,
         CredentialFormatEnum.MSO_MDOC_ZK -> ClaimFormat.MSO_MDOC
+
         CredentialFormatEnum.NONE,
         CredentialFormatEnum.JWT_VC_JSON_LD,
         CredentialFormatEnum.JSON_LD,
@@ -126,13 +133,13 @@ internal class VpTokenValidator(
         claimFormat: ClaimFormat,
         relatedPresentation: JsonElement,
         session: ChallengeSession,
-        input: ResponseParametersFrom,
         clientId: String?,
         responseUrl: String?,
         transactionData: List<TransactionDataBase64Url>?,
         clientIdRequired: Boolean,
         origin: String?,
         requireCryptographicHolderBinding: Boolean? = null,
+        recipientKey: JsonWebKey?,
     ): KmmResult<VerifyPresentationResult> = catching {
         when (claimFormat) {
             ClaimFormat.SD_JWT -> {
@@ -173,7 +180,7 @@ internal class VpTokenValidator(
                         responseUrl = responseUrl,
                         clientIdRequired = clientIdRequired,
                         origin = origin,
-                        recipientKey = if (input.hasBeenEncrypted) decryptionKeyMaterial.jsonWebKey else null,
+                        recipientKey = recipientKey,
                     )
                 )
             }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/Iso180137AnnexCProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/Iso180137AnnexCProtocolTest.kt
@@ -21,15 +21,16 @@ import at.asitplus.iso.sha256
 import at.asitplus.iso.wrapInCborTag
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.dcql.DCQLClaimsPathPointer
+import at.asitplus.signum.indispensable.CryptoPrivateKey
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
-import at.asitplus.signum.indispensable.cosef.toCoseKey
 import at.asitplus.signum.supreme.asymmetric.HPKE
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
 import at.asitplus.wallet.lib.RequestOptionsCredential
 import at.asitplus.wallet.lib.agent.CreatePresentationResult
+import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.Holder
@@ -53,6 +54,7 @@ import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.LocalDate
@@ -89,7 +91,7 @@ val Iso180137AnnexCProtocolTest by matrixSuite {
                 issueAndStoreIsoMdoc(agent, holderKeyMaterial, issuer)
             }
             object {
-                val decryptionKeyMaterial = EphemeralKeyWithoutCert()
+                val ephemeralKeyStore = DefaultMapStore<String, String>()
                 val stateToIsoMdocRequestStore = DefaultMapStore<String, IsoMdocRequest>()
                 val verifier = DcApiVerifier(
                     clientIdScheme = ClientIdScheme.PreRegistered(
@@ -97,7 +99,7 @@ val Iso180137AnnexCProtocolTest by matrixSuite {
                         redirectUri = "https://example.com/callback",
                     ),
                     stateToIsoMdocRequestStore = stateToIsoMdocRequestStore,
-                    decryptionKeyMaterial = decryptionKeyMaterial,
+                    ephemeralEncryptionKeyService = EphemeralEncryptionKeyService(ephemeralKeyStore),
                 )
 
                 /** Extracts the Annex C request from the browser-facing [CredentialRequestOptions]. */
@@ -114,6 +116,11 @@ val Iso180137AnnexCProtocolTest by matrixSuite {
                     .digital.requests.shouldBeSingleton().first()
                     .shouldBeInstanceOf<DigitalCredentialGetRequest.IsoMdoc>()
                     .data
+
+                /** The ephemeral encryption key the verifier created for the request identified by [state]. */
+                suspend fun storedEphemeralKey(state: String): CryptoPrivateKey.EC.WithPublicKey =
+                    CryptoPrivateKey.decodeFromPem(ephemeralKeyStore.get(state).shouldNotBeNull()).getOrThrow()
+                        .shouldBeInstanceOf<CryptoPrivateKey.EC.WithPublicKey>()
 
                 suspend fun walletResponse(
                     isoMdocRequest: IsoMdocRequest,
@@ -135,11 +142,20 @@ val Iso180137AnnexCProtocolTest by matrixSuite {
                 }
                 encryptionInfo.type shouldBe TYPE_DCAPI
                 encryptionInfo.encryptionParameters.nonce.shouldNotBeNull()
-                encryptionInfo.encryptionParameters.recipientPublicKey shouldBe
-                        f.decryptionKeyMaterial.publicKey.toCoseKey().getOrThrow()
+                // the recipient key is ephemeral for this request, its private part kept for [validateIsoResponse]
+                encryptionInfo.encryptionParameters.recipientPublicKey.toCryptoPublicKey().getOrThrow() shouldBe
+                        f.storedEphemeralKey(transactionId).publicKey
             }
 
             f.stateToIsoMdocRequestStore.get(transactionId) shouldBe isoMdocRequest
+        }
+
+        test("createAuthnRequest uses a fresh encryption key for every request") { f ->
+            val first = f.createIsoMdocRequest(uuid4().toString())
+            val second = f.createIsoMdocRequest(uuid4().toString())
+
+            first.encryptionInfo.encryptionParameters.recipientPublicKey shouldNotBe
+                    second.encryptionInfo.encryptionParameters.recipientPublicKey
         }
 
         test("Annex C walk-through: wallet response validates and contains requested claims") { f ->

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/IsoMdocDcapiResponseBuilderTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/IsoMdocDcapiResponseBuilderTest.kt
@@ -30,11 +30,13 @@ import at.asitplus.signum.supreme.asymmetric.HPKE
 import at.asitplus.testballoon.matrix.matrixSuite
 import at.asitplus.wallet.lib.RequestOptionsCredential
 import at.asitplus.wallet.lib.agent.CredentialToBeIssued
+import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.HolderAgent
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.toStoreCredentialInput
+import at.asitplus.wallet.lib.utils.DefaultMapStore
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.CredentialPresentation
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest
@@ -91,7 +93,7 @@ val IsoMdocDcapiResponseBuilderTest by matrixSuite {
             pt = plaintext,
         )
 
-        val skR = fixture.verifierKey.exportPrivateKey().getOrThrow()
+        val skR = CryptoPrivateKey.decodeFromPem(fixture.verifierKeyPem).getOrThrow()
             .shouldBeInstanceOf<CryptoPrivateKey.EC.WithPublicKey>()
 
         hpke.OpenBase(
@@ -308,13 +310,13 @@ private suspend fun dcapiFixture(
         )
     )
 ): DcapiFixture {
-    val verifierKey = EphemeralKeyWithoutCert()
+    val ephemeralKeyStore = DefaultMapStore<String, String>()
     val verifier = DcApiVerifier(
         clientIdScheme = ClientIdScheme.PreRegistered(
             clientId = "dc-api-rp",
             redirectUri = "https://verifier.example.com/callback",
         ),
-        decryptionKeyMaterial = verifierKey,
+        ephemeralEncryptionKeyService = EphemeralEncryptionKeyService(ephemeralKeyStore),
     )
     val presentationRequestBuilder = CredentialPresentationRequestBuilder(requestOptions)
     val isoRequest = verifier.createAuthnRequest(
@@ -329,7 +331,7 @@ private suspend fun dcapiFixture(
         .shouldBeInstanceOf<DigitalCredentialGetRequest.IsoMdoc>().data
     return DcapiFixture(
         verifier = verifier,
-        verifierKey = verifierKey,
+        verifierKeyPem = ephemeralKeyStore.get(STATE) ?: error("No ephemeral encryption key stored for $STATE"),
         presentationRequestBuilder = presentationRequestBuilder,
         walletRequest = RequestParametersFrom.IsoMdocDcApi(
             parameters = RequestParametersFrom.IsoMdocDcApi.IsoMdocRequestWrapper(isoRequest),
@@ -372,7 +374,8 @@ private object SecondAtomicAttribute : IsoMdocCredentialScheme {
 
 private data class DcapiFixture(
     val verifier: DcApiVerifier,
-    val verifierKey: EphemeralKeyWithoutCert,
+    /** The ephemeral encryption key the verifier created for the request under [STATE], PKCS#8 PEM encoded. */
+    val verifierKeyPem: String,
     val presentationRequestBuilder: CredentialPresentationRequestBuilder,
     val walletRequest: RequestParametersFrom.IsoMdocDcApi,
 )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/JarmTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/JarmTest.kt
@@ -30,6 +30,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.runBlocking
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/JarmTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/JarmTest.kt
@@ -1,12 +1,17 @@
 package at.asitplus.wallet.lib.openid
 
+import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.RelyingPartyMetadata
 import at.asitplus.openid.dcql.DCQLClaimsPathPointer
+import at.asitplus.signum.indispensable.josef.JsonWebKey
+import at.asitplus.signum.indispensable.josef.JweAlgorithm
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.wallet.lib.DefaultNonceService
 import at.asitplus.wallet.lib.RequestOptionsCredential
+import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.HolderAgent
 import at.asitplus.wallet.lib.agent.IssuerAgent
@@ -15,11 +20,17 @@ import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.rfc3986.toUri
+import at.asitplus.wallet.lib.extensions.getEncryptionTargetKey
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
+import at.asitplus.wallet.lib.oidvci.formUrlEncode
 import at.asitplus.wallet.lib.openid.DummyCredentialDataProvider.issueAndStorePlainJwt
+import at.asitplus.wallet.lib.utils.DefaultMapStore
 import com.benasher44.uuid.uuid4
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.runBlocking
 
 val JarmTest by matrixSuite {
@@ -79,5 +90,57 @@ val JarmTest by matrixSuite {
                 it.holderOid4vp.createAuthnResponse(joseCompliantSerializer.encodeToString(invalidReq)).getOrThrow()
             }
         }
+
+        /**
+         * OpenID4VC HAIP: *"Verifiers MUST supply ephemeral encryption public keys specific to each Authorization
+         * Request passed via client metadata as specified in Section 8.3 of OpenID4VP"*.
+         */
+        "every request carries its own ephemeral encryption key" {
+            val first = it.verifierOid4vp.createPlainAuthnRequest(directPostJwtOptions()).encryptionKey()
+            val second = it.verifierOid4vp.createPlainAuthnRequest(directPostJwtOptions()).encryptionKey()
+
+            first.publicKeyUse shouldBe "enc"
+            first.algorithm shouldBe JweAlgorithm.ECDH_ES
+            first.keyId.shouldNotBeNull() shouldNotBe second.keyId.shouldNotBeNull()
+            first.shouldNotBe(second)
+        }
+
+        "a response is validated by another instance sharing the ephemeral key store" {
+            // deployments running in a cluster do not receive the response on the instance that created the
+            // request, so the ephemeral encryption key has to be synchronized along with the request itself
+            val nonceService = DefaultNonceService()
+            val stateToAuthnRequestStore = DefaultMapStore<String, AuthenticationRequestParameters>()
+            val ephemeralEncryptionKeyService = EphemeralEncryptionKeyService()
+            val newInstance = {
+                OpenId4VpVerifier(
+                    keyMaterial = it.verifierKeyMaterial,
+                    clientIdScheme = ClientIdScheme.RedirectUri(it.clientId),
+                    nonceService = nonceService,
+                    stateToAuthnRequestStore = stateToAuthnRequestStore,
+                    ephemeralEncryptionKeyService = ephemeralEncryptionKeyService,
+                )
+            }
+
+            val authnRequest = newInstance().createPlainAuthnRequest(directPostJwtOptions())
+            val authnResponse = it.holderOid4vp
+                .createAuthnResponse(joseCompliantSerializer.encodeToString(authnRequest)).getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Post>()
+
+            newInstance().validateAuthnResponse(authnResponse.params.formUrlEncode()).getOrThrow()
+                .vpTokenValidationResult.shouldNotBeNull().getOrThrow()
+        }
     }
 }
+
+/** Asks for the plain JWT credential the fixture's holder actually holds, so that the flow can complete. */
+private fun directPostJwtOptions() = OpenId4VpRequestOptions(
+    presentationRequest = CredentialPresentationRequestBuilder(
+        RequestOptionsCredential(AtomicAttribute2023)
+    ).toDCQLRequest(),
+    responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
+    responseUrl = "https://example.com/${uuid4()}",
+)
+
+/** The key the wallet is supposed to encrypt its response to, i.e. the one from this request's client metadata. */
+private fun AuthenticationRequestParameters.encryptionKey(): JsonWebKey =
+    clientMetadata.shouldNotBeNull().jsonWebKeySet.shouldNotBeNull().keys.getEncryptionTargetKey().shouldNotBeNull()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpIsoProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpIsoProtocolTest.kt
@@ -57,7 +57,6 @@ val OpenId4VpIsoProtocolTest by matrixSuite {
                 val holderAgent = agent
                 val verifierOid4vp = OpenId4VpVerifier(
                     keyMaterial = verifierKeyMaterial,
-                    decryptionKeyMaterial = verifierKeyMaterial,
                     clientIdScheme = ClientIdScheme.RedirectUri(clientId),
                     //nonceService = FixedNonceService(),
                 )

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/EphemeralEncryptionKeyService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/EphemeralEncryptionKeyService.kt
@@ -1,0 +1,64 @@
+package at.asitplus.wallet.lib.agent
+
+import at.asitplus.signum.indispensable.CryptoPrivateKey
+import at.asitplus.signum.indispensable.SecretExposure
+import at.asitplus.signum.indispensable.SignatureAlgorithm
+import at.asitplus.signum.indispensable.asn1.encodeToPEM
+import at.asitplus.signum.indispensable.pki.X509Certificate
+import at.asitplus.signum.supreme.sign.Signer
+import at.asitplus.signum.supreme.sign.signerFor
+import at.asitplus.wallet.lib.utils.DefaultMapStore
+import at.asitplus.wallet.lib.utils.MapStore
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Creates one ephemeral encryption key for every authentication request, and recovers it once the response to that
+ * request comes in, as required by
+ * [OpenID4VP 1.0, 8.3](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-encrypted-responses),
+ * and by
+ * [OpenID4VC HAIP 1.0](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0-final.html).
+ *
+ * Private keys are kept PKCS#8-PEM-encoded in [identifierToPrivateKeyPem], so that deployments running several
+ * instances can synchronize them between the instance that created the request and the instance receiving the response,
+ * by passing the same sort of [MapStore] implementation they use for the other stores of e.g. `OpenId4VpVerifier`.
+ * Note that keys of abandoned flows are never consumed, so entries
+ * need to be evicted eventually, which [DefaultMapStore] does after its `lifetime`.
+ */
+class EphemeralEncryptionKeyService(
+    private val identifierToPrivateKeyPem: MapStore<String, String> = DefaultMapStore(),
+) {
+
+    /**
+     * Creates and stores a fresh key, to be advertised in the client metadata of a single authentication request.
+     * Pass an [identifier] to look the key up by something other than its own random [KeyMaterial.identifier],
+     * e.g. by the `state` of the request, when the response won't carry a key identifier.
+     */
+    @OptIn(SecretExposure::class)
+    suspend fun createKey(identifier: String? = null): KeyMaterial =
+        (identifier?.let { EphemeralKeyWithoutCert(customKeyId = it) } ?: EphemeralKeyWithoutCert()).also {
+            identifierToPrivateKeyPem.put(
+                it.identifier,
+                it.key.exportPrivateKey().getOrThrow().encodeToPEM().getOrThrow()
+            )
+        }
+
+    /**
+     * Loads and removes the key stored under [identifier], i.e. every key decrypts at most one response, matching the
+     * single-use lifecycle of the authentication request it belongs to.
+     */
+    @Throws(IllegalArgumentException::class, CancellationException::class)
+    suspend fun consumeKey(identifier: String): KeyMaterial? =
+        identifierToPrivateKeyPem.remove(identifier)?.let { pem ->
+            val privateKey = CryptoPrivateKey.decodeFromPem(pem).getOrThrow()
+            require(privateKey is CryptoPrivateKey.EC.WithPublicKey) { "Not an EC private key: $identifier" }
+            EphemeralEncryptionKey(
+                signer = SignatureAlgorithm.ECDSAwithSHA256.signerFor(privateKey).getOrThrow(),
+                identifier = identifier,
+            )
+        }
+}
+
+/** Key material recovered from [EphemeralEncryptionKeyService], used for key agreement only. */
+private class EphemeralEncryptionKey(signer: Signer, identifier: String) : SignerBasedKeyMaterial(signer, identifier) {
+    override suspend fun getCertificate(): X509Certificate? = null
+}

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/EphemeralEncryptionKeyService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/EphemeralEncryptionKeyService.kt
@@ -23,6 +23,10 @@ import kotlin.coroutines.cancellation.CancellationException
  * by passing the same sort of [MapStore] implementation they use for the other stores of e.g. `OpenId4VpVerifier`.
  * Note that keys of abandoned flows are never consumed, so entries
  * need to be evicted eventually, which [DefaultMapStore] does after its `lifetime`.
+ * Attackers might extract the `kid` from a request sent to the other party,
+ * and trick us into decrypting a forged response with that `kid` in the header,
+ * leading us into consuming the key, and burning that session for the righteous party.
+ * We've decided to take this risk, as keys are, per definition, short-lived and used for one request/response only.
  */
 class EphemeralEncryptionKeyService(
     private val identifierToPrivateKeyPem: MapStore<String, String> = DefaultMapStore(),
@@ -48,17 +52,20 @@ class EphemeralEncryptionKeyService(
      */
     @Throws(IllegalArgumentException::class, CancellationException::class)
     suspend fun consumeKey(identifier: String): KeyMaterial? =
-        identifierToPrivateKeyPem.remove(identifier)?.let { pem ->
-            val privateKey = CryptoPrivateKey.decodeFromPem(pem).getOrThrow()
-            require(privateKey is CryptoPrivateKey.EC.WithPublicKey) { "Not an EC private key: $identifier" }
-            EphemeralEncryptionKey(
-                signer = SignatureAlgorithm.ECDSAwithSHA256.signerFor(privateKey).getOrThrow(),
-                identifier = identifier,
-            )
-        }
+        identifierToPrivateKeyPem.remove(identifier)?.toKeyMaterial(identifier)
+
+    private fun String.toKeyMaterial(identifier: String): KeyMaterial {
+        val privateKey = CryptoPrivateKey.decodeFromPem(this).getOrThrow()
+        require(privateKey is CryptoPrivateKey.EC.WithPublicKey) { "Not an EC private key: $identifier" }
+        return EphemeralEncryptionKey(
+            signer = SignatureAlgorithm.ECDSAwithSHA256.signerFor(privateKey).getOrThrow(),
+            identifier = identifier,
+        )
+    }
 }
 
 /** Key material recovered from [EphemeralEncryptionKeyService], used for key agreement only. */
 private class EphemeralEncryptionKey(signer: Signer, identifier: String) : SignerBasedKeyMaterial(signer, identifier) {
     override suspend fun getCertificate(): X509Certificate? = null
 }
+

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
@@ -49,6 +49,7 @@ import at.asitplus.signum.supreme.sign.Signer
 import at.asitplus.signum.supreme.sign.Verifier
 import at.asitplus.signum.supreme.symmetric.decrypt
 import at.asitplus.signum.supreme.symmetric.encrypt
+import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.PublishedKeyMaterial
 import at.asitplus.wallet.lib.agent.TrustedCertificates
@@ -453,6 +454,25 @@ class DecryptJwe(
         JweUtils.decryptJwe(keyMaterial, header, jweObject)
     }
 
+}
+
+/**
+ * Decrypts JWE payloads with the ephemeral key referenced by the JWE's `kid` header, as per
+ * [OpenID4VP 1.0, 8.3](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-encrypted-responses).
+ */
+class DecryptJweWithEphemeralKey(
+    private val ephemeralEncryptionKeyService: EphemeralEncryptionKeyService,
+    /** Long-lived key to fall back to, for client identifier schemes without client metadata in the request. */
+    private val fallbackKeyMaterial: KeyMaterial? = null,
+) : DecryptJweFun {
+    override suspend operator fun invoke(
+        jweObject: JweEncrypted,
+    ) = catching {
+        val keyMaterial = jweObject.header.keyId?.let { ephemeralEncryptionKeyService.consumeKey(it) }
+            ?: fallbackKeyMaterial
+            ?: throw IllegalArgumentException("No decryption key for kid ${jweObject.header.keyId}")
+        DecryptJwe(keyMaterial)(jweObject).getOrThrow()
+    }
 }
 
 /**

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
@@ -468,8 +468,9 @@ class DecryptJweWithEphemeralKey(
     override suspend operator fun invoke(
         jweObject: JweEncrypted,
     ) = catching {
-        val keyMaterial = jweObject.header.keyId?.let { ephemeralEncryptionKeyService.consumeKey(it) }
-            ?: fallbackKeyMaterial
+        val keyId = jweObject.header.keyId
+        val keyMaterial = keyId?.let { ephemeralEncryptionKeyService.consumeKey(it) }
+            ?: fallbackKeyMaterial?.takeIf { keyId == null || it.identifier == keyId }
             ?: throw IllegalArgumentException("No decryption key for kid ${jweObject.header.keyId}")
         DecryptJwe(keyMaterial)(jweObject).getOrThrow()
     }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/EphemeralEncryptionKeyServiceTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/EphemeralEncryptionKeyServiceTest.kt
@@ -1,0 +1,55 @@
+package at.asitplus.wallet.lib.agent
+
+import at.asitplus.signum.indispensable.CryptoPublicKey
+import at.asitplus.signum.supreme.agree.keyAgreement
+import at.asitplus.signum.supreme.sign.Signer
+import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.wallet.lib.utils.DefaultMapStore
+import com.benasher44.uuid.uuid4
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+val EphemeralEncryptionKeyServiceTest by matrixSuite {
+
+    test("keys are synchronized through the store, and consumable exactly once") {
+        // the instance creating the authentication request is not the one receiving the response, e.g. in a cluster
+        val store = DefaultMapStore<String, String>()
+        val requestSide = EphemeralEncryptionKeyService(store)
+        val responseSide = EphemeralEncryptionKeyService(store)
+
+        val created = requestSide.createKey()
+        val recovered = responseSide.consumeKey(created.identifier).shouldNotBeNull()
+
+        recovered.identifier shouldBe created.identifier
+        recovered.publicKey shouldBe created.publicKey
+        // single-use, matching the lifecycle of the request the key belongs to
+        responseSide.consumeKey(created.identifier).shouldBeNull()
+    }
+
+    test("every request gets its own key, optionally identified by something else than its own key id") {
+        val service = EphemeralEncryptionKeyService()
+
+        service.createKey().publicKey shouldNotBe service.createKey().publicKey
+
+        val state = "state-${uuid4()}"
+        service.createKey(state).identifier shouldBe state
+        service.consumeKey(state).shouldNotBeNull().identifier shouldBe state
+        service.consumeKey("never issued").shouldBeNull()
+    }
+
+    test("a recovered key agrees on the same secret as the key that was created") {
+        val store = DefaultMapStore<String, String>()
+        val created = EphemeralEncryptionKeyService(store).createKey()
+        val recovered = EphemeralEncryptionKeyService(store).consumeKey(created.identifier).shouldNotBeNull()
+
+        val wallet = EphemeralKeyWithoutCert()
+        val secretFromRecoveredKey = (recovered.getUnderLyingSigner() as Signer.ECDSA)
+            .keyAgreement(wallet.publicKey as CryptoPublicKey.EC).getOrThrow()
+        val secretFromWalletSide = (wallet.getUnderLyingSigner() as Signer.ECDSA)
+            .keyAgreement(created.publicKey as CryptoPublicKey.EC).getOrThrow()
+
+        secretFromRecoveredKey shouldBe secretFromWalletSide
+    }
+}


### PR DESCRIPTION
Asserts conformance to [HAIP 1.0](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0-final.html#section-5-2.6):
> Verifiers MUST supply ephemeral encryption public keys specific to each Authorization Request passed via client metadata as specified in Section 8.3 of [[OIDF.OID4VP](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-encrypted-responses)].