### PR TITLE
OpenID4VP: Fix parsing of request objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Release 8.0.0 (unreleased):
     - Terminate request processing if the request object does not carry back the `wallet_nonce` we sent, as required by OpenID4VP 1.0, Section 5.10.1
     - Pass `requireEncryptedRequests = true` to `OpenId4VpHolder` to reject a plain request object served at a `request_uri` fetched with POST
     - Add `decryptedFrom` to `RequestParametersFrom.Jws` and `RequestParametersFrom.Json`, holding the header of the JWE a request was decrypted from, and `requestWasEncrypted` to `AuthorizationResponsePreparationState`
+    - Reject request objects that are not a JWS (and optionally encrypted) per RFC 9101, Section 4
+    - Reject request objects that do not carry `typ: oauth-authz-req+jwt` as required by OpenID4VP 1.0, Section 5.1
+    - Deprecate `CreationOptions.RequestByReference` at error level: it serves an unsigned request object by reference, which OpenID4VP 1.0, Section 5.10.1 forbids, instead use `CreationOptions.SignedRequestByReference`
 - OpenID for Verifiable Credential Issuance:
     - Rework validation of key attestation statements
     - Make sure a `nonce` provided by the credential issuer can only be used for one request to the credential endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Release 8.0.0 (unreleased):
     - Pass `requireEncryptedRequests = true` to `OpenId4VpHolder` to reject a plain request object served at a `request_uri` fetched with POST
     - Add `decryptedFrom` to `RequestParametersFrom.Jws` and `RequestParametersFrom.Json`, holding the header of the JWE a request was decrypted from, and `requestWasEncrypted` to `AuthorizationResponsePreparationState`
     - Reject request objects that are not a JWS (and optionally encrypted) per RFC 9101, Section 4
-    - Reject request objects that do not carry `typ: oauth-authz-req+jwt` as required by OpenID4VP 1.0, Section 5.1
+    - Reject request objects that do not carry `typ: oauth-authz-req+jwt` as required by OpenID4VP 1.0, Section 5, also for signed and multi-signed requests over the DC API
     - Deprecate `CreationOptions.RequestByReference` at error level: it serves an unsigned request object by reference, which OpenID4VP 1.0, Section 5.10.1 forbids, instead use `CreationOptions.SignedRequestByReference`
 - OpenID for Verifiable Credential Issuance:
     - Rework validation of key attestation statements

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthorizationRequestValidator.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthorizationRequestValidator.kt
@@ -9,6 +9,7 @@ import at.asitplus.openid.OpenIdConstants.ClientIdScheme
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import at.asitplus.signum.indispensable.josef.JWS
 import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.signum.indispensable.josef.JwsAlgorithm
 import at.asitplus.signum.indispensable.josef.JwsCompact
@@ -19,6 +20,7 @@ import at.asitplus.signum.indispensable.pki.leaf
 import at.asitplus.wallet.lib.agent.VerifySignature
 import at.asitplus.wallet.lib.agent.VerifySignatureFun
 import at.asitplus.wallet.lib.agent.requireTrustedSigningCertificate
+import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.jws.VerifyJwsObjectTrusted
 import at.asitplus.wallet.lib.jws.VerifyJwsObjectTrustedCertificate
 import at.asitplus.wallet.lib.jws.VerifyJwsSignature
