### PR TITLE
Remove unused parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Release 8.0.0 (unreleased):
     - Rename existing `ClientAuthenticationService` to `AttestationBasedClientAuthenticationService` and extract an interface
     - Return the validated token from `validateAccessToken()` in `TokenVerificationService` and `OAuth2AuthorizationServerAdapter` as `ValidatedAccessToken`, and move `validCredentialIdentifiers` from `TokenInfo` to `ValidatedAccessToken`
     - Authorize credential requests in `CredentialIssuer` from the `ValidatedAccessToken`
+    - In `EncryptJwe` remove `keyMaterial` as it always relies on ephemeral keys embedded in the JWE header
  - Dependencies:
     - Update to [Signum 3.25.0](https://github.com/a-sit-plus/signum/releases/tag/3.25.0) for HPKE support
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -770,11 +770,23 @@ class SimpleAuthorizationService @JvmOverloads constructor(
         this?.dpop?.let { tokenService.verification.extractValidatedClientKey(this).getOrThrow() }
 }
 
+/**
+ * Implements [RFC 9449 8.2.](https://datatracker.ietf.org/doc/html/rfc9449#name-providing-a-new-nonce-value):
+ * Authorization servers may include a fresh DPoP nonce by including values in HTTP 200 responses
+ */
 data class ResponseWithDpopNonce<T>(
     val response: T,
+    /** Set as HTTP header `DPoP-Nonce` in the response, see [HttpHeaders.DPoPNonce] */
     val dpopNonce: String?,
 )
 
+/**
+ * Internal class used to store pushed authorization requests created for clients in
+ * [SimpleAuthorizationService.requestUriToPushedAuthorizationRequest],
+ * which are referenced by a `request_uri` and fetched later on in the process.
+ *
+ * Needs to be public to allow for implementations of [MapStore] with this type.
+ */
 data class PushedAuthorizationRequest(
     val request: AuthenticationRequestParameters,
     val clientBinding: ClientBinding

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/IssuerEncryptionService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/IssuerEncryptionService.kt
@@ -31,7 +31,7 @@ import kotlin.jvm.JvmOverloads
  */
 class IssuerEncryptionService @JvmOverloads constructor(
     /** Encrypt credential response, if requested by client or [requireResponseEncryption] is set. */
-    private val encryptCredentialResponse: EncryptJweFun = EncryptJwe(EphemeralKeyWithoutCert()),
+    private val encryptCredentialResponse: EncryptJweFun = EncryptJwe(),
     /** Whether to indicate in [metadataCredentialResponseEncryption] if credential response encryption is required. */
     internal val requireResponseEncryption: Boolean = false,
     /** Algorithms to indicate support for credential response encryption. */

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletEncryptionService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletEncryptionService.kt
@@ -41,7 +41,7 @@ class WalletEncryptionService @JvmOverloads constructor(
     /** Whether to encrypt the credential request, if supported by the issuer.*/
     internal val requireRequestEncryption: Boolean = false,
     /** Encrypt credential request, if requested by the issuer. */
-    private val encryptCredentialRequest: EncryptJweFun = EncryptJwe(EphemeralKeyWithoutCert()),
+    private val encryptCredentialRequest: EncryptJweFun = EncryptJwe(),
     /** Algorithms to indicate support for credential response encryption. */
     private val supportedJweAlgorithm: JweAlgorithm = JweAlgorithm.ECDH_ES,
     /** Algorithm to fallback to for credential response encryption. */

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -79,8 +79,8 @@ class OpenId4VpHolder @JvmOverloads constructor(
     private val holder: Holder = HolderAgent(keyMaterial),
     @Deprecated("Support for SIOPv2 has been removed")
     private val signIdToken: SignJwtFun<IdToken> = SignJwt(keyMaterial, JwsHeaderCertOrJwk()),
-    /** Encrypts the authn response to the holder using [keyMaterial], if requested. */
-    private val encryptJarm: EncryptJweFun = EncryptJwe(keyMaterial),
+    /** Encrypts the authn response to the verifier, if this has been requested. */
+    private val encryptJarm: EncryptJweFun = EncryptJwe(),
     /** Advertised in [metadata] and compared against holder's requirements. */
     private val supportedAlgorithms: Set<SignatureAlgorithm> = setOf(SignatureAlgorithm.ECDSAwithSHA256),
     /** Signs the session transcript for mDoc responses. */

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpRequestFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpRequestFactory.kt
@@ -70,7 +70,7 @@ internal class OpenId4VpRequestFactory(
     /** Algorithms supported to decrypt responses from wallets and to encrypt request objects. */
     private val supportedJweEncryptionAlgorithms: Set<JweEncryption>,
     /** Encrypts the request object, if the wallet asked us to in its `wallet_metadata`, see [createRequestObject]. */
-    private val encryptRequestObject: EncryptJweFun = EncryptJwe(EphemeralKeyWithoutCert()),
+    private val encryptRequestObject: EncryptJweFun = EncryptJwe(),
 ) {
 
     private val supportedJwsAlgorithms = supportedAlgorithms

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEncryptedRequestTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEncryptedRequestTest.kt
@@ -143,7 +143,7 @@ val OpenId4VpEncryptedRequestTest by matrixSuite {
 
             val foreignKey = EphemeralEncryptionKeyService().createKey().toEncryptionJsonWebKey()
             val holder = f.holder(EphemeralEncryptionKeyService()) { params ->
-                EncryptJwe(EphemeralKeyWithoutCert())(
+                EncryptJwe()(
                     JweHeader(JweAlgorithm.ECDH_ES, JweEncryption.A128GCM, keyId = foreignKey.keyId),
                     jar.invoke(params).getOrThrow(),
                     foreignKey,
@@ -184,7 +184,7 @@ val OpenId4VpEncryptedRequestTest by matrixSuite {
 
             val foreignKey = EphemeralEncryptionKeyService().createKey().toEncryptionJsonWebKey()
             val holder = f.holder(null) { params ->
-                EncryptJwe(EphemeralKeyWithoutCert())(
+                EncryptJwe()(
                     JweHeader(JweAlgorithm.ECDH_ES, JweEncryption.A128GCM, keyId = foreignKey.keyId),
                     jar.invoke(params).getOrThrow(),
                     foreignKey,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
@@ -457,6 +457,8 @@ class DecryptJwe(
 /**
  * Decrypts JWE payloads with the ephemeral key referenced by the JWE's `kid` header, as per
  * [OpenID4VP 1.0, 8.3](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-encrypted-responses).
+ *
+ * *Note that this function only loads the key but does not consume it from [ephemeralEncryptionKeyService]!*
  */
 class DecryptJweWithEphemeralKey(
     private val ephemeralEncryptionKeyService: EphemeralEncryptionKeyService,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
@@ -194,10 +194,8 @@ fun interface EncryptJweFun {
 }
 
 
-/** Create a [JweEncrypted], setting values for [JweHeader]. */
-class EncryptJwe(
-    val keyMaterial: KeyMaterial,
-) : EncryptJweFun {
+/** Create a [JweEncrypted], setting values for [JweHeader], uses ephemeral private keys. */
+class EncryptJwe : EncryptJweFun {
     override suspend operator fun invoke(
         header: JweHeader,
         payload: String,

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceTest.kt
@@ -142,8 +142,7 @@ val JwsServiceTest by matrixSuite {
         }
 
         test("encrypted object can be decrypted") {
-            val encrypterKey = EphemeralKeyWithoutCert()
-            val encrypter = EncryptJwe(encrypterKey)
+            val encrypter = EncryptJwe()
             val decrypterKey = EphemeralKeyWithoutCert()
             val decrypter = DecryptJwe(decrypterKey)
 

--- a/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/jws/JweServiceJvmTest.kt
+++ b/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/jws/JweServiceJvmTest.kt
@@ -59,7 +59,7 @@ val JweServiceJvmTest by matrixSuite {
         val jvmDecrypter = ECDHDecrypter(ephemeralKey.jcaPrivateKey as ECPrivateKey)
 
         val keyMaterial = EphemeralKeyWithoutCert(ephemeralKey)
-        val encrypter = EncryptJwe(keyMaterial)
+        val encrypter = EncryptJwe()
         val decrypter = DecryptJwe(keyMaterial)
         val randomPayload = uuid4().toString()
 


### PR DESCRIPTION
By removing that unused parameter we clearly state the one-shot shape of encrypting JWEs as used in OpenID4VP and other standards.