### PR TITLE
OpenID4VP: Support fetching encrypted authn requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ Release 8.0.0 (unreleased):
     - In `OpenId4VpVerifier` and `DcApiVerifier` the `decryptionKeyMaterial` is now nullable and defaults to `null`: it is only advertised in `metadataWithEncryption`, i.e. for client identifier schemes that distribute it out-of-band, which is not conformant to HAIP. `metadata` carries no key to encrypt responses to at all
     - In `OpenId4VpVerifier` and `DcApiVerifier` remove the `decryptJwe` function from the list of constructor arguments
     - Consume the request's nonce when validating an authentication response, regardless of the validation result, i.e. authentication responses are not retryable
+    - Support encrypted authorization requests as per OpenID4VP 1.0, Section 5.10: pass an `ephemeralEncryptionKeyService` to `OpenId4VpHolder` to advertise one ephemeral ECDH-ES key per request in `wallet_metadata.jwks` when fetching the request object with `request_uri_method=post`, and to decrypt the JWE the verifier returns. Keys are single-use, and consumed only after authenticated decryption
+    - Add `jwks`, `request_object_encryption_alg_values_supported` and `request_object_encryption_enc_values_supported` to `OAuth2AuthorizationServerMetadata`
+    - `OpenId4VpVerifier` encrypts the signed request object served at `request_uri` whenever the wallet passed a suitable encryption key in `wallet_metadata`, using ECDH-ES with the wallet's preferred `enc`, falling back to `A128GCM`
+    - Fix decoding of form-encoded parameters whose value is a JSON string, e.g. `wallet_metadata` posted to the request URI endpoint: these were parsed as JSON objects and thus failed to deserialize
+    - Send `wallet_metadata` and `wallet_nonce` only when fetching the request object with `request_uri_method=post`, which is the only channel OpenID4VP 1.0, Section 5.10 defines for them: they were previously appended as query parameters on `get` too
+    - Terminate request processing if the request object does not carry back the `wallet_nonce` we sent, as required by OpenID4VP 1.0, Section 5.10.1: a request object omitting the claim entirely was previously accepted
 - OpenID for Verifiable Credential Issuance:
     - Rework validation of key attestation statements
     - Make sure a `nonce` provided by the credential issuer can only be used for one request to the credential endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,13 @@ Release 8.0.0 (unreleased):
     - In `OpenId4VpVerifier` and `DcApiVerifier` the `decryptionKeyMaterial` is now nullable and defaults to `null`: it is only advertised in `metadataWithEncryption`, i.e. for client identifier schemes that distribute it out-of-band, which is not conformant to HAIP. `metadata` carries no key to encrypt responses to at all
     - In `OpenId4VpVerifier` and `DcApiVerifier` remove the `decryptJwe` function from the list of constructor arguments
     - Consume the request's nonce when validating an authentication response, regardless of the validation result, i.e. authentication responses are not retryable
-    - Support encrypted authorization requests as per OpenID4VP 1.0, Section 5.10: pass an `ephemeralEncryptionKeyService` to `OpenId4VpHolder` to advertise one ephemeral ECDH-ES key per request in `wallet_metadata.jwks` when fetching the request object with `request_uri_method=post`, and to decrypt the JWE the verifier returns. Keys are single-use, and consumed only after authenticated decryption
+    - Support requesting and serving encrypted authorization requests as per OpenID4VP 1.0, Section 5.10
     - Add `jwks`, `request_object_encryption_alg_values_supported` and `request_object_encryption_enc_values_supported` to `OAuth2AuthorizationServerMetadata`
-    - `OpenId4VpVerifier` encrypts the signed request object served at `request_uri` whenever the wallet passed a suitable encryption key in `wallet_metadata`, using ECDH-ES with the wallet's preferred `enc`, falling back to `A128GCM`
-    - Fix decoding of form-encoded parameters whose value is a JSON string, e.g. `wallet_metadata` posted to the request URI endpoint: these were parsed as JSON objects and thus failed to deserialize
-    - Send `wallet_metadata` and `wallet_nonce` only when fetching the request object with `request_uri_method=post`, which is the only channel OpenID4VP 1.0, Section 5.10 defines for them: they were previously appended as query parameters on `get` too
-    - Terminate request processing if the request object does not carry back the `wallet_nonce` we sent, as required by OpenID4VP 1.0, Section 5.10.1: a request object omitting the claim entirely was previously accepted
+    - Fix decoding of form-encoded parameters whose value is a JSON string, e.g. `wallet_metadata` posted to the request URI endpoint
+    - Send `wallet_metadata` and `wallet_nonce` only when fetching the request object with `request_uri_method=post`
+    - Terminate request processing if the request object does not carry back the `wallet_nonce` we sent, as required by OpenID4VP 1.0, Section 5.10.1
+    - Pass `requireEncryptedRequests = true` to `OpenId4VpHolder` to reject a plain request object served at a `request_uri` fetched with POST
+    - Add `decryptedFrom` to `RequestParametersFrom.Jws` and `RequestParametersFrom.Json`, holding the header of the JWE a request was decrypted from, and `requestWasEncrypted` to `AuthorizationResponsePreparationState`
 - OpenID for Verifiable Credential Issuance:
     - Rework validation of key attestation statements
     - Make sure a `nonce` provided by the credential issuer can only be used for one request to the credential endpoint

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OAuth2AuthorizationServerMetadata.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/OAuth2AuthorizationServerMetadata.kt
@@ -1,6 +1,9 @@
 package at.asitplus.openid
 
 import at.asitplus.signum.indispensable.josef.JsonWebAlgorithm
