### PR TITLE
OID4VP: Harden request parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Release 8.0.0 (unreleased):
     - Fix decoding of form-encoded parameters whose value is a JSON string, e.g. `wallet_metadata` posted to the request URI endpoint
     - Send `wallet_metadata` and `wallet_nonce` only when fetching the request object with `request_uri_method=post`
     - Terminate request processing if the request object does not carry back the `wallet_nonce` we sent, as required by OpenID4VP 1.0, Section 5.10.1
+    - Reject a JAR request whose request object can not be retrieved from `request_uri`, that carries neither `request` nor `request_uri`, or whose request object nests another `request`/`request_uri` (RFC 9101, Section 6.2), with `invalid_request` in `RequestParser`
+    - In `OpenId4VpHolder` reject requests that are not authorization requests, e.g. RQES signature requests, with `invalid_request` instead of failing with a `ClassCastException` during request validation
     - Pass `requireEncryptedRequests = true` to `OpenId4VpHolder` to reject a plain request object served at a `request_uri` fetched with POST
     - Add `decryptedFrom` to `RequestParametersFrom.Jws` and `RequestParametersFrom.Json`, holding the header of the JWE a request was decrypted from, and `requestWasEncrypted` to `AuthorizationResponsePreparationState`
     - Reject request objects that are not a JWS (and optionally encrypted) per RFC 9101, Section 4

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -230,11 +230,10 @@ class OpenId4VpHolder @JvmOverloads constructor(
         createAuthnResponse(parse(input)).getOrThrow()
     }
 
-    @Suppress("UNCHECKED_CAST")
     private suspend fun parse(
         input: String,
     ) = requestParser.parseRequestParameters(input)
-        .getOrThrow() as RequestParametersFrom<AuthenticationRequestParameters>
+        .getOrThrow().requireAuthenticationRequest()
 
     @Deprecated("Use createAuthnErrorResponse with AuthorizationResponsePreparationState parameter")
     suspend fun createAuthnErrorResponse(
@@ -448,6 +447,18 @@ class OpenId4VpHolder @JvmOverloads constructor(
         } else null
 
 }