@@ -29,7 +31,6 @@ import at.asitplus.wallet.lib.utils.DefaultMapStore
 import at.asitplus.wallet.lib.utils.MapStore
 import io.ktor.http.*
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import kotlin.coroutines.cancellation.CancellationException
 
 internal class AuthorizationRequestValidator(
     private val walletNonceMapStore: MapStore<String, String> = DefaultMapStore(),
@@ -42,6 +43,9 @@ internal class AuthorizationRequestValidator(
     suspend fun validateAuthorizationRequest(
         request: RequestParametersFrom<AuthenticationRequestParameters>,
     ) {
+        (request as? RequestParametersFrom.RequestParametersSigned<AuthenticationRequestParameters>)
+            ?.jwsTyped?.jws?.requireRequestObjectType()
+
         request.parameters.responseType?.let {
             if (!it.contains(OpenIdConstants.VP_TOKEN)) {
                 throw InvalidRequest("invalid response_type: $it")
@@ -188,7 +192,8 @@ internal class AuthorizationRequestValidator(
         }
         when (this) {
             is RequestParametersFrom.OpenId4VpDcApiSigned,
-            is RequestParametersFrom.OpenId4VpDcApiMultiSigned -> {
+            is RequestParametersFrom.OpenId4VpDcApiMultiSigned,
+                -> {
                 if (this.parameters.clientId == null)
                     throw InvalidRequest("client_id must be set for signed DC API request")
                 val expectedOrigins = this.parameters.expectedOrigins
@@ -345,4 +350,20 @@ private inline fun <reified T : RelyingPartyTrust> Set<RelyingPartyTrust>.requir
         failures += catchingUnwrapped { check(source) }.exceptionOrNull() ?: return
     }
     throw InvalidRequest("$rejected: ${failures.joinToString { it.message ?: it::class.simpleName ?: "" }}")
+}
+
+/**
+ * Require `typ` to be `oauth-authz-req+jwt` per OpenID4VP 1.0, 5.
+ *
+ * A request carrying several signatures, i.e. a multi-signed DC API request per OpenID4VP 1.0, A.3.2.2, is still one
+ * request object, so every protected header has to declare it.
+ */
+@Throws(OAuth2Exception::class)
+internal fun JWS.requireRequestObjectType() = when (this) {
+    is JwsCompact -> listOf(jwsHeader)
+    is JwsGeneral -> jwsHeaders
+    else -> throw InvalidRequest("Unsupported request object signature: $this")
+}.forEach {
+    if (it.type != JwsContentTypeConstants.OAUTH_AUTHZ_REQUEST)
+        throw InvalidRequest("request object typ is not ${JwsContentTypeConstants.OAUTH_AUTHZ_REQUEST}: ${it.type}")
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/ClientIdScheme.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/ClientIdScheme.kt
@@ -49,7 +49,9 @@ sealed class ClientIdScheme(
     ) {
 
         init {
-            require(redirectUri.contains(":/"))
+            require(redirectUri.contains(":/")) {
+                "Redirect URI must contain a scheme and a host"
+            }
         }
     }
 
@@ -78,7 +80,9 @@ sealed class ClientIdScheme(
     ) {
 
         init {
-            require(chain.first().tbsCertificate.subjectAlternativeNames?.dnsNames?.contains(clientIdDnsName) == true)
+            require(chain.first().tbsCertificate.subjectAlternativeNames?.dnsNames?.contains(clientIdDnsName) == true) {
+                "Client Identifier $clientIdDnsName not in DNS names in leaf certificate"
+            }
         }
     }
 
@@ -118,7 +122,9 @@ sealed class ClientIdScheme(
     ) {
 
         init {
-            require(redirectUri.contains(":/"))
+            require(redirectUri.contains(":/")) {
+                "Redirect URI must contain a scheme and a host"
+            }
         }
     }
 
@@ -140,9 +146,17 @@ sealed class ClientIdScheme(
     ) {
 
         init {
-            require(!clientId.contains(":"))
-            require(redirectUri.contains(":/"))
-            issuerUri?.let { require(it.contains(":/")) }
+            require(!clientId.contains(":")) {
+                "Client ID must not contain a scheme"
+            }
+            require(redirectUri.contains(":/")) {
+                "Redirect URI must contain a scheme and a host"
+            }
+            issuerUri?.let {
+                require(it.contains(":/")) {
+                    "Issuer URI must contain a scheme and a host"
+                }
+            }
         }
     }
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/CreationOptions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/CreationOptions.kt
@@ -14,8 +14,14 @@ sealed class CreationOptions {
 
     /**
      * Appends [requestUrl] to [walletUrl], callers need to call [CreatedRequest.loadRequestObject] with the
-     * Wallet's request to actually create the authn request object.
+     * Wallet's request to actually create the authn request object, which will be unsigned.
      **/
+    @Deprecated(
+        "Forbidden by OpenID4VP 1.0, 5.10.1: the request URI response MUST be a signed request object. The " +
+                "redirect_uri prefix, the only one that cannot sign, therefore cannot use by-reference at all.",
+        ReplaceWith("SignedRequestByReference(walletUrl, requestUrl, requestUrlMethod)"),
+        level = DeprecationLevel.ERROR,
+    )
     data class RequestByReference(
         val walletUrl: String,
         val requestUrl: String,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiHolder.kt
@@ -6,10 +6,8 @@ import at.asitplus.dcapi.DCAPIResponse
 import at.asitplus.dcapi.DigitalCredentialInterface
 import at.asitplus.dcapi.IsoMdocResponse
 import at.asitplus.openid.RequestParametersFrom
-import at.asitplus.openid.RequestParametersFrom.IsoMdocDcApi
-import at.asitplus.openid.RequestParametersFrom.OpenId4VpDcApiMultiSigned
-import at.asitplus.openid.RequestParametersFrom.OpenId4VpDcApiSigned
-import at.asitplus.openid.RequestParametersFrom.OpenId4VpDcApiUnsigned
+import at.asitplus.openid.RequestParametersFrom.*
+import at.asitplus.wallet.lib.agent.CredentialMatchingResult
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.Holder
 import at.asitplus.wallet.lib.agent.HolderAgent
@@ -44,7 +42,7 @@ class DcApiHolder @JvmOverloads constructor(
      * consent, and resume with [finalizeAuthorizationResponse].
      */
     suspend fun startAuthorizationResponsePreparation(
-        request: RequestParametersFrom.DcApiRequest,
+        request: DcApiRequest,
     ): KmmResult<DcApiPreparationState> = catching {
         when (request) {
             is OpenId4VpDcApiSigned -> DcApiPreparationState.OpenId4Vp(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -132,6 +132,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     /**
      * Creates a new authentication request conforming to OpenID4VP.
      */
+    @Suppress("DEPRECATION_ERROR")
     suspend fun createAuthnRequest(
         requestOptions: OpenId4VpRequestOptions,
         creationOptions: CreationOptions,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
@@ -19,7 +19,6 @@ import at.asitplus.wallet.lib.data.MediaTypes
 import at.asitplus.wallet.lib.extensions.getEncryptionTargetKey
 import at.asitplus.wallet.lib.jws.DecryptJweFun
 import at.asitplus.wallet.lib.jws.DecryptJweWithEphemeralKey
-import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.oidc.RequestObjectJwsVerifier
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidRequest
 import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
@@ -159,12 +158,7 @@ class RequestParser(
     ): RequestParametersFrom<*>? =
         catching { JwsCompactTyped<RequestParameters>(this) }
             .getOrNull()?.let { jws ->
-                jws.jws.jwsHeader.type.let { type ->
-                    if (type != JwsContentTypeConstants.OAUTH_AUTHZ_REQUEST)
-                        throw InvalidRequest(
-                            "request object typ is not ${JwsContentTypeConstants.OAUTH_AUTHZ_REQUEST}: $type"
-                        )
-                }
+                jws.jws.requireRequestObjectType()
                 RequestParametersFrom.Jws(
                     jws = jws.jws,
                     parameters = jws.payload,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
@@ -19,6 +19,7 @@ import at.asitplus.wallet.lib.data.MediaTypes
 import at.asitplus.wallet.lib.extensions.getEncryptionTargetKey
 import at.asitplus.wallet.lib.jws.DecryptJweFun
 import at.asitplus.wallet.lib.jws.DecryptJweWithEphemeralKey
+import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.oidc.RequestObjectJwsVerifier
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidRequest
 import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
@@ -101,8 +102,11 @@ class RequestParser(
         parameters: JarRequestParameters,
         parent: RequestParametersFrom<out RequestParameters>?,
     ): RequestParametersFrom<*>? = parameters.request?.let {
+        // no JSON fallback: RFC 9101, 4 admits only a signed, or a signed and encrypted, request object. Throwing
+        // rather than returning null keeps this arm parallel to the `request_uri` one below, and reports the actual
+        // problem instead of letting the elvis fall through to a request that is missing every parameter
         it.parseAsJwsRequest(parent)
-            ?: it.parseFromJson(parent)
+            ?: throw InvalidRequest("request content not a valid request object")
     } ?: parameters.requestUri?.let { uri ->
         val method = parameters.requestUriMethod?.toHttpMethod() ?: HttpMethod.Get
         // only the POST request to the request URI endpoint has a channel for these, see OpenID4VP 1.0, 5.10, and it
@@ -117,7 +121,6 @@ class RequestParser(
                 throw InvalidRequest("request object from $uri is not encrypted, but we require encryption")
             (fromJwe
                 ?: it.parseAsJwsRequest(parent)
-                ?: it.parseFromJson(parent)
                 ?: throw InvalidRequest("request_uri content not a valid request object: $uri"))
                 .also { request -> request.requireWalletNonce(requestObjectParameters?.walletNonce) }
         }
@@ -156,6 +159,12 @@ class RequestParser(
     ): RequestParametersFrom<*>? =
         catching { JwsCompactTyped<RequestParameters>(this) }
             .getOrNull()?.let { jws ->
+                jws.jws.jwsHeader.type.let { type ->
+                    if (type != JwsContentTypeConstants.OAUTH_AUTHZ_REQUEST)
+                        throw InvalidRequest(
+                            "request object typ is not ${JwsContentTypeConstants.OAUTH_AUTHZ_REQUEST}: $type"
+                        )
+                }
                 RequestParametersFrom.Jws(
                     jws = jws.jws,
                     parameters = jws.payload,
@@ -185,9 +194,10 @@ class RequestParser(
         val decrypted = decryptRequestObject(jwe).getOrElse {
             throw InvalidRequest("Decryption of request object failed", it)
         }
+        // OpenID4VP 1.0, 5.10.1 permits encryption only in addition to signing, never instead of it, and per
+        // RFC 9101, 6.1 decrypting a request object yields "a signed Request Object"
         return decrypted.payload.parseAsJwsRequest(parent, jwe.header)
-            ?: decrypted.payload.parseFromJson(parent, jwe.header)
-            ?: throw InvalidRequest("Decrypted request object is not a valid request object")
+            ?: throw InvalidRequest("Decrypted request object is not a signed request object")
     }
 
 }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
@@ -8,6 +8,7 @@ import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.josef.JweAlgorithm
 import at.asitplus.signum.indispensable.josef.JweEncryption
 import at.asitplus.signum.indispensable.josef.JweHeader
+import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.JwsTyped
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.toJwsFlattened
@@ -42,7 +43,7 @@ val AuthenticationRequestParameterFromSerializerTest by matrixSuite {
         clientIdScheme = ClientIdScheme.PreRegistered(clientId, redirectUrl),
     )
     val representations = listOf(PLAIN_JWT, SD_JWT, ISO_MDOC)
-    val byReference = CreationOptions.RequestByReference("https://example.com", "https://example.com")
+    val byReference = CreationOptions.SignedRequestByReference("https://example.com", "https://example.com")
 
     representations.forEach { representation ->
         val reqOptions = OpenId4VpRequestOptions(
@@ -52,10 +53,8 @@ val AuthenticationRequestParameterFromSerializerTest by matrixSuite {
         )
 
         "URL test $representation" {
-            val authnRequest = verifierOid4vp.createAuthnRequest(
-                reqOptions,
-                CreationOptions.Query(walletUrl)
-            ).getOrThrow().url
+            val authnRequest =
+                verifierOid4vp.createAuthnRequest(reqOptions, CreationOptions.Query(walletUrl)).getOrThrow().url
 
             val params = holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow().request
                 .shouldBeInstanceOf<RequestParametersFrom.Uri<AuthenticationRequestParameters>>()
@@ -67,8 +66,12 @@ val AuthenticationRequestParameterFromSerializerTest by matrixSuite {
         }
 
         "Json test $representation" {
-            val authnRequest = verifierOid4vp.createAuthnRequest(reqOptions, byReference).getOrThrow()
-                .loadRequestObject.shouldNotBeNull().invoke(RequestObjectParameters()).getOrThrow()
+            val authnRequest = joseCompliantSerializer.encodeToString(
+                verifierOid4vp.createAuthnRequest(reqOptions, byReference).getOrThrow()
+                    .loadRequestObject.shouldNotBeNull().invoke(RequestObjectParameters()).getOrThrow().run {
+                        JwsCompactTyped<AuthenticationRequestParameters>(this).payload
+                    }
+            )
             authnRequest.shouldNotContain(DifInputDescriptor::class.simpleName!!)
             val params = holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow().request
                 .shouldBeInstanceOf<RequestParametersFrom.Json<AuthenticationRequestParameters>>()
@@ -80,10 +83,10 @@ val AuthenticationRequestParameterFromSerializerTest by matrixSuite {
         }
 
         "DcApiUnsigned test $representation" {
-            val parameters = joseCompliantSerializer.decodeFromString<AuthenticationRequestParameters>(
-                verifierOid4vp.createAuthnRequest(reqOptions, byReference).getOrThrow()
-                    .loadRequestObject.shouldNotBeNull().invoke(RequestObjectParameters()).getOrThrow()
-            )
+            val parameters = verifierOid4vp.createAuthnRequest(reqOptions, byReference).getOrThrow()
+                .loadRequestObject.shouldNotBeNull().invoke(RequestObjectParameters()).getOrThrow().run {
+                    JwsCompactTyped<AuthenticationRequestParameters>(this).payload
+                }
             val authnRequest = RequestParametersFrom.OpenId4VpDcApiUnsigned(
                 parameters = parameters,
                 jsonString = joseCompliantSerializer.encodeToString(parameters),

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpDcApiProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpDcApiProtocolTest.kt
@@ -34,6 +34,9 @@ import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest
+import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
+import at.asitplus.wallet.lib.jws.JwsHeaderNone
+import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.data.rfc3986.toUri
 import at.asitplus.wallet.lib.openid.DummyCredentialDataProvider.issueAndStoreIsoMdoc
 import at.asitplus.wallet.lib.openid.DummyCredentialDataProvider.issueAndStoreSdJwt
@@ -611,6 +614,60 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
             f.holderOid4vp.finalizeAuthorizationResponse(preparationState).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.DcApi>()
                 .params.shouldBeInstanceOf<OpenId4VpResponseMultiSigned>()
+        }
+
+        test("DC API signed: wrong typ is rejected") { f ->
+            // OpenID4VP 1.0, A.3.2.1 encodes the DC API signed request as "a request object as defined in Section 5",
+            // so Section 5's "Wallets MUST NOT process Request Objects where the typ Header Parameter is not present
+            // or does not have the value oauth-authz-req+jwt" applies here too
+            val reqOptions = OpenId4VpRequestOptions(
+                presentationRequest = dcqlRequest,
+                responseMode = OpenIdConstants.ResponseMode.DcApi,
+                expectedOrigins = listOf(callingOrigin),
+            )
+            val payload = f.createSignedAuthnRequest(reqOptions).payload
+
+            val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiSigned(
+                jwsTyped = SignJwt<AuthenticationRequestParameters>(EphemeralKeyWithoutCert(), JwsHeaderNone())(
+                    JwsContentTypeConstants.JWT, payload, AuthenticationRequestParameters.serializer()
+                ).getOrThrow(),
+                credentialIds = listOf(credentialId),
+                callingPackageName = callingPackageName,
+                callingOrigin = callingOrigin,
+            )
+
+            f.holderOid4vp.startAuthorizationResponsePreparation(dcApiRequest).apply {
+                isFailure shouldBe true
+                exceptionOrNull()!!.message!! shouldContain "typ"
+            }
+        }
+
+        test("DC API multisigned: every signature has to carry the typ, not just one") { f ->
+            // one request object, several protected headers, see OpenID4VP 1.0, A.3.2.2: a verifier typing only the
+            // signature we happen to rely on is not enough
+            val reqOptions = OpenId4VpRequestOptions(
+                presentationRequest = dcqlRequest,
+                responseMode = OpenIdConstants.ResponseMode.DcApi,
+                expectedOrigins = listOf(callingOrigin),
+            )
+            val signedRequest = f.createSignedAuthnRequest(reqOptions)
+            val untyped = SignJwt<AuthenticationRequestParameters>(EphemeralKeyWithoutCert(), JwsHeaderNone())(
+                JwsContentTypeConstants.JWT, signedRequest.payload, AuthenticationRequestParameters.serializer()
+            ).getOrThrow()
+
+            val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiMultiSigned(
+                jwsTyped = JwsTyped<AuthenticationRequestParameters>(
+                    listOf(signedRequest.jws.toJwsFlattened(), untyped.jws.toJwsFlattened())
+                ),
+                credentialIds = listOf(credentialId),
+                callingPackageName = callingPackageName,
+                callingOrigin = callingOrigin,
+            )
+
+            f.holderOid4vp.startAuthorizationResponsePreparation(dcApiRequest).apply {
+                isFailure shouldBe true
+                exceptionOrNull()!!.message!! shouldContain "typ"
+            }
         }
 
         test("DC API multisigned: origin mismatch rejects with InvalidRequest when expected_origins is set") { f ->

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEncryptedRequestTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEncryptedRequestTest.kt
@@ -418,7 +418,7 @@ val OpenId4VpEncryptedRequestTest by matrixSuite {
         }
 
         "request object with the wrong typ is rejected" { f ->
-            // OpenID4VP 1.0, 5.1: "Wallets MUST NOT process Request Objects where the typ Header Parameter is not
+            // OpenID4VP 1.0, 5: "Wallets MUST NOT process Request Objects where the typ Header Parameter is not
             // present or does not have the value oauth-authz-req+jwt"
             val (url, _) = f.verifierOid4vp.createAuthnRequest(
                 f.requestOptions,

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEncryptedRequestTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEncryptedRequestTest.kt
@@ -1,11 +1,15 @@
 package at.asitplus.wallet.lib.openid
 
+import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.JarRequestParameters
+import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.josef.JweAlgorithm
 import at.asitplus.signum.indispensable.josef.JweEncryption
 import at.asitplus.signum.indispensable.josef.JweHeader
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.wallet.lib.DefaultNonceService
 import at.asitplus.wallet.lib.RequestOptionsCredential
 import at.asitplus.wallet.lib.agent.EphemeralEncryptionKeyService
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
@@ -14,13 +18,18 @@ import at.asitplus.wallet.lib.agent.RandomSource
 import at.asitplus.wallet.lib.agent.toEncryptionJsonWebKey
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.jws.EncryptJwe
+import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
+import at.asitplus.wallet.lib.jws.JwsHeaderNone
+import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.openid.DummyCredentialDataProvider.issueAndStorePlainJwt
+import at.asitplus.wallet.lib.utils.DefaultMapStore
 import com.benasher44.uuid.uuid4
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -41,22 +50,34 @@ val OpenId4VpEncryptedRequestTest by matrixSuite {
                 val redirectUrl = "https://example.com/rp/${uuid4()}"
                 val walletUrl = "https://example.com/wallet/${uuid4()}"
                 val requestUrl = "https://example.com/request/${uuid4()}"
+                val verifierKeyMaterial = EphemeralKeyWithoutCert()
+                val clientIdScheme = ClientIdScheme.PreRegistered(clientId, redirectUrl)
                 val verifierOid4vp = OpenId4VpVerifier(
-                    keyMaterial = EphemeralKeyWithoutCert(),
-                    clientIdScheme = ClientIdScheme.PreRegistered(clientId, redirectUrl),
+                    keyMaterial = verifierKeyMaterial,
+                    clientIdScheme = clientIdScheme,
                 )
                 val requestOptions = OpenId4VpRequestOptions(
                     presentationRequest = CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)
                     ).toDCQLRequest(),
                 )
+                val requestFactory = OpenId4VpRequestFactory(
+                    clientIdScheme = clientIdScheme,
+                    ephemeralEncryptionKeyService = EphemeralEncryptionKeyService(),
+                    decryptionKeyMaterial = null,
+                    signAuthnRequest = SignJwt(verifierKeyMaterial, JwsHeaderClientIdScheme(clientIdScheme)),
+                    nonceService = DefaultNonceService(),
+                    supportedAlgorithms = setOf(SignatureAlgorithm.ECDSAwithSHA256),
+                    stateToAuthnRequestStore = DefaultMapStore(),
+                    supportedJweEncryptionAlgorithms = JweEncryption.entries.toSet(),
+                )
 
                 /** Holder fetching the request object from [requestUrl] with POST, [served] records what it got. */
                 var served: String? = null
                 fun holder(
-                    ephemeralEncryptionKeyService: EphemeralEncryptionKeyService?,
+                    ephemeralEncryptionKeyService: EphemeralEncryptionKeyService? = null,
                     requireEncryptedRequests: Boolean = false,
-                    serve: suspend (at.asitplus.openid.RequestObjectParameters?) -> String,
+                    serve: suspend (at.asitplus.openid.RequestObjectParameters?) -> String = { "" },
                 ) = OpenId4VpHolder(
                     holder = holderAgent,
                     randomSource = RandomSource.Default,
@@ -102,7 +123,7 @@ val OpenId4VpEncryptedRequestTest by matrixSuite {
             ).getOrThrow()
             jar.shouldNotBeNull()
 
-            val holder = f.holder(null) { jar.invoke(it).getOrThrow() }
+            val holder = f.holder { jar.invoke(it).getOrThrow() }
 
             holder.createAuthnResponse(url).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
@@ -183,7 +204,7 @@ val OpenId4VpEncryptedRequestTest by matrixSuite {
             jar.shouldNotBeNull()
 
             val foreignKey = EphemeralEncryptionKeyService().createKey().toEncryptionJsonWebKey()
-            val holder = f.holder(null) { params ->
+            val holder = f.holder { params ->
                 EncryptJwe()(
                     JweHeader(JweAlgorithm.ECDH_ES, JweEncryption.A128GCM, keyId = foreignKey.keyId),
                     jar.invoke(params).getOrThrow(),
@@ -346,12 +367,97 @@ val OpenId4VpEncryptedRequestTest by matrixSuite {
             ).getOrThrow()
             jar.shouldNotBeNull()
 
-            val holder = f.holder(null) { jar.invoke(it).getOrThrow() }
+            val holder = f.holder { jar.invoke(it).getOrThrow() }
 
             holder.startAuthorizationResponsePreparation(url).getOrThrow().apply {
                 requestWasEncrypted shouldBe false
                 request.decryptedFrom shouldBe null
             }
+        }
+
+        "plain request object served at the request_uri is rejected" { f ->
+            // OpenID4VP 1.0, 5.10.1: the request URI response body is "a signed, optionally encrypted, request object"
+            val (url, _) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+
+            val holder = f.holder(EphemeralEncryptionKeyService()) { params ->
+                joseCompliantSerializer.encodeToString(
+                    f.requestFactory.createPlainAuthnRequest(f.requestOptions, params)
+                )
+            }
+
+            holder.createAuthnResponse(url).isFailure shouldBe true
+        }
+
+        "encrypted request object whose payload is plain JSON is rejected" { f ->
+            // encryption is permitted in addition to signing, never instead of it, see OpenID4VP 1.0, 5.10.1
+            val (url, _) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+
+            val holder = f.holder(EphemeralEncryptionKeyService()) { params ->
+                val recipientKey = params.shouldNotBeNull().walletMetadata.shouldNotBeNull()
+                    .jsonWebKeySet.shouldNotBeNull().keys.first()
+                EncryptJwe()(
+                    JweHeader(JweAlgorithm.ECDH_ES, JweEncryption.A128GCM, keyId = recipientKey.keyId),
+                    joseCompliantSerializer.encodeToString(
+                        f.requestFactory.createPlainAuthnRequest(f.requestOptions, params)
+                    ),
+                    recipientKey,
+                ).getOrThrow().serialize()
+            }
+
+            holder.createAuthnResponse(url).isFailure shouldBe true
+        }
+
+        "request object with the wrong typ is rejected" { f ->
+            // OpenID4VP 1.0, 5.1: "Wallets MUST NOT process Request Objects where the typ Header Parameter is not
+            // present or does not have the value oauth-authz-req+jwt"
+            val (url, _) = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions,
+                CreationOptions.SignedRequestByReference(
+                    f.walletUrl, f.requestUrl, JarRequestParameters.RequestUriMethod.POST
+                )
+            ).getOrThrow()
+
+            val holder = f.holder(EphemeralEncryptionKeyService()) { params ->
+                SignJwt<AuthenticationRequestParameters>(EphemeralKeyWithoutCert(), JwsHeaderNone())(
+                    JwsContentTypeConstants.JWT,
+                    f.requestFactory.createPlainAuthnRequest(f.requestOptions, params),
+                    AuthenticationRequestParameters.serializer(),
+                ).getOrThrow().toString()
+            }
+
+            holder.createAuthnResponse(url).isFailure shouldBe true
+        }
+
+        "plain request object in the request parameter is rejected" { f ->
+            // RFC 9101, 4: a request object is "JWS signed" or "JWS signed and JWE encrypted", there is no third form
+            val url = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions, CreationOptions.Query(f.walletUrl)
+            ).getOrThrow().url + "&request=" + joseCompliantSerializer.encodeToString(
+                f.requestFactory.createPlainAuthnRequest(f.requestOptions)
+            ).encodeURLParameter()
+
+            f.holder().createAuthnResponse(url).isFailure shouldBe true
+        }
+
+        "unparseable request parameter is rejected" { f ->
+            // `RequestParametersSerializer` picks `JarRequestParameters` as soon as `request` is present, so the other
+            // query parameters are dropped and there is nothing to fall back to either way, but the error should name
+            // the request object rather than the `response_type` that went missing with it
+            val url = f.verifierOid4vp.createAuthnRequest(
+                f.requestOptions, CreationOptions.Query(f.walletUrl)
+            ).getOrThrow().url + "&request=not-a-request-object"
+
+            f.holder().createAuthnResponse(url).isFailure shouldBe true
         }
 
         "wallet metadata carries exactly one encryption key, fresh for every request" { f ->

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenIdRequestParserTests.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenIdRequestParserTests.kt
@@ -6,6 +6,10 @@ import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
+import at.asitplus.wallet.lib.jws.JwsHeaderNone
+import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.oidvci.encodeToParameters
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
@@ -13,6 +17,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonObject
 
 
@@ -89,6 +94,17 @@ val OpenIdRequestParserTests by matrixSuite {
 
     val authnRequestSerialized = joseCompliantSerializer.encodeToString(authnRequest)
 
+    /**
+     * The captured [jws] above is a real request from a deployed verifier whose header is `{"alg":"RS256","x5c":[…]}`,
+     * i.e. it carries no `typ` at all, which OpenID4VP 1.0, 5.1 forbids wallets to process. This is the same request
+     * object, correctly typed, for the cases that assert successful parsing.
+     */
+    val typedJws = runBlocking {
+        SignJwt<JsonObject>(EphemeralKeyWithoutCert(), JwsHeaderNone())(
+            JwsContentTypeConstants.OAUTH_AUTHZ_REQUEST, authnRequest, JsonObject.serializer()
+        ).getOrThrow().toString()
+    }
+
     fixture {
         RequestParser()
     } - {
@@ -125,11 +141,17 @@ val OpenIdRequestParserTests by matrixSuite {
             }
         }
 
+        "request object without typ is rejected" { requestParser ->
+            // OpenID4VP 1.0, 5.1: "Wallets MUST NOT process Request Objects where the typ Header Parameter is not
+            // present or does not have the value oauth-authz-req+jwt"
+            requestParser.parseRequestParameters(jws).isFailure shouldBe true
+        }
+
         "signed request directly" { requestParser ->
-            requestParser.parseRequestParameters(jws).getOrThrow().apply {
+            requestParser.parseRequestParameters(typedJws).getOrThrow().apply {
                 shouldBeInstanceOf<RequestParametersFrom<AuthenticationRequestParameters>>()
                 shouldBeInstanceOf<RequestParametersFrom.Jws<*>>()
-                this.jws.toString() shouldBe jws
+                this.jws.toString() shouldBe typedJws
                 parameters.assertParams()
 
                 joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(
@@ -140,12 +162,12 @@ val OpenIdRequestParserTests by matrixSuite {
 
 
         "signed request by value" { requestParser ->
-            val input = "https://example.com?request=$jws&client_id=s6BhdRkqt3"
+            val input = "https://example.com?request=$typedJws&client_id=s6BhdRkqt3"
 
             requestParser.parseRequestParameters(input).getOrThrow().apply {
                 shouldBeInstanceOf<RequestParametersFrom<AuthenticationRequestParameters>>()
                 shouldBeInstanceOf<RequestParametersFrom.Jws<*>>()
-                this.jws.toString() shouldBe jws
+                this.jws.toString() shouldBe typedJws
                 parent.toString() shouldBe input
                 parameters.assertParams()
 
@@ -165,27 +187,18 @@ val OpenIdRequestParserTests by matrixSuite {
         )
     } - {
 
-        "plain request by reference" { requestParser ->
+        "plain request by reference is rejected" { requestParser ->
+            // OpenID4VP 1.0, 5.10.1: the request URI response body is "a signed, optionally encrypted, request object"
             val input = "https://example.com?request_uri=https%3A%2F%2Fclient.example.org%2Freq%2F1234567890&client_id=s6BhdRkqt3"
 
-            requestParser.parseRequestParameters(input).getOrThrow().apply {
-                shouldBeInstanceOf<RequestParametersFrom<AuthenticationRequestParameters>>()
-                shouldBeInstanceOf<RequestParametersFrom.Json<*>>()
-                jsonString shouldBe authnRequestSerialized
-                parent.toString() shouldBe input
-                parameters.assertParams()
-
-                joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(
-                    joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(this)
-                ).shouldBe(this)
-            }
+            requestParser.parseRequestParameters(input).isFailure shouldBe true
         }
 
     }
     fixture {
         RequestParser(
             remoteResourceRetriever = {
-                if (it.url == "https://client.example.org/req/1234567890") jws else null
+                if (it.url == "https://client.example.org/req/1234567890") typedJws else null
             }
         )
     } - {
@@ -195,7 +208,7 @@ val OpenIdRequestParserTests by matrixSuite {
             requestParser.parseRequestParameters(input).getOrThrow().apply {
                 shouldBeInstanceOf<RequestParametersFrom<AuthenticationRequestParameters>>()
                 shouldBeInstanceOf<RequestParametersFrom.Jws<*>>()
-                this.jws.toString() shouldBe jws
+                this.jws.toString() shouldBe typedJws
                 parent.toString() shouldBe input
                 parameters.assertParams()
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenIdRequestParserTests.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenIdRequestParserTests.kt
@@ -96,7 +96,7 @@ val OpenIdRequestParserTests by matrixSuite {
 
     /**
      * The captured [jws] above is a real request from a deployed verifier whose header is `{"alg":"RS256","x5c":[…]}`,
-     * i.e. it carries no `typ` at all, which OpenID4VP 1.0, 5.1 forbids wallets to process. This is the same request
+     * i.e. it carries no `typ` at all, which OpenID4VP 1.0, 5 forbids wallets to process. This is the same request
      * object, correctly typed, for the cases that assert successful parsing.
      */
     val typedJws = runBlocking {
@@ -142,7 +142,7 @@ val OpenIdRequestParserTests by matrixSuite {
         }
 
         "request object without typ is rejected" { requestParser ->
-            // OpenID4VP 1.0, 5.1: "Wallets MUST NOT process Request Objects where the typ Header Parameter is not
+            // OpenID4VP 1.0, 5: "Wallets MUST NOT process Request Objects where the typ Header Parameter is not
             // present or does not have the value oauth-authz-req+jwt"
             requestParser.parseRequestParameters(jws).isFailure shouldBe true
         }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
@@ -384,8 +384,9 @@ val PreRegisteredClientTest by matrixSuite {
             val requestUrl = "https://www.example.com/request/${uuid4()}"
             val (authRequestUrlWithRequestUri, jar) = it.verifierOid4vp.createAuthnRequest(
                 requestOptionsAtomicAttribute(),
-                // `wallet_nonce` is only sent when fetching the request object with POST, see OpenID4VP 1.0, 5.10
-                CreationOptions.RequestByReference(
+                // `wallet_nonce` is only sent when fetching the request object with POST, see OpenID4VP 1.0, 5.10,
+                // and 5.10.1 requires the request object served there to be signed
+                CreationOptions.SignedRequestByReference(
                     it.walletUrl, requestUrl, JarRequestParameters.RequestUriMethod.POST
                 )
             ).getOrThrow()
@@ -405,7 +406,7 @@ val PreRegisteredClientTest by matrixSuite {
                 remoteResourceRetriever = {
                     if (it.url == requestUrl) {
                         jar.invoke(it.requestObjectParameters).getOrThrow().also {
-                            joseCompliantSerializer.decodeFromString<AuthenticationRequestParameters>(it).walletNonce.also {
+                            JwsCompactTyped<AuthenticationRequestParameters>(it).payload.walletNonce.also {
                                 it.shouldNotBeNull()
                                 nonceMap.contains(it).shouldBeTrue()
                             }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RemoteResourceRetrieverFunctionTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RemoteResourceRetrieverFunctionTest.kt
@@ -7,10 +7,15 @@ import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.matrix.matrixSuite
 import at.asitplus.wallet.lib.RemoteResourceRetrieverInput
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
+import at.asitplus.wallet.lib.jws.JwsHeaderNone
+import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.oidvci.WalletService
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
 
 private data class FakeHttpResponse(
     val body: String? = null,
@@ -34,13 +39,19 @@ val RemoteResourceRetrieverFunctionTest by matrixSuite {
         redirectUrl = "https://client.example.org/callback",
         scope = "openid",
     )
-    val authnRequestSerialized = joseCompliantSerializer.encodeToString(RequestParameters.serializer(), authnRequest)
+
+    // OpenID4VP 1.0, 5.10.1 requires the request URI response to be a signed request object, so serve one of those
+    val authnRequestSigned = runBlocking {
+        SignJwt<RequestParameters>(EphemeralKeyWithoutCert(), JwsHeaderNone())(
+            JwsContentTypeConstants.OAUTH_AUTHZ_REQUEST, authnRequest, RequestParameters.serializer()
+        ).getOrThrow().toString()
+    }
 
     "body response is used when present" {
         val retriever = FakeRemoteResourceRetriever(
             mapOf(
                 requestUri to FakeHttpResponse(
-                    body = authnRequestSerialized,
+                    body = authnRequestSigned,
                     location = "https://redirect.example.org/not-used",
                 )
             )
@@ -53,8 +64,8 @@ val RemoteResourceRetrieverFunctionTest by matrixSuite {
 
         parser.parseRequestParameters(input).getOrThrow().apply {
             shouldBeInstanceOf<RequestParametersFrom<AuthenticationRequestParameters>>()
-            shouldBeInstanceOf<RequestParametersFrom.Json<*>>()
-            jsonString shouldBe authnRequestSerialized
+            shouldBeInstanceOf<RequestParametersFrom.Jws<*>>()
+            jws.toString() shouldBe authnRequestSigned
             parameters shouldBe authnRequest
         }
     }


### PR DESCRIPTION
Correctly implement parsing request objects, as defined in [OpenID4VP 1.0 5](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-authorization-request):

> The Verifier MAY send an Authorization Request as a Request Object either by value or by reference, as defined in the JWT-Secured Authorization Request (JAR) [[RFC9101](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#RFC9101)]. Verifiers MUST include the `typ` Header Parameter in Request Objects with the value `oauth-authz-req+jwt`, as defined in [[RFC9101](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#RFC9101)]. Wallets MUST NOT process Request Objects where the typ Header Parameter is not present or does not have the value `oauth-authz-req+jwt`.