+import at.asitplus.signum.indispensable.josef.JsonWebKeySet
+import at.asitplus.signum.indispensable.josef.JweAlgorithm
+import at.asitplus.signum.indispensable.josef.JweEncryption
 import at.asitplus.signum.indispensable.josef.JwsAlgorithm
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -84,6 +87,14 @@ data class OAuth2AuthorizationServerMetadata(
      */
     @SerialName("jwks_uri")
     val jsonWebKeySetUrl: String? = null,
+
+    /**
+     * OpenID4VP: A JSON Web Key Set, as defined in RFC7591, that contains one or more public keys, such as those used
+     * by the Wallet as an input to a key agreement that may be used for encryption of the Authorization Request, see
+     * [OpenID4VP 1.0, 5.10](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-request-uri-method-post).
+     */
+    @SerialName("jwks")
+    val jsonWebKeySet: JsonWebKeySet? = null,
 
     /**
      * OPTIONAL.  URL of the authorization server's OAuth 2.0 Dynamic
@@ -184,6 +195,22 @@ data class OAuth2AuthorizationServerMetadata(
      */
     @SerialName("request_object_signing_alg_values_supported")
     val requestObjectSigningAlgorithmsSupportedStrings: Set<String>? = null,
+
+    /**
+     * OIDC Discovery: OPTIONAL. JSON array containing a list of the JWE encryption algorithms (`alg` values) supported
+     * by the OP for Request Objects. These algorithms are used both when the Request Object is passed by value and
+     * when it is passed by reference.
+     */
+    @SerialName("request_object_encryption_alg_values_supported")
+    val requestObjectEncryptionAlgValuesSupportedStrings: Set<String>? = null,
+
+    /**
+     * OIDC Discovery: OPTIONAL. JSON array containing a list of the JWE encryption algorithms (`enc` values) supported
+     * by the OP for Request Objects. These algorithms are used both when the Request Object is passed by value and
+     * when it is passed by reference.
+     */
+    @SerialName("request_object_encryption_enc_values_supported")
+    val requestObjectEncryptionEncValuesSupportedStrings: Set<String>? = null,
 
     /**
      * RFC 9101: Indicates where authorization request needs to be protected as Request Object and provided through
@@ -428,6 +455,24 @@ data class OAuth2AuthorizationServerMetadata(
     @Transient
     val requestObjectSigningAlgorithmsSupported: Set<JwsAlgorithm>? = requestObjectSigningAlgorithmsSupportedStrings
         ?.mapNotNull { it.toJwsAlgorithm() }?.toSet()
+
+    /**
+     * OIDC Discovery: OPTIONAL. JSON array containing a list of the JWE encryption algorithms (`alg` values) supported
+     * by the OP for Request Objects.
+     */
+    @Transient
+    val requestObjectEncryptionAlgValuesSupported: Set<JweAlgorithm>? =
+        requestObjectEncryptionAlgValuesSupportedStrings
+            ?.mapNotNull { s -> JweAlgorithm.entries.firstOrNull { it.identifier == s } }?.toSet()
+
+    /**
+     * OIDC Discovery: OPTIONAL. JSON array containing a list of the JWE encryption algorithms (`enc` values) supported
+     * by the OP for Request Objects.
+     */
+    @Transient
+    val requestObjectEncryptionEncValuesSupported: Set<JweEncryption>? =
+        requestObjectEncryptionEncValuesSupportedStrings
+            ?.mapNotNull { s -> JweEncryption.entries.firstOrNull { it.identifier == s } }?.toSet()
 
     /**
      * RFC 9449: A JSON array containing a list of the JWS alg values (from the `IANA.JOSE.ALGS` registry) supported

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
@@ -4,6 +4,7 @@ import at.asitplus.dcapi.request.ExchangeProtocolIdentifier
 import at.asitplus.dcapi.request.IsoMdocRequest
 import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
 import at.asitplus.signum.indispensable.josef.JWS
+import at.asitplus.signum.indispensable.josef.JweHeader
 import at.asitplus.signum.indispensable.josef.JwsCompactStringSerializer
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.JwsGeneral
@@ -25,6 +26,9 @@ import kotlin.jvm.JvmOverloads
 sealed class RequestParametersFrom<S : RequestParameters> {
 
     abstract val parameters: S
+
+    /** JWE header this request was decrypted from, or `null` if it did not arrive encrypted, see OpenID4VP 1.0, 5.10 */
+    open val decryptedFrom: JweHeader? get() = null
 
     /**
      * Common ancestor for request parameters that are represented with a JWS signature
@@ -48,7 +52,6 @@ sealed class RequestParametersFrom<S : RequestParameters> {
 
         @SerialName(SerialNames.CALLING_ORIGIN)
         val callingOrigin: String
-
         val protocol: ExchangeProtocolIdentifier
 
         object SerialNames {
@@ -67,6 +70,8 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         override val parameters: T,
         @SerialName(SerialNames.PARENT)
         val parent: Url? = null,
+        @SerialName(SerialNames.DECRYPTED_FROM)
+        override val decryptedFrom: JweHeader? = null,
     ) : RequestParametersSigned<T>() {
         override val jwsTyped get() = JwsTyped(jws, parameters)
     }
@@ -196,6 +201,8 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         override val parameters: T,
         @SerialName(SerialNames.PARENT)
         val parent: Url? = null,
+        @SerialName(SerialNames.DECRYPTED_FROM)
+        override val decryptedFrom: JweHeader? = null,
     ) : RequestParametersFrom<T>()
 
     object SerialNames {
@@ -212,6 +219,7 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         const val URL = "url"
         const val PARENT = "parent"
         const val PARAMETERS = "parameters"
+        const val DECRYPTED_FROM = "decryptedFrom"
     }
 
 }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFromSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFromSerializer.kt
@@ -1,6 +1,7 @@
 package at.asitplus.openid
 
 import at.asitplus.dcapi.request.ExchangeProtocolIdentifier
+import at.asitplus.openid.RequestParametersFrom.SerialNames.DECRYPTED_FROM
 import at.asitplus.openid.RequestParametersFrom.SerialNames.JSON_STRING
 import at.asitplus.openid.RequestParametersFrom.SerialNames.JWS
 import at.asitplus.openid.RequestParametersFrom.SerialNames.PARAMETERS
@@ -10,6 +11,7 @@ import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
 import at.asitplus.signum.indispensable.josef.JWS
 import at.asitplus.signum.indispensable.josef.JwsCompact
 import at.asitplus.signum.indispensable.josef.JwsFlattened
+import at.asitplus.signum.indispensable.josef.JweHeader
 import at.asitplus.signum.indispensable.josef.JwsGeneral
 import at.asitplus.signum.indispensable.josef.JwsTyped
 import io.ktor.http.*
@@ -61,6 +63,8 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
     val callingPackageName: String? = null,
     @SerialName(CALLING_ORIGIN)
     val callingOrigin: String? = null,
+    @SerialName(DECRYPTED_FROM)
+    val decryptedFrom: JweHeader? = null,
 ) {
     constructor(value: RequestParametersFrom<T>) : this(
         parameters = value.parameters,
@@ -91,6 +95,7 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
         credentialIds = (value as? RequestParametersFrom.DcApiRequest)?.credentialIds,
         callingPackageName = (value as? RequestParametersFrom.DcApiRequest)?.callingPackageName,
         callingOrigin = (value as? RequestParametersFrom.DcApiRequest)?.callingOrigin,
+        decryptedFrom = value.decryptedFrom,
     )
 
     fun toRequestParametersFrom(): RequestParametersFrom<T> = when {
@@ -135,6 +140,7 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
                 jsonString = jsonString,
                 parameters = parameters,
                 parent = parent,
+                decryptedFrom = decryptedFrom,
             )
 
         jws != null ->
@@ -142,6 +148,7 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
                 jws = jws,
                 parameters = parameters,
                 parent = parent,
+                decryptedFrom = decryptedFrom,
             )
 
         url != null ->

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/WalletMetadataEncryptionTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/WalletMetadataEncryptionTest.kt
@@ -1,0 +1,71 @@
+package at.asitplus.openid
+
+import at.asitplus.signum.indispensable.josef.JsonWebKey
+import at.asitplus.signum.indispensable.josef.JsonWebKeySet
+import at.asitplus.signum.indispensable.josef.JweAlgorithm
+import at.asitplus.signum.indispensable.josef.JweEncryption
+import at.asitplus.signum.indispensable.josef.JwkType
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.testballoon.matrix.matrixSuite
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * Wallet metadata parameters for encrypted authorization requests, as per
+ * [OpenID4VP 1.0, 5.10](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-request-uri-method-post).
+ */
+val WalletMetadataEncryptionTest by matrixSuite {
+
+    test("serializes and parses back") {
+        val metadata = OAuth2AuthorizationServerMetadata(
+            issuer = "https://wallet.example.com",
+            jsonWebKeySet = JsonWebKeySet(
+                listOf(
+                    JsonWebKey(
+                        type = JwkType.EC,
+                        keyId = "some-key-id",
+                        algorithm = JweAlgorithm.ECDH_ES,
+                        publicKeyUse = "enc",
+                    )
+                )
+            ),
+            requestObjectEncryptionAlgValuesSupportedStrings = setOf(JweAlgorithm.ECDH_ES.identifier),
+            requestObjectEncryptionEncValuesSupportedStrings = setOf(
+                JweEncryption.A128GCM.identifier,
+                JweEncryption.A256GCM.identifier,
+            ),
+        )
+
+        val serialized = joseCompliantSerializer.encodeToString(metadata)
+        serialized shouldContain "\"jwks\""
+        serialized shouldContain "\"request_object_encryption_alg_values_supported\""
+        serialized shouldContain "\"request_object_encryption_enc_values_supported\""
+
+        joseCompliantSerializer.decodeFromString<OAuth2AuthorizationServerMetadata>(serialized).apply {
+            jsonWebKeySet.shouldNotBeNull().keys.first().keyId shouldBe "some-key-id"
+            requestObjectEncryptionAlgValuesSupported shouldBe setOf(JweAlgorithm.ECDH_ES)
+            requestObjectEncryptionEncValuesSupported shouldBe
+                    setOf(JweEncryption.A128GCM, JweEncryption.A256GCM)
+        }
+    }
+
+    test("unset parameters resolve to null") {
+        OAuth2AuthorizationServerMetadata(issuer = "https://wallet.example.com").apply {
+            jsonWebKeySet shouldBe null
+            requestObjectEncryptionAlgValuesSupported shouldBe null
+            requestObjectEncryptionEncValuesSupported shouldBe null
+        }
+    }
+
+    test("unknown algorithms are dropped") {
+        OAuth2AuthorizationServerMetadata(
+            issuer = "https://wallet.example.com",
+            requestObjectEncryptionAlgValuesSupportedStrings = setOf("NOT-AN-ALG"),
+            requestObjectEncryptionEncValuesSupportedStrings = setOf("NOT-AN-ENC", JweEncryption.A128GCM.identifier),
+        ).apply {
+            requestObjectEncryptionAlgValuesSupported shouldBe emptySet()
+            requestObjectEncryptionEncValuesSupported shouldBe setOf(JweEncryption.A128GCM)
+        }
+    }
+}

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWallet.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWallet.kt
@@ -60,6 +60,8 @@ class OpenId4VpWallet(
     relyingPartyTrust: Set<RelyingPartyTrust>? = null,
     /** Set to accept encrypted authorization requests, to be passed on to [OpenId4VpHolder]. */
     ephemeralEncryptionKeyService: EphemeralEncryptionKeyService? = null,
+    /** Set to reject plain request objects fetched with POST, to be passed on to [OpenId4VpHolder]. */
+    requireEncryptedRequests: Boolean = false,
 ) {
 
     sealed interface AuthenticationResult
@@ -108,6 +110,7 @@ class OpenId4VpWallet(
         relyingPartyTrust = relyingPartyTrust,
         allowedDcApiOriginSchemes = allowedDcApiOriginSchemes,
         ephemeralEncryptionKeyService = ephemeralEncryptionKeyService,
+        requireEncryptedRequests = requireEncryptedRequests,
     )
 
     val iso180137AnnexCHolder = Iso180137AnnexCHolder(

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWallet.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWallet.kt
@@ -6,6 +6,7 @@ import at.asitplus.catchingUnwrapped
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.supreme.UserInitiatedCancellationReason
+import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
 import at.asitplus.wallet.lib.agent.HolderAgent
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.RandomSource
@@ -57,6 +58,8 @@ class OpenId4VpWallet(
     },
     /** How to establish trust in the relying party, to be passed on to [OpenId4VpHolder]. */
     relyingPartyTrust: Set<RelyingPartyTrust>? = null,
+    /** Set to accept encrypted authorization requests, to be passed on to [OpenId4VpHolder]. */
+    ephemeralEncryptionKeyService: EphemeralEncryptionKeyService? = null,
 ) {
 
     sealed interface AuthenticationResult
@@ -104,6 +107,7 @@ class OpenId4VpWallet(
         randomSource = randomSource,
         relyingPartyTrust = relyingPartyTrust,
         allowedDcApiOriginSchemes = allowedDcApiOriginSchemes,
+        ephemeralEncryptionKeyService = ephemeralEncryptionKeyService,
     )
 
     val iso180137AnnexCHolder = Iso180137AnnexCHolder(

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
@@ -9,6 +9,7 @@ import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.openid.OidcUserInfo
 import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.openid.OpenIdConstants.ResponseMode
+import at.asitplus.openid.JarRequestParameters
 import at.asitplus.openid.RequestObjectParameters
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.openid.dcql.DCQLClaimsPathPointer
@@ -36,6 +37,7 @@ import at.asitplus.wallet.lib.agent.CredentialToBeIssued
 import at.asitplus.wallet.lib.agent.DCQLMatchingResult
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
 import at.asitplus.wallet.lib.agent.HolderAgent
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.RandomSource
@@ -112,6 +114,9 @@ val OpenId4VpWalletTest by matrixSuite {
                 responseMode: ResponseMode,
                 clientId: String,
                 storeCredentials: Boolean = true,
+                requestUriMethod: JarRequestParameters.RequestUriMethod =
+                    JarRequestParameters.RequestUriMethod.GET,
+                ephemeralEncryptionKeyService: EphemeralEncryptionKeyService? = null,
             ) {
                 val requestOptions = OpenId4VpRequestOptions(
                     presentationRequest = CredentialPresentationRequestBuilder(
@@ -128,16 +133,20 @@ val OpenId4VpWalletTest by matrixSuite {
                 if (storeCredentials) {
                     storeMockCredentials(scheme, representation, attributes)
                 }
-                setupRelyingPartyService(clientId, requestOptions) {
+                setupRelyingPartyService(clientId, requestOptions, requestUriMethod) {
                     verifyReceivedAttributes(it, attributes)
                 }
-                setupWallet(this.mockEngine)
+                setupWallet(this.mockEngine, ephemeralEncryptionKeyService)
             }
 
-            fun setupWallet(engine: HttpClientEngine) = OpenId4VpWallet(
+            fun setupWallet(
+                engine: HttpClientEngine,
+                ephemeralEncryptionKeyService: EphemeralEncryptionKeyService? = null,
+            ) = OpenId4VpWallet(
                 engine = engine,
                 keyMaterial = keyMaterial,
                 holderAgent = holderAgent,
+                ephemeralEncryptionKeyService = ephemeralEncryptionKeyService,
             ).also { this.wallet = it }
 
             fun verifyReceivedAttributes(
@@ -200,6 +209,8 @@ val OpenId4VpWalletTest by matrixSuite {
             suspend fun setupRelyingPartyService(
                 clientId: String,
                 requestOptions: OpenId4VpRequestOptions,
+                requestUriMethod: JarRequestParameters.RequestUriMethod =
+                    JarRequestParameters.RequestUriMethod.GET,
                 validate: (KmmResult<AuthnResponseResult>) -> Unit,
             ) {
                 val requestEndpointPath = "/request/${uuid4()}"
@@ -212,7 +223,8 @@ val OpenId4VpWalletTest by matrixSuite {
                     requestOptions.copy(responseUrl = responseEndpointPath),
                     CreationOptions.SignedRequestByReference(
                         "http://wallet.example.com/",
-                        "http://rp.example.com$requestEndpointPath"
+                        "http://rp.example.com$requestEndpointPath",
+                        requestUriMethod,
                     )
                 ).getOrThrow()
                 jar.shouldNotBeNull()
@@ -267,6 +279,28 @@ val OpenId4VpWalletTest by matrixSuite {
 
             val state = it.wallet.startAuthorizationResponsePreparation(it.url).getOrThrow()
             // sends the response to the mock RP, which calls verifyReceivedAttributes, which unlocks the latch
+            it.wallet.finalizeAuthorizationResponse(state).getOrThrow()
+                .shouldBeInstanceOf<OpenId4VpWallet.AuthenticationSuccess>()
+                .redirectUri?.let { uri -> HttpClient(it.mockEngine).get(uri) }
+
+            assertPresentation(it.countdownLatch)
+        }
+
+        test("presentEuPidCredentialSdJwtEncryptedRequestByPost") {
+            val euPidSdJwtScheme = AttributeIndex.resolveIdentifier(EU_PID_SD_JWT_VCT, SD_JWT)
+            it.setup(
+                scheme = euPidSdJwtScheme,
+                representation = SD_JWT,
+                attributes = mapOf(
+                    DCQLClaimsPathPointer(EuPidSdJwtDataElements.FAMILY_NAME) to randomString()
+                ),
+                responseMode = ResponseMode.DirectPost,
+                clientId = uuid4().toString(),
+                requestUriMethod = JarRequestParameters.RequestUriMethod.POST,
+                ephemeralEncryptionKeyService = EphemeralEncryptionKeyService(),
+            )
+
+            val state = it.wallet.startAuthorizationResponsePreparation(it.url).getOrThrow()
             it.wallet.finalizeAuthorizationResponse(state).getOrThrow()
                 .shouldBeInstanceOf<OpenId4VpWallet.AuthenticationSuccess>()
                 .redirectUri?.let { uri -> HttpClient(it.mockEngine).get(uri) }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/SerializerSketch.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/SerializerSketch.kt
@@ -1,9 +1,14 @@
 package at.asitplus.wallet.lib.oidvci
 
+import at.asitplus.catchingUnwrapped
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import io.ktor.http.*
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -15,14 +20,28 @@ import kotlinx.serialization.json.encodeToJsonElement
 typealias Parameters = Map<String, String>
 
 @OptIn(ExperimentalSerializationApi::class)
-inline fun <reified T> Parameters.decode(): T =
+inline fun <reified T> Parameters.decode(): T = json.serializersModule.serializer<T>().descriptor.let { descriptor ->
     json.decodeFromJsonElement<T>(JsonObject(entries.associate { (k, v) ->
-        k to when (v[0]) {
-            '{' -> json.decodeFromString<JsonObject>(v)
-            '[' -> json.decodeFromString<JsonArray>(v)
+        // ponytail: `v[0]` throwing on an empty value is load-bearing: `ResponseParser` relies on it to fall back
+        // from parsing an input as URL to parsing it as POST body
+        k to when {
+            // members declared as strings keep their content verbatim, even if that content happens to be JSON
+            // itself, e.g. `wallet_metadata` of `at.asitplus.openid.RequestObjectParameters`
+            descriptor.isStringElement(k) -> JsonPrimitive(v)
+            v[0] == '{' -> json.decodeFromString<JsonObject>(v)
+            v[0] == '[' -> json.decodeFromString<JsonArray>(v)
             else -> JsonUnquotedLiteral(v)  //no quoted → can be any type for deserializing. requires lenient parsing
         }
     }))
+}
+
+/** Whether the member serialized as [name] is a string, for descriptors that have members at all. */
+@OptIn(ExperimentalSerializationApi::class)
+fun SerialDescriptor.isStringElement(name: String): Boolean = catchingUnwrapped {
+    getElementIndex(name).let {
+        it != CompositeDecoder.UNKNOWN_NAME && getElementDescriptor(it).kind == PrimitiveKind.STRING
+    }
+}.getOrElse { false }
 
 inline fun <reified T> Parameters.decodeFromUrlQuery(): T =
     entries.filter { (k, v) -> k.isNotEmpty() && v.isNotEmpty() }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/SerializerSketch.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/SerializerSketch.kt
@@ -3,37 +3,40 @@ package at.asitplus.wallet.lib.oidvci
 import at.asitplus.catchingUnwrapped
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import io.ktor.http.*
+import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.CompositeDecoder
-import kotlinx.serialization.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.JsonUnquotedLiteral
-import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.serializer
 
 typealias Parameters = Map<String, String>
 
-@OptIn(ExperimentalSerializationApi::class)
-inline fun <reified T> Parameters.decode(): T = json.serializersModule.serializer<T>().descriptor.let { descriptor ->
-    json.decodeFromJsonElement<T>(JsonObject(entries.associate { (k, v) ->
-        // ponytail: `v[0]` throwing on an empty value is load-bearing: `ResponseParser` relies on it to fall back
-        // from parsing an input as URL to parsing it as POST body
-        k to when {
-            // members declared as strings keep their content verbatim, even if that content happens to be JSON
-            // itself, e.g. `wallet_metadata` of `at.asitplus.openid.RequestObjectParameters`
-            descriptor.isStringElement(k) -> JsonPrimitive(v)
-            v[0] == '{' -> json.decodeFromString<JsonObject>(v)
-            v[0] == '[' -> json.decodeFromString<JsonArray>(v)
-            else -> JsonUnquotedLiteral(v)  //no quoted → can be any type for deserializing. requires lenient parsing
-        }
-    }))
-}
+fun <T> Parameters.decode(deserializer: DeserializationStrategy<T>): T =
+    deserializer.descriptor.let { descriptor ->
+        jsonForParameters.decodeFromJsonElement(deserializer, JsonObject(entries.associate { (k, v) ->
+            // ponytail: `v[0]` throwing on an empty value is load-bearing: `ResponseParser` relies on it to fall back
+            // from parsing an input as URL to parsing it as POST body
+            k to when {
+                // members declared as strings keep their content verbatim, even if that content happens to be JSON
+                // itself, e.g. `wallet_metadata` of `at.asitplus.openid.RequestObjectParameters`
+                descriptor.isStringElement(k) -> JsonPrimitive(v)
+                v[0] == '{' -> jsonForParameters.decodeFromString<JsonObject>(v)
+                v[0] == '[' -> jsonForParameters.decodeFromString<JsonArray>(v)
+                else -> JsonUnquotedLiteral(v)  //no quoted → can be any type for deserializing. requires lenient parsing
+            }
+        }))
+    }
+
+inline fun <reified T> Parameters.decode(): T =
+    decode(jsonForParameters.serializersModule.serializer<T>())
 
 /** Whether the member serialized as [name] is a string, for descriptors that have members at all. */
 @OptIn(ExperimentalSerializationApi::class)
@@ -74,15 +77,19 @@ fun String.safeDecodeUrlQueryComponent(plusIsSpace: Boolean = false) =
 fun Parameters.formUrlEncode() = map { (k, v) -> k to v }.formUrlEncode()
 
 inline fun <reified T> T.encodeToParameters(): Parameters =
-    when (val element = json.encodeToJsonElement(this)) {
+    when (val element = jsonForParameters.encodeToJsonElement(this)) {
         is JsonArray -> element.mapIndexed { i, v -> i.toString() to v }
         is JsonObject -> element.map { (k, v) -> k to v }
         else -> throw SerializationException("Literals are not supported")
     }.associate { (key, value) ->
-        key to if (value is JsonPrimitive) value.content else json.encodeToString(value)
+        key to if (value is JsonPrimitive) value.content else jsonForParameters.encodeToString(value)
     }
 
-val json by lazy {
+
+/**
+ * The important bit here compared to other instances is `isLenient=true` to be able to decode URL query parameters
+ */
+val jsonForParameters by lazy {
     Json {
         prettyPrint = false
         encodeDefaults = true

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthorizationResponsePreparationState.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthorizationResponsePreparationState.kt
@@ -31,4 +31,8 @@ data class AuthorizationResponsePreparationState(
     val responseRequiresEncryption: Boolean
         get() = request.parameters.responseMode?.requiresEncryption == true
 
+    /** Whether the authn request arrived encrypted for a key from `wallet_metadata`, see OpenID4VP 1.0, 5.10. */
+    val requestWasEncrypted: Boolean
+        get() = request.decryptedFrom != null
+
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -24,6 +24,8 @@ import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.cosef.toCoseAlgorithm
 import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JsonWebKeySet
+import at.asitplus.signum.indispensable.josef.JweAlgorithm
+import at.asitplus.signum.indispensable.josef.JweEncryption
 import at.asitplus.signum.indispensable.josef.JwsCompact
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
@@ -31,6 +33,7 @@ import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
 import at.asitplus.signum.supreme.UserInitiatedCancellationReason
 import at.asitplus.wallet.lib.RemoteResourceRetrieverFunction
 import at.asitplus.wallet.lib.RemoteResourceRetrieverInput
+import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.Holder
 import at.asitplus.wallet.lib.agent.HolderAgent
@@ -38,6 +41,7 @@ import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.PresentationResponseParameters.*
 import at.asitplus.wallet.lib.agent.RandomSource
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
+import at.asitplus.wallet.lib.agent.toEncryptionJsonWebKey
 import at.asitplus.wallet.lib.cbor.CoseHeaderNone
 import at.asitplus.wallet.lib.cbor.SignCoseDetached
 import at.asitplus.wallet.lib.cbor.SignCoseDetachedFun
@@ -116,6 +120,16 @@ class OpenId4VpHolder @JvmOverloads constructor(
      * is invoked for every request so applications can update their policy at runtime.
      */
     private val allowedDcApiOriginSchemes: suspend () -> Set<String> = { DEFAULT_ALLOWED_DC_API_ORIGIN_SCHEMES },
+    /**
+     * Set to accept encrypted authorization requests, as per
+     * [OpenID4VP 1.0, 5.10](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-request-uri-method-post):
+     * When fetching the request object with `request_uri_method=post`, we advertise one ephemeral encryption key per
+     * request in `wallet_metadata`, for the verifier to encrypt the request object to. Leave `null` to keep requesting
+     * plain request objects. May hold a [MapStore] to synchronize these keys between instances.
+     */
+    private val ephemeralEncryptionKeyService: EphemeralEncryptionKeyService? = null,
+    /** Advertised in `wallet_metadata` to encrypt authorization requests, see [ephemeralEncryptionKeyService]. */
+    private val supportedJweEncryptionAlgorithms: Set<JweEncryption> = JweEncryption.entries.toSet(),
 ) {
 
     companion object {
@@ -177,10 +191,27 @@ class OpenId4VpHolder @JvmOverloads constructor(
         )
     }
 
+    /**
+     * The [metadata] to send when fetching a request object, carrying one ephemeral encryption key valid for exactly
+     * that request, if [ephemeralEncryptionKeyService] is set. Must be evaluated exactly once per request.
+     */
+    private suspend fun metadataForRequestObject(): OAuth2AuthorizationServerMetadata =
+        ephemeralEncryptionKeyService?.let {
+            metadata.copy(
+                jsonWebKeySet = JsonWebKeySet(listOf(it.createKey().toEncryptionJsonWebKey())),
+                requestObjectEncryptionAlgValuesSupportedStrings = setOf(JweAlgorithm.ECDH_ES.identifier),
+                requestObjectEncryptionEncValuesSupportedStrings = supportedJweEncryptionAlgorithms
+                    .map { enc -> enc.identifier }.toSet(),
+            )
+        } ?: metadata
+
     private val requestParser: RequestParser =
-        RequestParser(remoteResourceRetriever) {
+        RequestParser(
+            remoteResourceRetriever = remoteResourceRetriever,
+            ephemeralEncryptionKeyService = ephemeralEncryptionKeyService,
+        ) {
             RequestObjectParameters(
-                metadata = metadata,
+                metadata = metadataForRequestObject(),
                 nonce = uuid4().toString().also { walletNonceMapStore.put(it, it) })
         }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -120,17 +120,19 @@ class OpenId4VpHolder @JvmOverloads constructor(
      * is invoked for every request so applications can update their policy at runtime.
      */
     private val allowedDcApiOriginSchemes: suspend () -> Set<String> = { DEFAULT_ALLOWED_DC_API_ORIGIN_SCHEMES },
-    /**
-     * Set to accept encrypted authorization requests, as per
-     * [OpenID4VP 1.0, 5.10](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-request-uri-method-post):
-     * When fetching the request object with `request_uri_method=post`, we advertise one ephemeral encryption key per
-     * request in `wallet_metadata`, for the verifier to encrypt the request object to. Leave `null` to keep requesting
-     * plain request objects. May hold a [MapStore] to synchronize these keys between instances.
-     */
+    /** Set to accept encrypted authorization requests fetched with a POST (when RP supports that). */
     private val ephemeralEncryptionKeyService: EphemeralEncryptionKeyService? = null,
     /** Advertised in `wallet_metadata` to encrypt authorization requests, see [ephemeralEncryptionKeyService]. */
     private val supportedJweEncryptionAlgorithms: Set<JweEncryption> = JweEncryption.entries.toSet(),
+    /** Set to reject a plain request object we have fetched with POST (when RP supports that) */
+    private val requireEncryptedRequests: Boolean = false,
 ) {
+
+    init {
+        require(!requireEncryptedRequests || ephemeralEncryptionKeyService != null) {
+            "requireEncryptedRequests needs an ephemeralEncryptionKeyService to advertise a key with"
+        }
+    }
 
     companion object {
         const val HTTPS_ORIGIN_SCHEME = "https"
@@ -205,15 +207,15 @@ class OpenId4VpHolder @JvmOverloads constructor(
             )
         } ?: metadata
 
-    private val requestParser: RequestParser =
-        RequestParser(
-            remoteResourceRetriever = remoteResourceRetriever,
-            ephemeralEncryptionKeyService = ephemeralEncryptionKeyService,
-        ) {
-            RequestObjectParameters(
-                metadata = metadataForRequestObject(),
-                nonce = uuid4().toString().also { walletNonceMapStore.put(it, it) })
-        }
+    private val requestParser = RequestParser(
+        remoteResourceRetriever = remoteResourceRetriever,
+        ephemeralEncryptionKeyService = ephemeralEncryptionKeyService,
+        requireEncryptedRequests = requireEncryptedRequests,
+    ) {
+        RequestObjectParameters(
+            metadata = metadataForRequestObject(),
+            nonce = uuid4().toString().also { walletNonceMapStore.put(it, it) })
+    }
 
     /**
      * Pass in the URL sent by the Verifier (containing the [AuthenticationRequestParameters] as query parameters),

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpRequestFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpRequestFactory.kt
@@ -67,10 +67,7 @@ internal class OpenId4VpRequestFactory(
     supportedAlgorithms: Set<SignatureAlgorithm>,
     /** Used to store issued authn requests to verify the authn response to it. */
     private val stateToAuthnRequestStore: MapStore<String, AuthenticationRequestParameters>,
-    /**
-     * Algorithms supported to decrypt responses from wallets, for [metadataWithEncryption], and to encrypt request
-     * objects with, see [createRequestObject].
-     */
+    /** Algorithms supported to decrypt responses from wallets and to encrypt request objects. */
     private val supportedJweEncryptionAlgorithms: Set<JweEncryption>,
     /** Encrypts the request object, if the wallet asked us to in its `wallet_metadata`, see [createRequestObject]. */
     private val encryptRequestObject: EncryptJweFun = EncryptJwe(EphemeralKeyWithoutCert()),
@@ -178,34 +175,42 @@ internal class OpenId4VpRequestFactory(
         requestObjectParameters: RequestObjectParameters? = null,
     ): KmmResult<String> = catching {
         val signed = createSignedRequestObject(requestOptions, signing, requestObjectParameters).getOrThrow().toString()
-        requestObjectParameters?.walletMetadata?.encryptionTarget()?.let { (recipientKey, jweEncryption) ->
+        val encryptionTarget = requestObjectParameters?.walletMetadata?.encryptionTarget
+        if (encryptionTarget == null) {
+            signed
+        } else {
             encryptRequestObject(
-                JweHeader(
+                header = JweHeader(
                     algorithm = JweAlgorithm.ECDH_ES,
-                    encryption = jweEncryption,
-                    keyId = recipientKey.keyId,
+                    encryption = encryptionTarget.second,
+                    keyId = encryptionTarget.first.keyId,
                     // RFC 7519, 5.2: a nested JWT, i.e. our signed request object inside this JWE, MUST declare `JWT`
                     contentType = "JWT",
                 ),
-                signed,
-                recipientKey,
+                payload = signed,
+                recipientKey = encryptionTarget.first,
             ).getOrThrow().serialize()
-        } ?: signed
+        }
     }
 
     /**
      * The wallet's encryption key and the content encryption algorithm to use, or `null` if the wallet did not ask for
      * an encrypted request object, or asked for algorithms we don't support.
      */
-    private fun OAuth2AuthorizationServerMetadata.encryptionTarget(): Pair<JsonWebKey, JweEncryption>? {
-        val recipientKey = jsonWebKeySet?.keys?.getEncryptionTargetKey() ?: return null
-        requestObjectEncryptionAlgValuesSupported?.let { if (JweAlgorithm.ECDH_ES !in it) return null }
-        // the wallet expressing no preference means the OpenID4VP default, otherwise we need a common algorithm
-        val jweEncryption = requestObjectEncryptionEncValuesSupported
-            ?.let { advertised -> advertised.firstOrNull { it in supportedJweEncryptionAlgorithms } ?: return null }
-            ?: JweEncryption.A128GCM
-        return recipientKey to jweEncryption
-    }
+    private val OAuth2AuthorizationServerMetadata.encryptionTarget: Pair<JsonWebKey, JweEncryption>?
+        get() {
+            val recipientKey = jsonWebKeySet?.keys?.getEncryptionTargetKey()
+                ?: return null
+            requestObjectEncryptionAlgValuesSupported?.let {
+                if (JweAlgorithm.ECDH_ES !in it)
+                    return null
+            }
+            // the wallet expressing no preference means the OpenID4VP default, otherwise we need a common algorithm
+            val jweEncryption = requestObjectEncryptionEncValuesSupported
+                ?.let { advertised -> advertised.firstOrNull { it in supportedJweEncryptionAlgorithms } ?: return null }
+                ?: JweEncryption.A128GCM
+            return recipientKey to jweEncryption
+        }
 
     suspend fun storeAuthnRequest(
         authenticationRequestParameters: AuthenticationRequestParameters,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpRequestFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpRequestFactory.kt
@@ -3,6 +3,7 @@ package at.asitplus.wallet.lib.openid
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.openid.AuthenticationRequestParameters
+import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.RelyingPartyMetadata
 import at.asitplus.openid.RequestObjectParameters
 import at.asitplus.openid.ResponseParametersFrom
@@ -14,16 +15,21 @@ import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.cosef.toCoseAlgorithm
 import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JsonWebKeySet
+import at.asitplus.signum.indispensable.josef.JweAlgorithm
 import at.asitplus.signum.indispensable.josef.JweEncryption
+import at.asitplus.signum.indispensable.josef.JweHeader
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
 import at.asitplus.wallet.lib.NonceService
 import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.toEncryptionJsonWebKey
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
 import at.asitplus.wallet.lib.data.toBase64UrlJsonString
 import at.asitplus.wallet.lib.extensions.getEncryptionTargetKey
+import at.asitplus.wallet.lib.jws.EncryptJwe
+import at.asitplus.wallet.lib.jws.EncryptJweFun
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.jws.SignJwtFun
 import at.asitplus.wallet.lib.utils.MapStore
@@ -61,8 +67,13 @@ internal class OpenId4VpRequestFactory(
     supportedAlgorithms: Set<SignatureAlgorithm>,
     /** Used to store issued authn requests to verify the authn response to it. */
     private val stateToAuthnRequestStore: MapStore<String, AuthenticationRequestParameters>,
-    /** Algorithms supported to decrypt responses from wallets, for [metadataWithEncryption]. */
+    /**
+     * Algorithms supported to decrypt responses from wallets, for [metadataWithEncryption], and to encrypt request
+     * objects with, see [createRequestObject].
+     */
     private val supportedJweEncryptionAlgorithms: Set<JweEncryption>,
+    /** Encrypts the request object, if the wallet asked us to in its `wallet_metadata`, see [createRequestObject]. */
+    private val encryptRequestObject: EncryptJweFun = EncryptJwe(EphemeralKeyWithoutCert()),
 ) {
 
     private val supportedJwsAlgorithms = supportedAlgorithms
@@ -154,6 +165,46 @@ internal class OpenId4VpRequestFactory(
             signedRequestObject,
             AuthenticationRequestParameters.serializer(),
         ).getOrThrow()
+    }
+
+    /**
+     * Creates the request object to serve at the `request_uri` endpoint: a signed request object, encrypted to the
+     * wallet's key if it passed one in its `wallet_metadata`, as per
+     * [OpenID4VP 1.0, 5.10](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-request-uri-method-post).
+     */
+    suspend fun createRequestObject(
+        requestOptions: OpenId4VpRequestOptions,
+        signing: RequestObjectSigning,
+        requestObjectParameters: RequestObjectParameters? = null,
+    ): KmmResult<String> = catching {
+        val signed = createSignedRequestObject(requestOptions, signing, requestObjectParameters).getOrThrow().toString()
+        requestObjectParameters?.walletMetadata?.encryptionTarget()?.let { (recipientKey, jweEncryption) ->
+            encryptRequestObject(
+                JweHeader(
+                    algorithm = JweAlgorithm.ECDH_ES,
+                    encryption = jweEncryption,
+                    keyId = recipientKey.keyId,
+                    // RFC 7519, 5.2: a nested JWT, i.e. our signed request object inside this JWE, MUST declare `JWT`
+                    contentType = "JWT",
+                ),
+                signed,
+                recipientKey,
+            ).getOrThrow().serialize()
+        } ?: signed
+    }
+
+    /**
+     * The wallet's encryption key and the content encryption algorithm to use, or `null` if the wallet did not ask for
+     * an encrypted request object, or asked for algorithms we don't support.
+     */
+    private fun OAuth2AuthorizationServerMetadata.encryptionTarget(): Pair<JsonWebKey, JweEncryption>? {
+        val recipientKey = jsonWebKeySet?.keys?.getEncryptionTargetKey() ?: return null
+        requestObjectEncryptionAlgValuesSupported?.let { if (JweAlgorithm.ECDH_ES !in it) return null }
+        // the wallet expressing no preference means the OpenID4VP default, otherwise we need a common algorithm
+        val jweEncryption = requestObjectEncryptionEncValuesSupported
+            ?.let { advertised -> advertised.firstOrNull { it in supportedJweEncryptionAlgorithms } ?: return null }
+            ?: JweEncryption.A128GCM
+        return recipientKey to jweEncryption
     }
 
     suspend fun storeAuthnRequest(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -11,7 +11,6 @@ import at.asitplus.openid.ResponseParametersFrom
 import at.asitplus.rfc6749OAuth2AuthorizationFramework.ResponseType
 import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.josef.JweEncryption
-import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.wallet.lib.DefaultNonceService
 import at.asitplus.wallet.lib.MdocDeviceSignatureVerifier
@@ -32,6 +31,9 @@ import at.asitplus.wallet.lib.jws.SignJwtFun
 import at.asitplus.wallet.lib.jws.VerifyJwsObject
 import at.asitplus.wallet.lib.jws.VerifyJwsObjectFun
 import at.asitplus.wallet.lib.oidvci.encodeToParameters
+import at.asitplus.wallet.lib.openid.ClientIdScheme.CertificateHash
+import at.asitplus.wallet.lib.openid.ClientIdScheme.CertificateSanDns
+import at.asitplus.wallet.lib.openid.ClientIdScheme.RedirectUri
 import at.asitplus.wallet.lib.utils.DefaultMapStore
 import at.asitplus.wallet.lib.utils.MapStore
 import io.github.aakira.napier.Napier
@@ -67,7 +69,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     @Deprecated("Will be derived from [ephemeralEncryptionKeyService] and [decryptionKeyMaterial]")
     private val decryptJwe: DecryptJweFun =
         DecryptJweWithEphemeralKey(ephemeralEncryptionKeyService, decryptionKeyMaterial),
-    /** Signs authentication requests in [createSignedRequestObject]. */
+    /** Signs authentication requests in [OpenId4VpRequestFactory]. */
     private val signAuthnRequest: SignJwtFun<AuthenticationRequestParameters> =
         SignJwt(keyMaterial, JwsHeaderClientIdScheme(clientIdScheme)),
     /** Validates signed responses from holders. */
@@ -136,15 +138,19 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     ): KmmResult<CreatedRequest> = catching {
         when (creationOptions) {
             is CreationOptions.Query -> {
-                require(clientIdScheme !is ClientIdScheme.CertificateSanDns) // per OpenID4VP d23 5.10.4
+                require(clientIdScheme !is CertificateHash && clientIdScheme !is CertificateSanDns) {
+                    "Requests using x509_hash or x509_san_dns client schemes must be signed"
+                }
                 URLBuilder(creationOptions.walletUrl).apply {
-                    createPlainAuthnRequest(requestOptions).encodeToParameters()
+                    requestFactory.createPlainAuthnRequest(requestOptions).encodeToParameters()
                         .forEach { parameters.append(it.key, it.value) }
                 }.buildString().toCreatedRequest()
             }
 
             is CreationOptions.RequestByReference -> {
-                require(clientIdScheme !is ClientIdScheme.CertificateSanDns) // per OpenID4VP d23 5.10.4
+                require(clientIdScheme !is CertificateHash && clientIdScheme !is CertificateSanDns) {
+                    "Requests using x509_hash or x509_san_dns client schemes must be signed"
+                }
                 URLBuilder(creationOptions.walletUrl).apply {
                     JarRequestParameters(
                         clientId = clientIdScheme.clientId,
@@ -154,24 +160,33 @@ class OpenId4VpVerifier @JvmOverloads constructor(
                         .forEach { parameters.append(it.key, it.value) }
                 }.buildString().toCreatedRequest {
                     catching {
-                        joseCompliantSerializer.encodeToString(createPlainAuthnRequest(requestOptions, it))
+                        joseCompliantSerializer.encodeToString(
+                            requestFactory.createPlainAuthnRequest(requestOptions, it)
+                        )
                     }
                 }
             }
 
             is CreationOptions.SignedRequestByValue -> {
-                require(clientIdScheme !is ClientIdScheme.RedirectUri) // per OpenID4VP d23 5.10.4
+                require(clientIdScheme !is RedirectUri) {
+                    "Requests using redirect_uri client scheme can't be signed per OpenID4VP 1.0 5.9.3."
+                }
                 URLBuilder(creationOptions.walletUrl).apply {
                     JarRequestParameters(
                         clientId = clientIdScheme.clientId,
-                        request = createSignedRequestObject(requestOptions).getOrThrow().toString(),
+                        request = requestFactory.createSignedRequestObject(
+                            requestOptions,
+                            RequestObjectSigning.Redirect
+                        ).getOrThrow().toString(),
                     ).encodeToParameters()
                         .forEach { parameters.append(it.key, it.value) }
                 }.buildString().toCreatedRequest()
             }
 
             is CreationOptions.SignedRequestByReference -> {
-                require(clientIdScheme !is ClientIdScheme.RedirectUri) // per OpenID4VP d23 5.10.4
+                require(clientIdScheme !is RedirectUri) {
+                    "Requests using redirect_uri client scheme can't be signed per OpenID4VP 1.0 5.9.3."
+                }
                 URLBuilder(creationOptions.walletUrl).apply {
                     JarRequestParameters(
                         clientId = clientIdScheme.clientId,
@@ -191,17 +206,6 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     private fun String.toCreatedRequest(
         loadRequestObject: suspend (RequestObjectParameters?) -> KmmResult<String>,
     ) = CreatedRequest(this, loadRequestObject)
-
-    internal suspend fun createSignedRequestObject(
-        requestOptions: OpenId4VpRequestOptions,
-        requestObjectParameters: RequestObjectParameters? = null,
-    ): KmmResult<JwsCompactTyped<AuthenticationRequestParameters>> =
-        requestFactory.createSignedRequestObject(requestOptions, RequestObjectSigning.Redirect, requestObjectParameters)
-
-    internal suspend fun createPlainAuthnRequest(
-        requestOptions: OpenId4VpRequestOptions,
-        requestObjectParameters: RequestObjectParameters? = null,
-    ) = requestFactory.createPlainAuthnRequest(requestOptions, requestObjectParameters)
 
     /**
      * Validates an Authentication Response from the Wallet, where [input] is either:

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -181,9 +181,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
                         .forEach { parameters.append(it.key, it.value) }
                 }.buildString()
                     .toCreatedRequest {
-                        catching {
-                            createSignedRequestObject(requestOptions, it).getOrThrow().toString()
-                        }
+                        requestFactory.createRequestObject(requestOptions, RequestObjectSigning.Redirect, it)
                     }
             }
         }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
@@ -5,11 +5,11 @@ import at.asitplus.catching
 import at.asitplus.catchingUnwrapped
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.JarRequestParameters
-import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.RequestObjectParameters
 import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.josef.JweEncrypted
+import at.asitplus.signum.indispensable.josef.JweHeader
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.wallet.lib.RemoteResourceRetrieverFunction
@@ -38,14 +38,19 @@ class RequestParser(
     private val remoteResourceRetriever: RemoteResourceRetrieverFunction = { null },
     @Deprecated("No longer used, decision moved to `AuthorizationRequestValidator`")
     private val requestObjectJwsVerifier: RequestObjectJwsVerifier = RequestObjectJwsVerifier { _: Any -> true },
-    /**
-     * Holds the ephemeral encryption keys advertised in `wallet_metadata` when fetching a request object with
-     * `request_uri_method=post`, see [OpenId4VpHolder]. Leave `null` to reject encrypted request objects.
-     */
+    /** Holds the ephemeral encryption keys advertised in `wallet_metadata` when fetching a request object with POST. */
     private val ephemeralEncryptionKeyService: EphemeralEncryptionKeyService? = null,
     /** Decrypts request objects sent by the verifier, keyed by the `kid` of the JWE. */
     private val decryptRequestObject: DecryptJweFun? =
         ephemeralEncryptionKeyService?.let { DecryptJweWithEphemeralKey(it) },
+    /**
+     * Set to reject a plain request object served at a `request_uri` we have fetched with POST, i.e. the one flow in
+     * which we advertised an encryption key, see [OpenId4VpHolder]. Requests that never gave the verifier a key to
+     * encrypt to at all, i.e. `request` by value, `request_uri_method=get`, and plain requests carrying their
+     * parameters in the URL, are still accepted: callers wanting those rejected too can do so themselves, by looking
+     * at [RequestParametersFrom.decryptedFrom].
+     */
+    private val requireEncryptedRequests: Boolean = false,
     /**
      * Callback to load [RequestObjectParameters] when loading a request object by reference (e.g. from `request_uri`)
      */
@@ -86,9 +91,10 @@ class RequestParser(
 
     private fun String.parseFromJson(
         parent: RequestParametersFrom<out RequestParameters>?,
+        decryptedFrom: JweHeader? = null,
     ): RequestParametersFrom<*>? = catchingUnwrapped {
         val params = joseCompliantSerializer.decodeFromString(RequestParameters.serializer(), this)
-        RequestParametersFrom.Json(this, params, (parent as? RequestParametersFrom.Uri)?.url)
+        RequestParametersFrom.Json(this, params, (parent as? RequestParametersFrom.Uri)?.url, decryptedFrom)
     }.getOrNull()
 
     suspend fun extractRequest(
@@ -103,7 +109,13 @@ class RequestParser(
         // is built once per request, since it carries the key the verifier shall encrypt this very request to
         val requestObjectParameters = if (method == HttpMethod.Post) buildRequestObjectParameters.invoke() else null
         remoteResourceRetriever.invoke(parameters.resourceRetrieverInput(uri, method, requestObjectParameters))?.let {
-            (it.parseAsJweRequest(parent, requestObjectParameters.expectedEncryptionKeyId())
+            val expectedKeyId = requestObjectParameters.expectedEncryptionKeyId()
+            val fromJwe = it.parseAsJweRequest(parent, expectedKeyId)
+            // a non-null `expectedKeyId` means we advertised a key in `wallet_metadata`, i.e. this was the POST fetch,
+            // the only flow in which the verifier had the chance to encrypt at all
+            if (fromJwe == null && requireEncryptedRequests && expectedKeyId != null)
+                throw InvalidRequest("request object from $uri is not encrypted, but we require encryption")
+            (fromJwe
                 ?: it.parseAsJwsRequest(parent)
                 ?: it.parseFromJson(parent)
                 ?: throw InvalidRequest("request_uri content not a valid request object: $uri"))
@@ -116,7 +128,7 @@ class RequestParser(
         this?.walletMetadata?.jsonWebKeySet?.keys?.getEncryptionTargetKey()?.keyId
 
     /**
-     * Per [OpenID4VP 1.0, 5.10.1](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-request-uri-response):
+     * Per OpenID4VP 1.0, 5.10.1:
      * If we passed a `wallet_nonce` when fetching the request object, it MUST come back in the request object,
      * otherwise we MUST terminate request processing.
      */
@@ -140,20 +152,21 @@ class RequestParser(
 
     private suspend fun String.parseAsJwsRequest(
         parent: RequestParametersFrom<out RequestParameters>?,
+        decryptedFrom: JweHeader? = null,
     ): RequestParametersFrom<*>? =
         catching { JwsCompactTyped<RequestParameters>(this) }
             .getOrNull()?.let { jws ->
                 RequestParametersFrom.Jws(
                     jws = jws.jws,
                     parameters = jws.payload,
-                    parent = (parent as? RequestParametersFrom.Uri)?.url
+                    parent = (parent as? RequestParametersFrom.Uri)?.url,
+                    decryptedFrom = decryptedFrom,
                 )
             }
 
     /**
      * Decrypts a request object encrypted to the key we have advertised in `wallet_metadata`, as per
-     * [OpenID4VP 1.0, 5.10](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-request-uri-method-post),
-     * and parses the plaintext, which is a signed or plain request object.
+     * OpenID4VP 1.0, 5.10 and parses the plaintext, which is a signed or plain request object.
      *
      * Returns `null` if this is not a JWE at all, and throws if it is one that we can't or shouldn't decrypt.
      */
@@ -172,8 +185,8 @@ class RequestParser(
         val decrypted = decryptRequestObject.invoke(jwe).getOrElse {
             throw InvalidRequest("Decryption of request object failed", it)
         }
-        return decrypted.payload.parseAsJwsRequest(parent)
-            ?: decrypted.payload.parseFromJson(parent)
+        return decrypted.payload.parseAsJwsRequest(parent, jwe.header)
+            ?: decrypted.payload.parseFromJson(parent, jwe.header)
             ?: throw InvalidRequest("Decrypted request object is not a valid request object")
     }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
@@ -107,8 +107,8 @@ class RequestParser(
         val method = parameters.requestUriMethod?.toHttpMethod() ?: HttpMethod.Get
         // only the POST request to the request URI endpoint has a channel for these, see OpenID4VP 1.0, 5.10, and it
         // is built once per request, since it carries the key the verifier shall encrypt this very request to
-        val requestObjectParameters = if (method == HttpMethod.Post) buildRequestObjectParameters.invoke() else null
-        remoteResourceRetriever.invoke(parameters.resourceRetrieverInput(uri, method, requestObjectParameters))?.let {
+        val requestObjectParameters = if (method == HttpMethod.Post) buildRequestObjectParameters() else null
+        remoteResourceRetriever(parameters.resourceRetrieverInput(uri, method, requestObjectParameters))?.let {
             val expectedKeyId = requestObjectParameters.expectedEncryptionKeyId()
             val fromJwe = it.parseAsJweRequest(parent, expectedKeyId)
             // a non-null `expectedKeyId` means we advertised a key in `wallet_metadata`, i.e. this was the POST fetch,
@@ -182,7 +182,7 @@ class RequestParser(
             throw InvalidRequest("Encrypted request key does not match the key we advertised")
         if (decryptRequestObject == null)
             throw InvalidRequest("Verifier sent an encrypted request, we can't decrypt it")
-        val decrypted = decryptRequestObject.invoke(jwe).getOrElse {
+        val decrypted = decryptRequestObject(jwe).getOrElse {
             throw InvalidRequest("Decryption of request object failed", it)
         }
         return decrypted.payload.parseAsJwsRequest(parent, jwe.header)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
@@ -9,11 +9,16 @@ import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.RequestObjectParameters
 import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.RequestParametersFrom
+import at.asitplus.signum.indispensable.josef.JweEncrypted
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.wallet.lib.RemoteResourceRetrieverFunction
 import at.asitplus.wallet.lib.RemoteResourceRetrieverInput
+import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
 import at.asitplus.wallet.lib.data.MediaTypes
+import at.asitplus.wallet.lib.extensions.getEncryptionTargetKey
+import at.asitplus.wallet.lib.jws.DecryptJweFun
+import at.asitplus.wallet.lib.jws.DecryptJweWithEphemeralKey
 import at.asitplus.wallet.lib.oidc.RequestObjectJwsVerifier
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidRequest
 import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
@@ -33,6 +38,14 @@ class RequestParser(
     private val remoteResourceRetriever: RemoteResourceRetrieverFunction = { null },
     @Deprecated("No longer used, decision moved to `AuthorizationRequestValidator`")
     private val requestObjectJwsVerifier: RequestObjectJwsVerifier = RequestObjectJwsVerifier { _: Any -> true },
+    /**
+     * Holds the ephemeral encryption keys advertised in `wallet_metadata` when fetching a request object with
+     * `request_uri_method=post`, see [OpenId4VpHolder]. Leave `null` to reject encrypted request objects.
+     */
+    private val ephemeralEncryptionKeyService: EphemeralEncryptionKeyService? = null,
+    /** Decrypts request objects sent by the verifier, keyed by the `kid` of the JWE. */
+    private val decryptRequestObject: DecryptJweFun? =
+        ephemeralEncryptionKeyService?.let { DecryptJweWithEphemeralKey(it) },
     /**
      * Callback to load [RequestObjectParameters] when loading a request object by reference (e.g. from `request_uri`)
      */
@@ -84,21 +97,45 @@ class RequestParser(
     ): RequestParametersFrom<*>? = parameters.request?.let {
         it.parseAsJwsRequest(parent)
             ?: it.parseFromJson(parent)
-    } ?: parameters.requestUri
-        ?.let { remoteResourceRetriever.invoke(parameters.resourceRetrieverInput(it)) }
-        ?.let {
-            it.parseAsJwsRequest(parent)
+    } ?: parameters.requestUri?.let { uri ->
+        val method = parameters.requestUriMethod?.toHttpMethod() ?: HttpMethod.Get
+        // only the POST request to the request URI endpoint has a channel for these, see OpenID4VP 1.0, 5.10, and it
+        // is built once per request, since it carries the key the verifier shall encrypt this very request to
+        val requestObjectParameters = if (method == HttpMethod.Post) buildRequestObjectParameters.invoke() else null
+        remoteResourceRetriever.invoke(parameters.resourceRetrieverInput(uri, method, requestObjectParameters))?.let {
+            (it.parseAsJweRequest(parent, requestObjectParameters.expectedEncryptionKeyId())
+                ?: it.parseAsJwsRequest(parent)
                 ?: it.parseFromJson(parent)
-                ?: throw InvalidRequest("request_uri content not a valid request object: ${parameters.requestUri}")
+                ?: throw InvalidRequest("request_uri content not a valid request object: $uri"))
+                .also { request -> request.requireWalletNonce(requestObjectParameters?.walletNonce) }
         }
+    }
 
-    private suspend fun JarRequestParameters.resourceRetrieverInput(
+    /** The `kid` of the encryption key we have advertised in `wallet_metadata` for this very request. */
+    private fun RequestObjectParameters?.expectedEncryptionKeyId(): String? =
+        this?.walletMetadata?.jsonWebKeySet?.keys?.getEncryptionTargetKey()?.keyId
+
+    /**
+     * Per [OpenID4VP 1.0, 5.10.1](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-request-uri-response):
+     * If we passed a `wallet_nonce` when fetching the request object, it MUST come back in the request object,
+     * otherwise we MUST terminate request processing.
+     */
+    private fun RequestParametersFrom<*>.requireWalletNonce(sent: String?) {
+        if (sent == null) return
+        val received = (parameters as? AuthenticationRequestParameters)?.walletNonce
+        if (received != sent)
+            throw InvalidRequest("wallet_nonce we sent is missing from the request object, got: $received")
+    }
+
+    private fun JarRequestParameters.resourceRetrieverInput(
         uri: String,
+        method: HttpMethod,
+        requestObjectParameters: RequestObjectParameters?,
     ): RemoteResourceRetrieverInput = RemoteResourceRetrieverInput(
         url = uri,
-        method = requestUriMethod?.toHttpMethod() ?: HttpMethod.Get,
+        method = method,
         headers = mapOf(HttpHeaders.Accept to MediaTypes.Application.AUTHZ_REQ_JWT),
-        requestObjectParameters = buildRequestObjectParameters.invoke()
+        requestObjectParameters = requestObjectParameters
     )
 
     private suspend fun String.parseAsJwsRequest(
@@ -112,5 +149,32 @@ class RequestParser(
                     parent = (parent as? RequestParametersFrom.Uri)?.url
                 )
             }
+
+    /**
+     * Decrypts a request object encrypted to the key we have advertised in `wallet_metadata`, as per
+     * [OpenID4VP 1.0, 5.10](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-request-uri-method-post),
+     * and parses the plaintext, which is a signed or plain request object.
+     *
+     * Returns `null` if this is not a JWE at all, and throws if it is one that we can't or shouldn't decrypt.
+     */
+    private suspend fun String.parseAsJweRequest(
+        parent: RequestParametersFrom<out RequestParameters>?,
+        expectedKeyId: String?,
+    ): RequestParametersFrom<*>? {
+        if (count { it == '.' } != 4) return null
+        val jwe = JweEncrypted.deserialize(this).getOrNull() ?: return null
+        if (expectedKeyId == null)
+            throw InvalidRequest("Verifier sent an encrypted request, but we did not request encryption")
+        if (jwe.header.keyId != expectedKeyId)
+            throw InvalidRequest("Encrypted request key does not match the key we advertised")
+        if (decryptRequestObject == null)
+            throw InvalidRequest("Verifier sent an encrypted request, we can't decrypt it")
+        val decrypted = decryptRequestObject.invoke(jwe).getOrElse {
+            throw InvalidRequest("Decryption of request object failed", it)
+        }
+        return decrypted.payload.parseAsJwsRequest(parent)
+            ?: decrypted.payload.parseFromJson(parent)
+            ?: throw InvalidRequest("Decrypted request object is not a valid request object")
+    }
 
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
@@ -22,7 +22,7 @@ import at.asitplus.wallet.lib.jws.DecryptJweWithEphemeralKey
 import at.asitplus.wallet.lib.oidc.RequestObjectJwsVerifier
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidRequest
 import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
-import at.asitplus.wallet.lib.oidvci.json
+import at.asitplus.wallet.lib.oidvci.jsonForParameters
 import io.ktor.http.*
 import io.ktor.util.*
 import kotlinx.serialization.json.JsonObject
@@ -81,7 +81,7 @@ class RequestParser(
         Url(this).let {
             RequestParametersFrom.Uri(
                 url = it,
-                parameters = json.decodeFromJsonElement(
+                parameters = jsonForParameters.decodeFromJsonElement(
                     RequestParameters.serializer(),
                     it.parameters.flattenEntries().toMap().decodeFromUrlQuery<JsonObject>()
                 )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/SerializationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/SerializationTest.kt
@@ -88,7 +88,7 @@ val SerializationTest by matrixSuite {
             this shouldContain "dcql_query=" + "{\"credentials".encodeURLParameter()
         }
 
-        intermediateMap.decode<AuthenticationRequestParameters>() shouldBe params
+        intermediateMap.decode(AuthenticationRequestParameters.serializer()) shouldBe params
     }
 
     test("createAuthorizationRequest as POST") {

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
@@ -3,6 +3,7 @@ package at.asitplus.wallet.lib.openid
 import at.asitplus.dif.DifInputDescriptor
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.JarRequestParameters
+import at.asitplus.openid.RequestObjectParameters
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.josef.JweAlgorithm
 import at.asitplus.signum.indispensable.josef.JweEncryption
@@ -41,6 +42,7 @@ val AuthenticationRequestParameterFromSerializerTest by matrixSuite {
         clientIdScheme = ClientIdScheme.PreRegistered(clientId, redirectUrl),
     )
     val representations = listOf(PLAIN_JWT, SD_JWT, ISO_MDOC)
+    val byReference = CreationOptions.RequestByReference("https://example.com", "https://example.com")
 
     representations.forEach { representation ->
         val reqOptions = OpenId4VpRequestOptions(
@@ -65,9 +67,8 @@ val AuthenticationRequestParameterFromSerializerTest by matrixSuite {
         }
 
         "Json test $representation" {
-            val authnRequest = joseCompliantSerializer.encodeToString(
-                verifierOid4vp.createPlainAuthnRequest(reqOptions)
-            )
+            val authnRequest = verifierOid4vp.createAuthnRequest(reqOptions, byReference).getOrThrow()
+                .loadRequestObject.shouldNotBeNull().invoke(RequestObjectParameters()).getOrThrow()
             authnRequest.shouldNotContain(DifInputDescriptor::class.simpleName!!)
             val params = holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow().request
                 .shouldBeInstanceOf<RequestParametersFrom.Json<AuthenticationRequestParameters>>()
@@ -79,7 +80,10 @@ val AuthenticationRequestParameterFromSerializerTest by matrixSuite {
         }
 
         "DcApiUnsigned test $representation" {
-            val parameters = verifierOid4vp.createPlainAuthnRequest(reqOptions)
+            val parameters = joseCompliantSerializer.decodeFromString<AuthenticationRequestParameters>(
+                verifierOid4vp.createAuthnRequest(reqOptions, byReference).getOrThrow()
+                    .loadRequestObject.shouldNotBeNull().invoke(RequestObjectParameters()).getOrThrow()
+            )
             val authnRequest = RequestParametersFrom.OpenId4VpDcApiUnsigned(
                 parameters = parameters,
                 jsonString = joseCompliantSerializer.encodeToString(parameters),

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
@@ -4,6 +4,9 @@ import at.asitplus.dif.DifInputDescriptor
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.JarRequestParameters
 import at.asitplus.openid.RequestParametersFrom
+import at.asitplus.signum.indispensable.josef.JweAlgorithm
+import at.asitplus.signum.indispensable.josef.JweEncryption
+import at.asitplus.signum.indispensable.josef.JweHeader
 import at.asitplus.signum.indispensable.josef.JwsTyped
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.toJwsFlattened
@@ -18,6 +21,7 @@ import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
 import com.benasher44.uuid.uuid4
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.http.*
@@ -158,5 +162,42 @@ val AuthenticationRequestParameterFromSerializerTest by matrixSuite {
             joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(serialized)
                 .shouldBe(params)
         }
+    }
+
+    // the JWE header a request was decrypted from, see OpenID4VP 1.0, 5.10, has to survive persisting the state
+    "decryptedFrom survives a round trip" {
+        val authnRequestUrl = verifierOid4vp.createAuthnRequest(
+            OpenId4VpRequestOptions(
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
+                ).toDCQLRequest()
+            ),
+            CreationOptions.SignedRequestByValue(walletUrl)
+        ).getOrThrow().url
+        val serializedRequest =
+            Url(authnRequestUrl).encodedQuery.decodeFromUrlQuery<JarRequestParameters>().request.shouldNotBeNull()
+
+        val params = RequestParametersFrom.Jws<AuthenticationRequestParameters>(
+            jws = JwsTyped<AuthenticationRequestParameters>(serializedRequest).jws,
+            parameters = JwsTyped<AuthenticationRequestParameters>(serializedRequest).payload,
+            decryptedFrom = JweHeader(
+                algorithm = JweAlgorithm.ECDH_ES,
+                encryption = JweEncryption.A128GCM,
+                keyId = "some-key-id",
+            ),
+        )
+
+        val serialized =
+            joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(params)
+        serialized shouldContain "decryptedFrom"
+        joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(serialized)
+            .shouldBe(params)
+
+        // state persisted before this field existed still parses, and reports "not encrypted"
+        joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(
+            joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(
+                params.copy(decryptedFrom = null)
+            )
+        ).decryptedFrom shouldBe null
     }
 }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/JarmTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/JarmTest.kt
@@ -4,8 +4,10 @@ import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.RelyingPartyMetadata
 import at.asitplus.openid.dcql.DCQLClaimsPathPointer
+import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JweAlgorithm
+import at.asitplus.signum.indispensable.josef.JweEncryption
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
@@ -21,6 +23,7 @@ import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.rfc3986.toUri
 import at.asitplus.wallet.lib.extensions.getEncryptionTargetKey
+import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 import at.asitplus.wallet.lib.oidvci.formUrlEncode
 import at.asitplus.wallet.lib.openid.DummyCredentialDataProvider.issueAndStorePlainJwt
@@ -30,7 +33,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.runBlocking
 
@@ -58,6 +60,19 @@ val JarmTest by matrixSuite {
                     keyMaterial = verifierKeyMaterial,
                     clientIdScheme = ClientIdScheme.RedirectUri(clientId)
                 )
+                val requestFactory = OpenId4VpRequestFactory(
+                    clientIdScheme = ClientIdScheme.RedirectUri(clientId),
+                    ephemeralEncryptionKeyService = EphemeralEncryptionKeyService(),
+                    decryptionKeyMaterial = null,
+                    signAuthnRequest = SignJwt(
+                        verifierKeyMaterial,
+                        JwsHeaderClientIdScheme(ClientIdScheme.RedirectUri(clientId))
+                    ),
+                    nonceService = DefaultNonceService(),
+                    supportedAlgorithms = setOf(SignatureAlgorithm.ECDSAwithSHA256),
+                    stateToAuthnRequestStore = DefaultMapStore(),
+                    supportedJweEncryptionAlgorithms = JweEncryption.entries.toSet(),
+                )
             }
         }
     } - {
@@ -66,7 +81,7 @@ val JarmTest by matrixSuite {
          * Incorrect behaviour arises when the [RelyingPartyMetadata.jsonWebKeySet] cannot be retrieved.
          */
         "DirectPostJwt must either be signed or encrypted" {
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+            val authnRequest = it.requestFactory.createPlainAuthnRequest(
                 OpenId4VpRequestOptions(
                     presentationRequest = CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(
@@ -97,8 +112,8 @@ val JarmTest by matrixSuite {
          * Request passed via client metadata as specified in Section 8.3 of OpenID4VP"*.
          */
         "every request carries its own ephemeral encryption key" {
-            val first = it.verifierOid4vp.createPlainAuthnRequest(directPostJwtOptions()).encryptionKey()
-            val second = it.verifierOid4vp.createPlainAuthnRequest(directPostJwtOptions()).encryptionKey()
+            val first = it.requestFactory.createPlainAuthnRequest(directPostJwtOptions()).encryptionKey()
+            val second = it.requestFactory.createPlainAuthnRequest(directPostJwtOptions()).encryptionKey()
 
             first.publicKeyUse shouldBe "enc"
             first.algorithm shouldBe JweAlgorithm.ECDH_ES
@@ -122,9 +137,12 @@ val JarmTest by matrixSuite {
                 )
             }
 
-            val authnRequest = newInstance().createPlainAuthnRequest(directPostJwtOptions())
-            val authnResponse = it.holderOid4vp
-                .createAuthnResponse(joseCompliantSerializer.encodeToString(authnRequest)).getOrThrow()
+            val authnRequest = newInstance().createAuthnRequest(
+                requestOptions = directPostJwtOptions(),
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
+
+            val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Post>()
 
             newInstance().validateAuthnResponse(authnResponse.params.formUrlEncode()).getOrThrow()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTest.kt
@@ -13,7 +13,6 @@ package at.asitplus.wallet.lib.openid
  */
 
 import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
-import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.dcql.DCQLClaimsPathPointer
 import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
 import at.asitplus.openid.dcql.DCQLCredentialQueryList
@@ -21,7 +20,6 @@ import at.asitplus.openid.dcql.DCQLIsoMdocCredentialQuery
 import at.asitplus.openid.dcql.DCQLIsoMdocZkCredentialQuery
 import at.asitplus.openid.dcql.DCQLJwtVcCredentialQuery
 import at.asitplus.openid.dcql.DCQLSdJwtCredentialQuery
-import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
 import at.asitplus.wallet.eupidsdjwt.EU_PID_SD_JWT_VCT
@@ -61,8 +59,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
-private fun AuthenticationRequestParameters.serialize(): String = joseCompliantSerializer.encodeToString(this)
-
 val OpenId4VpCombinedProtocolTest by matrixSuite {
 
     fixture {
@@ -95,14 +91,15 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             issueAndStoreSdJwt(it.holderAgent, it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             issueAndStoreIsoMdoc(it.holderAgent, it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
-                OpenId4VpRequestOptions(
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(
                     CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
                     ).toDCQLRequest()
-                )
-            )
-            it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
+                ),
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
+            it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
                 .error.shouldNotBeNull()
         }
@@ -113,16 +110,18 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             issueAndStoreSdJwt(it.holderAgent, it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             issueAndStoreIsoMdoc(it.holderAgent, it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
-                OpenId4VpRequestOptions(
+
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(
                     CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
-                    ).toDCQLRequest(),
-                )
-            )
+                    ).toDCQLRequest()
+                ),
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
 
             val authnResponse =
-                it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
+                it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
                     .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
 
             it.verifierOid4vp.validateAuthnResponse(authnResponse.url).getOrThrow()
@@ -147,29 +146,32 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             issueAndStoreSdJwt(it.holderAgent, it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             issueAndStoreIsoMdoc(it.holderAgent, it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
-                OpenId4VpRequestOptions(
-                    CredentialPresentationRequestBuilder(
-                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
-                    ).toDCQLRequest()?.let {
-                        CredentialPresentationRequest.DCQLRequest(
-                            it.dcqlQuery.copy(
-                                credentials = DCQLCredentialQueryList(
-                                    it.dcqlQuery.credentials.map {
-                                        it as DCQLJwtVcCredentialQuery
-                                    }.map {
-                                        it.copy(
-                                            requireCryptographicHolderBinding = false
-                                        )
-                                    }.toNonEmptyList()
-                                )
+            val requestOptions = OpenId4VpRequestOptions(
+                CredentialPresentationRequestBuilder(
+                    RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
+                ).toDCQLRequest()?.let {
+                    CredentialPresentationRequest.DCQLRequest(
+                        it.dcqlQuery.copy(
+                            credentials = DCQLCredentialQueryList(
+                                it.dcqlQuery.credentials.map {
+                                    it as DCQLJwtVcCredentialQuery
+                                }.map {
+                                    it.copy(
+                                        requireCryptographicHolderBinding = false
+                                    )
+                                }.toNonEmptyList()
                             )
                         )
-                    },
-                )
+                    )
+                },
             )
 
-            val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = requestOptions,
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
+
+            val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
 
             val vcFreshnessSummary = it.verifierOid4vp.validateAuthnResponse(authnResponse.url).getOrThrow()
@@ -189,15 +191,16 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             issueAndStoreSdJwt(it.holderAgent, it.holderKeyMaterial, it.euPidSdJwtScheme)
             issueAndStoreIsoMdoc(it.holderAgent, it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
-                OpenId4VpRequestOptions(
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(
                     CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
-                    ).toDCQLRequest(),
+                    ).toDCQLRequest()
                 ),
-            )
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
 
-            it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
+            it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
                 .error.shouldNotBeNull()
         }
@@ -208,15 +211,16 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             issueAndStoreSdJwt(it.holderAgent, it.holderKeyMaterial, it.euPidSdJwtScheme)
             issueAndStoreIsoMdoc(it.holderAgent, it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
-                OpenId4VpRequestOptions(
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(
                     CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
-                    ).toDCQLRequest(),
+                    ).toDCQLRequest()
                 ),
-            )
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
 
-            val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
+            val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
 
             it.verifierOid4vp.validateAuthnResponse(authnResponse.url).getOrThrow()
@@ -234,15 +238,16 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             issueAndStoreSdJwt(it.holderAgent, it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             issueAndStoreIsoMdoc(it.holderAgent, it.holderKeyMaterial, it.mdlScheme)
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
-                OpenId4VpRequestOptions(
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(
                     CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
-                    ).toDCQLRequest(),
+                    ).toDCQLRequest()
                 ),
-            )
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
 
-            it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
+            it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
                 .error.shouldNotBeNull()
         }
@@ -253,15 +258,16 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             issueAndStoreIsoMdoc(it.holderAgent, it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             issueAndStoreIsoMdoc(it.holderAgent, it.holderKeyMaterial, it.mdlScheme)
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
-                OpenId4VpRequestOptions(
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(
                     CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
-                    ).toDCQLRequest(),
+                    ).toDCQLRequest()
                 ),
-            )
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
 
-            val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
+            val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
 
             it.verifierOid4vp.validateAuthnResponse(authnResponse.url).getOrThrow()
@@ -280,10 +286,13 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
                 RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
             ).toDCQLRequest().shouldNotBeNull()
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(OpenId4VpRequestOptions(dcqlRequest))
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(dcqlRequest),
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
 
             val preparationState =
-                it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest.serialize()).getOrThrow()
+                it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow()
 
             val matchesWithBadQueryIdentifiers = it.holderAgent
                 .matchPresentationRequestAgainstCredentialStore(dcqlRequest).getOrThrow()
@@ -311,23 +320,26 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             issueAndStoreIsoMdoc(it.holderAgent, it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             issueAndStoreIsoMdoc(it.holderAgent, it.holderKeyMaterial, it.mdlScheme)
 
-            val originalDcqlRequest = CredentialPresentationRequestBuilder(
+            val dcqlRequest = CredentialPresentationRequestBuilder(
                 RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
             ).toDCQLRequest().shouldNotBeNull()
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(OpenId4VpRequestOptions(originalDcqlRequest))
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(dcqlRequest),
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
 
             val preparationState =
-                it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest.serialize()).getOrThrow()
+                it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow()
 
             val otherDcqlQuery = CredentialPresentationRequestBuilder(
                 RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
             ).toDCQLRequest().shouldNotBeNull().dcqlQuery
 
             val otherQueryWithOriginalIds = CredentialPresentationRequest.DCQLRequest(
-                originalDcqlRequest.dcqlQuery.copy(
+                dcqlRequest.dcqlQuery.copy(
                     credentials = DCQLCredentialQueryList(
-                        originalDcqlRequest.dcqlQuery.credentials.zip(otherDcqlQuery.credentials) { good, bad ->
+                        dcqlRequest.dcqlQuery.credentials.zip(otherDcqlQuery.credentials) { good, bad ->
                             when (bad) {
                                 is DCQLIsoMdocCredentialQuery -> bad.copy(id = good.id)
                                 is DCQLIsoMdocZkCredentialQuery -> bad.copy(id = good.id)
@@ -351,7 +363,7 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             val authnResponse = it.holderOid4vp.finalizeAuthorizationResponse(
                 preparationState = preparationState,
                 credentialPresentation = CredentialPresentation.DCQLPresentation(
-                    presentationRequest = originalDcqlRequest,
+                    presentationRequest = dcqlRequest,
                     credentialQuerySubmissions = badMatches
                 ),
             ).getOrThrow()
@@ -373,10 +385,12 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
                 RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
             ).toDCQLRequest().shouldNotBeNull()
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(OpenId4VpRequestOptions(dcqlRequest))
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(dcqlRequest),
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
 
-            val preparationState =
-                it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest.serialize()).getOrThrow()
+            val preparationState = it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow()
 
             val goodMatches = it.holderAgent
                 .matchPresentationRequestAgainstCredentialStore(dcqlRequest).getOrThrow()
@@ -402,15 +416,15 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             issueAndStorePlainJwt(it.holderAgent, it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             issueAndStoreIsoMdoc(it.holderAgent, it.holderKeyMaterial, it.mdlScheme)
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
-                OpenId4VpRequestOptions(
-                    CredentialPresentationRequestBuilder(
-                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT),
-                        RequestOptionsCredential(it.mdlScheme, ISO_MDOC)
-                    ).toDCQLRequest(),
-                ),
-            )
-            val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(CredentialPresentationRequestBuilder(
+                    RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT),
+                    RequestOptionsCredential(it.mdlScheme, ISO_MDOC)
+                ).toDCQLRequest(),),
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
+
+            val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
 
             it.verifierOid4vp.validateAuthnResponse(authnResponse.url).getOrThrow()
@@ -440,9 +454,13 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
                     )
                 ).toDCQLRequest(),
             )
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(requestOptions)
 
-            val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = requestOptions,
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
+
+            val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
 
             val groupedResult = it.verifierOid4vp.validateAuthnResponse(authnResponse.url).getOrThrow()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTwoStepTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTwoStepTest.kt
@@ -19,10 +19,6 @@ import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MD
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.CredentialPresentation.DCQLPresentation
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
-import at.asitplus.wallet.lib.data.CredentialScheme
-import at.asitplus.wallet.lib.data.rfc3986.toUri
-import at.asitplus.wallet.lib.data.CredentialPresentation.PresentationExchangePresentation
-import at.asitplus.wallet.lib.data.CredentialPresentationRequest.PresentationExchangeRequest
 import at.asitplus.wallet.lib.openid.DummyCredentialDataProvider.issueAndStoreIsoMdoc
 import at.asitplus.wallet.lib.openid.DummyCredentialDataProvider.issueAndStoreSdJwt
 import com.benasher44.uuid.uuid4
@@ -58,14 +54,17 @@ val OpenId4VpCombinedProtocolTwoStepTest by matrixSuite {
             issueAndStoreIsoMdoc(it.holderAgent, it.holderKeyMaterial, AtomicAttribute2023)
             issueAndStoreSdJwt(it.holderAgent, it.holderKeyMaterial, AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
-                OpenId4VpRequestOptions(
+
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(
                     CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC)
                     ).toDCQLRequest(),
-                )
-            )
-            val preparationState = it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest.serialize())
+                ),
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
+
+            val preparationState = it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest)
                 .getOrThrow()
             val dcqlQuery = preparationState.credentialPresentationRequest
                 .shouldBeInstanceOf<DCQLRequest>()
@@ -91,17 +90,18 @@ val OpenId4VpCombinedProtocolTwoStepTest by matrixSuite {
             issueAndStoreIsoMdoc(it.holderAgent, it.holderKeyMaterial, AtomicAttribute2023)
             issueAndStoreSdJwt(it.holderAgent, it.holderKeyMaterial, AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
-                OpenId4VpRequestOptions(
+
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(
                     CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC)
                     ).toDCQLRequest(),
-                )
-            )
+                ),
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
 
-            val preparationState =
-                it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest.serialize())
-                    .getOrThrow()
+            val preparationState = it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest)
+                .getOrThrow()
             val dcqlRequest = preparationState.credentialPresentationRequest
                 .shouldBeInstanceOf<DCQLRequest>()
             val credentialQueryId = dcqlRequest.dcqlQuery.credentials.first().id
@@ -133,8 +133,8 @@ val OpenId4VpCombinedProtocolTwoStepTest by matrixSuite {
         test("submission requirements need to match: not all optional claims need to be presented") {
             issueAndStoreIsoMdoc(it.holderAgent, it.holderKeyMaterial, AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
-                OpenId4VpRequestOptions(
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(
                     CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(
                             credentialScheme = AtomicAttribute2023,
@@ -145,12 +145,12 @@ val OpenId4VpCombinedProtocolTwoStepTest by matrixSuite {
                             ),
                         )
                     ).toDCQLRequest(),
-                )
-            )
+                ),
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
 
-            val preparationState =
-                it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest.serialize())
-                    .getOrThrow()
+            val preparationState = it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest)
+                .getOrThrow()
             val dcqlRequest = preparationState.credentialPresentationRequest
                 .shouldBeInstanceOf<DCQLRequest>()
             val credentialQueryId = dcqlRequest.dcqlQuery.credentials.first().id
@@ -212,17 +212,17 @@ val OpenId4VpCombinedProtocolTwoStepTest by matrixSuite {
                         .credential.shouldBeInstanceOf<SubjectCredentialStore.StoreEntry.SdJwt>()
                 }
 
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
-                OpenId4VpRequestOptions(
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(
                     CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC)
                     ).toDCQLRequest(),
-                )
-            )
+                ),
+                creationOptions = CreationOptions.Query("https://example.com")
+            ).getOrThrow().url
 
-            val preparationState =
-                it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest.serialize())
-                    .getOrThrow()
+            val preparationState = it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest)
+                .getOrThrow()
             val dcqlRequest = preparationState.credentialPresentationRequest
                 .shouldBeInstanceOf<DCQLRequest>()
             val credentialQueryId = dcqlRequest.dcqlQuery.credentials.first().id

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEncryptedRequestTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEncryptedRequestTest.kt
@@ -1,0 +1,292 @@
+package at.asitplus.wallet.lib.openid
+
+import at.asitplus.openid.JarRequestParameters
+import at.asitplus.signum.indispensable.josef.JweAlgorithm
+import at.asitplus.signum.indispensable.josef.JweEncryption
+import at.asitplus.signum.indispensable.josef.JweHeader
+import at.asitplus.testballoon.matrix.fixture
+import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.wallet.lib.RequestOptionsCredential
+import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.agent.HolderAgent
+import at.asitplus.wallet.lib.agent.RandomSource
+import at.asitplus.wallet.lib.agent.toEncryptionJsonWebKey
+import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.jws.EncryptJwe
+import at.asitplus.wallet.lib.openid.DummyCredentialDataProvider.issueAndStorePlainJwt
+import com.benasher44.uuid.uuid4
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Encrypted authorization requests as per
+ * [OpenID4VP 1.0, 5.10](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-request-uri-method-post).
+ */
+val OpenId4VpEncryptedRequestTest by matrixSuite {
+
+    fixture {
+        runBlocking {
+            val holderKeyMaterial = EphemeralKeyWithoutCert()
+            val holderAgent = HolderAgent(holderKeyMaterial).also {
+                issueAndStorePlainJwt(it, holderKeyMaterial)
+            }
+            object {
+                val holderAgent = holderAgent
+                val clientId = "PRE-REGISTERED-CLIENT-${uuid4()}"
+                val redirectUrl = "https://example.com/rp/${uuid4()}"
+                val walletUrl = "https://example.com/wallet/${uuid4()}"
+                val requestUrl = "https://example.com/request/${uuid4()}"
+                val verifierOid4vp = OpenId4VpVerifier(
+                    keyMaterial = EphemeralKeyWithoutCert(),
+                    clientIdScheme = ClientIdScheme.PreRegistered(clientId, redirectUrl),
+                )
+                val requestOptions = OpenId4VpRequestOptions(
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)
+                    ).toDCQLRequest(),
+                )
+
+                /** Holder fetching the request object from [requestUrl] with POST, [served] records what it got. */
+                var served: String? = null
+                fun holder(
+                    ephemeralEncryptionKeyService: EphemeralEncryptionKeyService?,
+                    serve: suspend (at.asitplus.openid.RequestObjectParameters?) -> String,
+                ) = OpenId4VpHolder(
+                    holder = holderAgent,
+                    randomSource = RandomSource.Default,
+                    ephemeralEncryptionKeyService = ephemeralEncryptionKeyService,
+                    remoteResourceRetriever = { input ->
+                        if (input.url == requestUrl)
+                            serve(input.requestObjectParameters).also { served = it }
+                        else null
+                    },
+                )
+            }
+        }
+    } - {
+
+        "verifier encrypts request object when the wallet advertises a key" { f ->
+            val (url, jar) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            val holder = f.holder(EphemeralEncryptionKeyService()) { jar.invoke(it).getOrThrow() }
+
+            holder.createAuthnResponse(url).getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+                .let { f.verifierOid4vp.validateAuthnResponse(it.url).getOrThrow() }
+                .vpTokenValidationResult.shouldNotBeNull().getOrThrow()
+                .shouldBeInstanceOf<VpTokenValidationResultDCQL>()
+
+            // five parts, i.e. a JWE, not the three parts of the signed request object
+            f.served.shouldNotBeNull().count { it == '.' } shouldBe 4
+        }
+
+        "verifier keeps sending plain request objects when the wallet advertises no key" { f ->
+            val (url, jar) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            val holder = f.holder(null) { jar.invoke(it).getOrThrow() }
+
+            holder.createAuthnResponse(url).getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+                .let { f.verifierOid4vp.validateAuthnResponse(it.url).getOrThrow() }
+                .vpTokenValidationResult.shouldNotBeNull().getOrThrow()
+
+            f.served.shouldNotBeNull().count { it == '.' } shouldBe 2
+        }
+
+        "wallet advertising a key still accepts a plain request object" { f ->
+            val (url, jar) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            // drop the wallet's metadata, so that the verifier does not encrypt
+            val holder = f.holder(EphemeralEncryptionKeyService()) {
+                jar.invoke(it?.copy(walletMetadataString = null)).getOrThrow()
+            }
+
+            holder.createAuthnResponse(url).getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+                .let { f.verifierOid4vp.validateAuthnResponse(it.url).getOrThrow() }
+                .vpTokenValidationResult.shouldNotBeNull().getOrThrow()
+        }
+
+        "request object encrypted to a key we never advertised is rejected" { f ->
+            val (url, jar) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            val foreignKey = EphemeralEncryptionKeyService().createKey().toEncryptionJsonWebKey()
+            val holder = f.holder(EphemeralEncryptionKeyService()) { params ->
+                EncryptJwe(EphemeralKeyWithoutCert())(
+                    JweHeader(JweAlgorithm.ECDH_ES, JweEncryption.A128GCM, keyId = foreignKey.keyId),
+                    jar.invoke(params).getOrThrow(),
+                    foreignKey,
+                ).getOrThrow().serialize()
+            }
+
+            holder.createAuthnResponse(url).isFailure shouldBe true
+        }
+
+        "encryption key is consumed, so the same request object can't be replayed" { f ->
+            val (url, jar) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            var first: String? = null
+            val holder = f.holder(EphemeralEncryptionKeyService()) { params ->
+                // serve the very first (encrypted) request object again on every subsequent fetch
+                first ?: jar.invoke(params).getOrThrow().also { first = it }
+            }
+
+            holder.createAuthnResponse(url).getOrThrow()
+            first.shouldNotBeNull()
+            holder.createAuthnResponse(url).isFailure shouldBe true
+        }
+
+        "encrypted request object is rejected if we did not ask for encryption" { f ->
+            val (url, jar) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            val foreignKey = EphemeralEncryptionKeyService().createKey().toEncryptionJsonWebKey()
+            val holder = f.holder(null) { params ->
+                EncryptJwe(EphemeralKeyWithoutCert())(
+                    JweHeader(JweAlgorithm.ECDH_ES, JweEncryption.A128GCM, keyId = foreignKey.keyId),
+                    jar.invoke(params).getOrThrow(),
+                    foreignKey,
+                ).getOrThrow().serialize()
+            }
+
+            holder.createAuthnResponse(url).isFailure shouldBe true
+        }
+
+        "no encryption when verifier and wallet share no content encryption algorithm" { f ->
+            val verifier = OpenId4VpVerifier(
+                keyMaterial = EphemeralKeyWithoutCert(),
+                clientIdScheme = ClientIdScheme.PreRegistered(f.clientId, f.redirectUrl),
+                supportedJweEncryptionAlgorithms = setOf(JweEncryption.A128GCM),
+            )
+            val (url, jar) = verifier.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            val holder = OpenId4VpHolder(
+                holder = f.holderAgent,
+                randomSource = RandomSource.Default,
+                ephemeralEncryptionKeyService = EphemeralEncryptionKeyService(),
+                supportedJweEncryptionAlgorithms = setOf(JweEncryption.A256GCM),
+                remoteResourceRetriever = { input ->
+                    if (input.url == f.requestUrl)
+                        jar.invoke(input.requestObjectParameters).getOrThrow().also { f.served = it }
+                    else null
+                },
+            )
+
+            holder.createAuthnResponse(url).getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+                .let { verifier.validateAuthnResponse(it.url).getOrThrow() }
+                .vpTokenValidationResult.shouldNotBeNull().getOrThrow()
+
+            // no common algorithm, so the verifier serves the plain signed request object
+            f.served.shouldNotBeNull().count { it == '.' } shouldBe 2
+        }
+
+        "request object dropping the wallet_nonce we sent is rejected" { f ->
+            val (url, jar) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            // drop the nonce, so that the verifier can't echo it back in the request object
+            val holder = f.holder(EphemeralEncryptionKeyService()) {
+                jar.invoke(it?.copy(walletNonce = null)).getOrThrow()
+            }
+
+            holder.createAuthnResponse(url).isFailure shouldBe true
+        }
+
+        "no wallet metadata is sent when fetching the request object with GET" { f ->
+            val (url, jar) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.GET
+                )
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            var params: at.asitplus.openid.RequestObjectParameters? = null
+            val holder = f.holder(EphemeralEncryptionKeyService()) {
+                params = it
+                jar.invoke(it).getOrThrow()
+            }
+
+            holder.createAuthnResponse(url).getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+                .let { f.verifierOid4vp.validateAuthnResponse(it.url).getOrThrow() }
+                .vpTokenValidationResult.shouldNotBeNull().getOrThrow()
+
+            params shouldBe null
+        }
+
+        "wallet metadata carries exactly one encryption key, fresh for every request" { f ->
+            val keyIds = mutableListOf<String?>()
+            val (url, jar) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            val holder = f.holder(EphemeralEncryptionKeyService()) { params ->
+                params.shouldNotBeNull().walletMetadata.shouldNotBeNull().jsonWebKeySet.shouldNotBeNull()
+                    .keys.also { it.size shouldBe 1 }
+                    .first().also { keyIds += it.keyId }
+                jar.invoke(params).getOrThrow()
+            }
+
+            holder.createAuthnResponse(url).getOrThrow()
+            holder.createAuthnResponse(url).getOrThrow()
+            keyIds.size shouldBe 2
+            keyIds[0].shouldNotBeNull() shouldNotBe keyIds[1].shouldNotBeNull()
+        }
+    }
+}

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEncryptedRequestTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEncryptedRequestTest.kt
@@ -16,6 +16,7 @@ import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.jws.EncryptJwe
 import at.asitplus.wallet.lib.openid.DummyCredentialDataProvider.issueAndStorePlainJwt
 import com.benasher44.uuid.uuid4
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -54,11 +55,13 @@ val OpenId4VpEncryptedRequestTest by matrixSuite {
                 var served: String? = null
                 fun holder(
                     ephemeralEncryptionKeyService: EphemeralEncryptionKeyService?,
+                    requireEncryptedRequests: Boolean = false,
                     serve: suspend (at.asitplus.openid.RequestObjectParameters?) -> String,
                 ) = OpenId4VpHolder(
                     holder = holderAgent,
                     randomSource = RandomSource.Default,
                     ephemeralEncryptionKeyService = ephemeralEncryptionKeyService,
+                    requireEncryptedRequests = requireEncryptedRequests,
                     remoteResourceRetriever = { input ->
                         if (input.url == requestUrl)
                             serve(input.requestObjectParameters).also { served = it }
@@ -264,6 +267,91 @@ val OpenId4VpEncryptedRequestTest by matrixSuite {
                 .vpTokenValidationResult.shouldNotBeNull().getOrThrow()
 
             params shouldBe null
+        }
+
+        "plain request object from the POST fetch is rejected when we require encryption" { f ->
+            val (url, jar) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            // drop the wallet's metadata, so that the verifier has no key to encrypt to
+            val holder = f.holder(EphemeralEncryptionKeyService(), requireEncryptedRequests = true) {
+                jar.invoke(it?.copy(walletMetadataString = null)).getOrThrow()
+            }
+
+            holder.createAuthnResponse(url).isFailure shouldBe true
+        }
+
+        "GET flow is still accepted when we require encryption" { f ->
+            val (url, jar) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.GET
+                )
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            // deliberate limit: a GET fetch never advertises a key, so there is nothing to require, see OpenID4VP 5.10
+            val holder = f.holder(EphemeralEncryptionKeyService(), requireEncryptedRequests = true) {
+                jar.invoke(it).getOrThrow()
+            }
+
+            holder.createAuthnResponse(url).getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+                .let { f.verifierOid4vp.validateAuthnResponse(it.url).getOrThrow() }
+                .vpTokenValidationResult.shouldNotBeNull().getOrThrow()
+        }
+
+        "requiring encryption needs a key service to advertise a key with" { f ->
+            shouldThrow<IllegalArgumentException> {
+                OpenId4VpHolder(
+                    holder = f.holderAgent,
+                    randomSource = RandomSource.Default,
+                    ephemeralEncryptionKeyService = null,
+                    requireEncryptedRequests = true,
+                )
+            }
+        }
+
+        "the decrypted request records the JWE header it came from" { f ->
+            val (url, jar) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            val holder = f.holder(EphemeralEncryptionKeyService()) { jar.invoke(it).getOrThrow() }
+
+            holder.startAuthorizationResponsePreparation(url).getOrThrow().apply {
+                requestWasEncrypted shouldBe true
+                request.decryptedFrom.shouldNotBeNull().apply {
+                    algorithm shouldBe JweAlgorithm.ECDH_ES
+                    encryption shouldBe JweEncryption.A128GCM
+                }
+            }
+        }
+
+        "a plain request records no JWE header" { f ->
+            val (url, jar) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            val holder = f.holder(null) { jar.invoke(it).getOrThrow() }
+
+            holder.startAuthorizationResponsePreparation(url).getOrThrow().apply {
+                requestWasEncrypted shouldBe false
+                request.decryptedFrom shouldBe null
+            }
         }
 
         "wallet metadata carries exactly one encryption key, fresh for every request" { f ->

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
@@ -384,7 +384,10 @@ val PreRegisteredClientTest by matrixSuite {
             val requestUrl = "https://www.example.com/request/${uuid4()}"
             val (authRequestUrlWithRequestUri, jar) = it.verifierOid4vp.createAuthnRequest(
                 requestOptionsAtomicAttribute(),
-                CreationOptions.RequestByReference(it.walletUrl, requestUrl)
+                // `wallet_nonce` is only sent when fetching the request object with POST, see OpenID4VP 1.0, 5.10
+                CreationOptions.RequestByReference(
+                    it.walletUrl, requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
             ).getOrThrow()
             jar.shouldNotBeNull()
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
@@ -178,11 +178,9 @@ val PreRegisteredClientTest by matrixSuite {
             val authnRequestUrl = it.verifierOid4vp.createAuthnRequest(
                 it.defaultRequestOptions, CreationOptions.SignedRequestByValue(it.walletUrl)
             ).getOrThrow().url
-            val authnRequest: JarRequestParameters =
-                Url(authnRequestUrl).encodedQuery.decodeFromUrlQuery()
+            val authnRequest: JarRequestParameters = Url(authnRequestUrl).encodedQuery.decodeFromUrlQuery()
             authnRequest.clientId shouldBe it.clientId
-            val jar = authnRequest.request
-                .shouldNotBeNull()
+            val jar = authnRequest.request.shouldNotBeNull()
             val jwsObject = JwsCompactTyped<AuthenticationRequestParameters>(jar)
             VerifyJwsObject().invoke(jwsObject.jws).getOrThrow()
 
@@ -272,8 +270,10 @@ val PreRegisteredClientTest by matrixSuite {
         }
 
         "test with deserializing" {
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(it.defaultRequestOptions)
-            val authnRequestUrlParams = authnRequest.encodeToParameters().formUrlEncode()
+            val authnRequest = it.verifierOid4vp
+                .createAuthnRequest(it.defaultRequestOptions, CreationOptions.Query(it.walletUrl))
+                .getOrThrow()
+            val authnRequestUrlParams = Url(authnRequest.url).encodedQuery
 
             val parsedAuthnRequest: AuthenticationRequestParameters =
                 authnRequestUrlParams.decodeFromUrlQuery()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RedirectUriClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RedirectUriClientTest.kt
@@ -166,7 +166,7 @@ val RedirectUriClientTest by matrixSuite {
             clientIdScheme.redirectUri shouldBe "https://example.com/callback"
             clientIdScheme.chain.size shouldBe 2
         }
-        
+
         "wrong client nonce in vp_token should lead to error" {
             val verifierOid4vp = OpenId4VpVerifier(
                 keyMaterial = it.verifierKeyMaterial,
@@ -315,8 +315,10 @@ val RedirectUriClientTest by matrixSuite {
         }
 
         "test with deserializing" {
-            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(defaultRequestOptions)
-            val authnRequestUrlParams = authnRequest.encodeToParameters().formUrlEncode()
+            val authnRequest = it.verifierOid4vp
+                .createAuthnRequest(defaultRequestOptions, CreationOptions.Query(it.walletUrl))
+                .getOrThrow()
+            val authnRequestUrlParams = Url(authnRequest.url).encodedQuery
 
             val parsedAuthnRequest: AuthenticationRequestParameters =
                 authnRequestUrlParams.decodeFromUrlQuery()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/KeyBindingTests.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/KeyBindingTests.kt
@@ -23,10 +23,11 @@ import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.SdJwtConstants
 import at.asitplus.wallet.lib.data.digest
 import at.asitplus.wallet.lib.data.toBase64UrlJsonString
-import at.asitplus.wallet.lib.oidvci.encodeToParameters
+import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
 import at.asitplus.wallet.lib.oidvci.formUrlEncode
 import at.asitplus.wallet.lib.openid.AuthenticationResponseResult
 import at.asitplus.wallet.lib.openid.ClientIdScheme
+import at.asitplus.wallet.lib.openid.CreationOptions
 import at.asitplus.wallet.lib.openid.DummyCredentialDataProvider.issueAndStoreSdJwt
 import at.asitplus.wallet.lib.openid.OpenId4VpHolder
 import at.asitplus.wallet.lib.openid.OpenId4VpVerifier
@@ -82,12 +83,11 @@ val KeyBindingTests by matrixSuite {
                 stateToAuthnRequestStore = it.externalMapStore
             )
             val requestOptions = buildRequestOptions(transactionDataHashAlgorithms = null)
-            val authnRequest = verifierOid4Vp.createPlainAuthnRequest(requestOptions)
 
-            val authnRequestUrl = URLBuilder(it.walletUrl).apply {
-                authnRequest.encodeToParameters()
-                    .forEach { parameters.append(it.key, it.value) }
-            }.buildString().apply {
+            val authnRequestUrl = verifierOid4Vp.createAuthnRequest(
+                requestOptions = requestOptions,
+                creationOptions = CreationOptions.Query(it.walletUrl)
+            ).getOrThrow().url.apply {
                 this shouldContain "transaction_data"
             }
 
@@ -116,14 +116,13 @@ val KeyBindingTests by matrixSuite {
                 stateToAuthnRequestStore = it.externalMapStore
             )
             val requestOptions = buildRequestOptions(transactionDataHashAlgorithms = setOf(SdJwtConstants.SHA_384))
-            val authnRequest = verifierOid4Vp.createPlainAuthnRequest(requestOptions)
 
-            val authnRequestUrl = URLBuilder(it.walletUrl).apply {
-                authnRequest.encodeToParameters()
-                    .forEach { parameters.append(it.key, it.value) }
-            }.buildString()
-
-            authnRequestUrl shouldContain "transaction_data"
+            val authnRequestUrl = verifierOid4Vp.createAuthnRequest(
+                requestOptions = requestOptions,
+                creationOptions = CreationOptions.Query(it.walletUrl)
+            ).getOrThrow().url.apply {
+                this.shouldContain("transaction_data")
+            }
 
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequestUrl).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
@@ -148,15 +147,20 @@ val KeyBindingTests by matrixSuite {
                 clientIdScheme = ClientIdScheme.RedirectUri(it.clientId),
                 stateToAuthnRequestStore = it.externalMapStore
             )
+
             val requestOptions =
                 buildRequestOptions(OpenIdConstants.ResponseMode.DirectPost, setOf(SdJwtConstants.SHA_256))
-            val authnRequest = verifierOid4Vp.createPlainAuthnRequest(requestOptions)
+
+            val authnRequest = verifierOid4Vp.createAuthnRequest(
+                requestOptions = requestOptions,
+                creationOptions = CreationOptions.Query(it.walletUrl)
+            ).getOrThrow().url.run {
+                Url(this).encodedQuery.decodeFromUrlQuery<AuthenticationRequestParameters>()
+            }
 
             val malignResponse = it.holderOid4vp.createAuthnResponse(
                 joseCompliantSerializer.encodeToString(
-                    authnRequest.copy(
-                        transactionData = malignTransactionData()
-                    )
+                    authnRequest.copy(transactionData = malignTransactionData())
                 )
             ).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Post>()
@@ -180,13 +184,15 @@ val KeyBindingTests by matrixSuite {
             )
 
             val requestOptions = buildRequestOptions(OpenIdConstants.ResponseMode.DirectPost, null)
-            val authnRequest = lenientVerifier.createPlainAuthnRequest(requestOptions)
-
+            val authnRequest = lenientVerifier.createAuthnRequest(
+                requestOptions = requestOptions,
+                creationOptions = CreationOptions.Query(it.walletUrl)
+            ).getOrThrow().url.run {
+                Url(this).encodedQuery.decodeFromUrlQuery<AuthenticationRequestParameters>()
+            }
             val malignResponse = it.holderOid4vp.createAuthnResponse(
                 joseCompliantSerializer.encodeToString(
-                    authnRequest.copy(
-                        transactionData = malignTransactionData()
-                    )
+                    authnRequest.copy(transactionData = malignTransactionData())
                 )
             ).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Post>()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/RqesRequestOptionsTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/RqesRequestOptionsTest.kt
@@ -3,6 +3,7 @@ package at.asitplus.wallet.lib.rqes
 import at.asitplus.csc.collection_entries.RqesDocumentDigestEntry
 import at.asitplus.csc.collection_entries.RqesDocumentDigestEntry.DocumentLocationMethod
 import at.asitplus.csc.enums.SignatureQualifier
+import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.QesAuthorization
 import at.asitplus.openid.TransactionData
@@ -19,7 +20,9 @@ import at.asitplus.wallet.lib.data.AttributeIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.SdJwtConstants
 import at.asitplus.wallet.lib.data.toTransactionData
+import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
 import at.asitplus.wallet.lib.openid.ClientIdScheme
+import at.asitplus.wallet.lib.openid.CreationOptions
 import at.asitplus.wallet.lib.openid.CredentialPresentationRequestBuilder
 import at.asitplus.wallet.lib.openid.OpenId4VpRequestOptions
 import at.asitplus.wallet.lib.openid.OpenId4VpVerifier
@@ -42,13 +45,14 @@ val RqesRequestOptionsTest by matrixSuite {
 
         test("Authentication request contains transactionData") {
             val requestOptions = buildRequestOptions(transactionDataHashAlgorithms = setOf(SdJwtConstants.SHA_256))
-            it.verifierOid4Vp.createPlainAuthnRequest(requestOptions).apply {
-                val dcqlId = dcqlQuery.shouldNotBeNull().credentials.first().id
-                transactionData.shouldNotBeNull().first().toTransactionData().apply {
-                    transactionDataHashAlgorithms shouldNotBe null
-                    credentialIds.first() shouldBe dcqlId.string
+            it.verifierOid4Vp.createAuthnRequest(requestOptions, CreationOptions.Query("https://example.com"))
+                .getOrThrow().url.decodeFromUrlQuery<AuthenticationRequestParameters>().apply {
+                    val dcqlId = dcqlQuery.shouldNotBeNull().credentials.first().id
+                    transactionData.shouldNotBeNull().first().toTransactionData().apply {
+                        transactionDataHashAlgorithms shouldNotBe null
+                        credentialIds.first() shouldBe dcqlId.string
+                    }
                 }
-            }
         }
     }
 }


### PR DESCRIPTION
Implements a missing feature: In OpenID4VP verifiers can support `POST` requests to deliver the Authn Request. In those requests the wallet may send a key that the verifier should use to encrypt the authn request for. See [OpenID4VP 5.10](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-request-uri-method-post).