+
+/**
+ * The type argument of [RequestParametersFrom] is erased, so casting it can never fail on its own: guard the cast with
+ * the runtime type of the parameters, so that a request we can not process in OpenID4VP, e.g. an RQES signature
+ * request, or a JAR request that has not been resolved into an authorization request, is reported as an OAuth 2.0
+ * error instead of failing with a [ClassCastException] somewhere inside request validation.
+ */
+@Suppress("UNCHECKED_CAST")
+private fun RequestParametersFrom<*>.requireAuthenticationRequest(): RequestParametersFrom<AuthenticationRequestParameters> =
+    if (parameters is AuthenticationRequestParameters)
+        this as RequestParametersFrom<AuthenticationRequestParameters>
+    else throw InvalidRequest("not an authorization request: ${parameters::class.simpleName}")
 
 private fun Collection<JsonWebKey>?.combine(certKey: JsonWebKey?): Collection<JsonWebKey> =
     certKey?.let { (this ?: listOf()) + certKey } ?: this ?: listOf()

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
@@ -74,8 +74,21 @@ class RequestParser(
             ?: parseFromJson(null)
             ?: throw InvalidRequest("parse error: $this")
 
+    /**
+     * Resolves a JAR request, i.e. the request object referenced in `request_uri` or carried in `request`, into the
+     * request parameters it holds. A JAR request we can not resolve is an error: passing it on unresolved would look
+     * like a successfully parsed request, but carry none of the parameters it is supposed to transport.
+     */
     private suspend fun RequestParametersFrom<out RequestParameters>.extractRequest(): RequestParametersFrom<*> =
-        (this.parameters as? JarRequestParameters)?.let { extractRequest(it, this) } ?: this
+        (this.parameters as? JarRequestParameters)?.let { jar ->
+            (extractRequest(jar, this)
+                ?: throw InvalidRequest("request contains neither `request` nor `request_uri`"))
+                // RFC 9101, 6.2: the request object must not contain `request` or `request_uri` itself
+                .also { resolved ->
+                    if (resolved.parameters is JarRequestParameters)
+                        throw InvalidRequest("request object must not contain `request` or `request_uri`")
+                }
+        } ?: this
 
     private fun String.parseFromParameters(): RequestParametersFrom<*>? = catchingUnwrapped {
         Url(this).let {
@@ -97,6 +110,13 @@ class RequestParser(
         RequestParametersFrom.Json(this, params, (parent as? RequestParametersFrom.Uri)?.url, decryptedFrom)
     }.getOrNull()
 
+    /**
+     * Resolves the request object of the JAR request in [parameters], either from `request`, or by fetching the
+     * `request_uri` with [remoteResourceRetriever].
+     *
+     * Returns `null` only if the request carries neither of the two, and throws if the request object can not be
+     * retrieved, or is not a valid request object.
+     */
     suspend fun extractRequest(
         parameters: JarRequestParameters,
         parent: RequestParametersFrom<out RequestParameters>?,
@@ -111,18 +131,18 @@ class RequestParser(
         // only the POST request to the request URI endpoint has a channel for these, see OpenID4VP 1.0, 5.10, and it
         // is built once per request, since it carries the key the verifier shall encrypt this very request to
         val requestObjectParameters = if (method == HttpMethod.Post) buildRequestObjectParameters() else null
-        remoteResourceRetriever(parameters.resourceRetrieverInput(uri, method, requestObjectParameters))?.let {
-            val expectedKeyId = requestObjectParameters.expectedEncryptionKeyId()
-            val fromJwe = it.parseAsJweRequest(parent, expectedKeyId)
-            // a non-null `expectedKeyId` means we advertised a key in `wallet_metadata`, i.e. this was the POST fetch,
-            // the only flow in which the verifier had the chance to encrypt at all
-            if (fromJwe == null && requireEncryptedRequests && expectedKeyId != null)
-                throw InvalidRequest("request object from $uri is not encrypted, but we require encryption")
-            (fromJwe
-                ?: it.parseAsJwsRequest(parent)
-                ?: throw InvalidRequest("request_uri content not a valid request object: $uri"))
-                .also { request -> request.requireWalletNonce(requestObjectParameters?.walletNonce) }
-        }
+        val content = remoteResourceRetriever(parameters.resourceRetrieverInput(uri, method, requestObjectParameters))
+            ?: throw InvalidRequest("could not retrieve request object from request_uri: $uri")
+        val expectedKeyId = requestObjectParameters.expectedEncryptionKeyId()
+        val fromJwe = content.parseAsJweRequest(parent, expectedKeyId)
+        // a non-null `expectedKeyId` means we advertised a key in `wallet_metadata`, i.e. this was the POST fetch,
+        // the only flow in which the verifier had the chance to encrypt at all
+        if (fromJwe == null && requireEncryptedRequests && expectedKeyId != null)
+            throw InvalidRequest("request object from $uri is not encrypted, but we require encryption")
+        (fromJwe
+            ?: content.parseAsJwsRequest(parent)
+            ?: throw InvalidRequest("request_uri content not a valid request object: $uri"))
+            .also { request -> request.requireWalletNonce(requestObjectParameters?.walletNonce) }
     }
 
     /** The `kid` of the encryption key we have advertised in `wallet_metadata` for this very request. */

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolderRequestParsingTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolderRequestParsingTest.kt
@@ -1,0 +1,65 @@
+package at.asitplus.wallet.lib.openid
+
+import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.http.*
+
+/**
+ * `OpenId4VpHolder` can only process authorization requests, but the request parser may well return something else,
+ * e.g. an unresolved JAR request, or an RQES signature request. Since the generic argument of `RequestParametersFrom`
+ * is erased, such requests used to pass the cast in `OpenId4VpHolder.parse` and fail with a `ClassCastException`
+ * ("JarRequestParameters cannot be cast to AuthenticationRequestParameters") somewhere inside request validation.
+ */
+val OpenId4VpHolderRequestParsingTest by matrixSuite {
+
+    val requestUri = "https://example.com/request/1234"
+
+    "request_uri that can not be retrieved is rejected" {
+        // The retriever answers nothing, e.g. because the fetch failed, or because the verifier put a URL into
+        // `request_uri` that the wallet does not handle: either way there is no request object to process
+        val holder = OpenId4VpHolder(remoteResourceRetriever = { null })
+        val input = URLBuilder("https://example.com/wallet").apply {
+            parameters.append("client_id", "https://example.com")
+            parameters.append("request_uri", requestUri)
+        }.buildString()
+
+        holder.startAuthorizationResponsePreparation(input)
+            .exceptionOrNull().shouldNotBeNull()
+            .shouldBeInstanceOf<OAuth2Exception.InvalidRequest>()
+            .message.shouldNotBeNull() shouldContain requestUri
+
+        holder.createAuthnResponse(input)
+            .exceptionOrNull().shouldNotBeNull()
+            .shouldBeInstanceOf<OAuth2Exception.InvalidRequest>()
+            .message.shouldNotBeNull() shouldContain requestUri
+    }
+
+    "request that is not an authorization request is rejected" {
+        // A request for remote signature creation (RQES), which is parsed into `SignatureRequestParameters`
+        val input = """
+            {
+              "response_type": "sign_response",
+              "client_id": "ff008dbe-0a00-43aa-8cbd-57b44fbd8cf9",
+              "response_mode": "direct_post",
+              "response_uri": "https://example.com/wallet/sd/upload",
+              "nonce": "SD6caM6K17zn6lnvVlu9FQ92Je2rWg-rqbMegL1CBIY",
+              "signatureQualifier": "eu_eidas_qes",
+              "documentDigests": [
+                { "hash": "dbe822af4b1cfddea8e8526a04a46557074d093cb02fee0f3dcc5f323629504e", "label": "sample.pdf" }
+              ],
+              "documentLocations": [
+                { "uri": "https://example.com/rp/document/sample.pdf", "method": { "type": "public" } }
+              ],
+              "hashAlgorithmOID": "2.16.840.1.101.3.4.2.1"
+            }
+        """.replace("\n", "").trimIndent()
+
+        OpenId4VpHolder().startAuthorizationResponsePreparation(input)
+            .exceptionOrNull().shouldNotBeNull()
+            .shouldBeInstanceOf<OAuth2Exception.InvalidRequest>()
+            .message.shouldNotBeNull() shouldContain "SignatureRequestParameters"
+    }
+}

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenIdRequestParserTests.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenIdRequestParserTests.kt
@@ -1,6 +1,8 @@
 package at.asitplus.wallet.lib.openid
 
 import at.asitplus.openid.AuthenticationRequestParameters
+import at.asitplus.openid.JarRequestParameters
+import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
@@ -15,6 +17,7 @@ import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
@@ -177,6 +180,17 @@ val OpenIdRequestParserTests by matrixSuite {
             }
         }
 
+        "request by reference that can not be retrieved is rejected" { requestParser ->
+            // This parser has no retriever, so there is no request object at all: the unresolved JAR request must
+            // not be reported as a successfully parsed authorization request
+            val input =
+                "https://example.com?request_uri=https%3A%2F%2Fclient.example.org%2Freq%2F1234567890&client_id=s6BhdRkqt3"
+
+            requestParser.parseRequestParameters(input)
+                .exceptionOrNull().shouldNotBeNull()
+                .message.shouldNotBeNull() shouldContain "https://client.example.org/req/1234567890"
+        }
+
     }
 
     fixture {
@@ -216,6 +230,36 @@ val OpenIdRequestParserTests by matrixSuite {
                     joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(this)
                 ).shouldBe(this)
             }
+        }
+
+    }
+
+    // RFC 9101, 6.2: a request object must not contain `request` or `request_uri` itself
+    val nestedJarJws = runBlocking {
+        SignJwt<RequestParameters>(EphemeralKeyWithoutCert(), JwsHeaderNone())(
+            JwsContentTypeConstants.OAUTH_AUTHZ_REQUEST,
+            JarRequestParameters(
+                clientId = "s6BhdRkqt3",
+                requestUri = "https://client.example.org/req/nested",
+            ),
+            RequestParameters.serializer()
+        ).getOrThrow().toString()
+    }
+
+    fixture {
+        RequestParser(
+            remoteResourceRetriever = {
+                if (it.url == "https://client.example.org/req/1234567890") nestedJarJws else null
+            }
+        )
+    } - {
+        "request object nesting another request_uri is rejected" { requestParser ->
+            val input =
+                "https://example.com?request_uri=https%3A%2F%2Fclient.example.org%2Freq%2F1234567890&client_id=s6BhdRkqt3"
+
+            requestParser.parseRequestParameters(input)
+                .exceptionOrNull().shouldNotBeNull()
+                .message.shouldNotBeNull() shouldContain "request_uri"
         }
 
     }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
@@ -380,6 +380,27 @@ val PreRegisteredClientTest by matrixSuite {
                 }
         }
 
+        "test with request object from request_uri that can not be retrieved should fail" {
+            val requestUrl = "https://www.example.com/request/${uuid4()}"
+            val (authRequestUrlWithRequestUri, jar) = it.verifierOid4vp.createAuthnRequest(
+                requestOptionsAtomicAttribute(),
+                CreationOptions.SignedRequestByReference(it.walletUrl, requestUrl)
+            ).getOrThrow()
+            jar.shouldNotBeNull()
+
+            it.holderOid4vp = OpenId4VpHolder(
+                holder = it.holderAgent,
+                // Answers a different URL only, i.e. the request object for `requestUrl` can not be retrieved
+                remoteResourceRetriever = { null },
+                randomSource = RandomSource.Default,
+            )
+
+            it.holderOid4vp.createAuthnResponse(authRequestUrlWithRequestUri)
+                .exceptionOrNull().shouldNotBeNull()
+                .shouldBeInstanceOf<OAuth2Exception.InvalidRequest>()
+                .message.shouldNotBeNull() shouldContain requestUrl
+        }
+
         "test with request object from request_uri contains wallet_nonce, but not in store should fail" {
             val requestUrl = "https://www.example.com/request/${uuid4()}"
             val (authRequestUrlWithRequestUri, jar) = it.verifierOid4vp.createAuthnRequest(


### PR DESCRIPTION
Error in Valera can be triggered by scanning QR Code in profile "Generic EUDI Wallet" from https://eudiw-playground.eideasy.com/qr ... but that contains several fields that should not be there, but tripped Valera into a ugly looking class cast exception. This commit here shows a better error message.